### PR TITLE
Chore/go 1.26 bump

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,14 +14,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.25']  # go.mod requires go 1.25; 1.24 removed to avoid covdata/toolchain issues
+        go-version: ['1.26']  # go.mod requires go 1.26
     steps:
     - uses: actions/checkout@v4
 
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25.7'
+        go-version: '1.26.0'
 
     - name: Cache Go modules
       uses: actions/cache@v4
@@ -29,9 +29,9 @@ jobs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-1.25.7-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-1.26.0-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-1.25.7-
+          ${{ runner.os }}-go-1.26.0-
 
     - name: Download dependencies
       run: go mod download
@@ -57,14 +57,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.25']  # go.mod requires go 1.25; 1.24 removed to avoid covdata/toolchain issues
+        go-version: ['1.26']  # go.mod requires go 1.26
     steps:
     - uses: actions/checkout@v4
 
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25.7'
+        go-version: '1.26.0'
 
     - name: Cache Go modules
       uses: actions/cache@v4
@@ -72,9 +72,9 @@ jobs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-1.25.7-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-1.26.0-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-1.25.7-
+          ${{ runner.os }}-go-1.26.0-
 
     - name: Install controller-gen
       run: |
@@ -94,14 +94,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.25']  # go.mod requires go 1.25; 1.24 removed to avoid covdata/toolchain issues
+        go-version: ['1.26']  # go.mod requires go 1.26
     steps:
     - uses: actions/checkout@v4
 
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25.7'
+        go-version: '1.26.0'
 
     - name: Cache Go modules
       uses: actions/cache@v4
@@ -109,9 +109,9 @@ jobs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-1.25.7-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-1.26.0-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-1.25.7-
+          ${{ runner.os }}-go-1.26.0-
 
     - name: Install controller-gen
       run: |
@@ -136,14 +136,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.25']  # go.mod requires go 1.25; 1.24 removed to avoid covdata/toolchain issues
+        go-version: ['1.26']  # go.mod requires go 1.26
     steps:
     - uses: actions/checkout@v4
 
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25.7'
+        go-version: '1.26.0'
 
     - name: Install envtest tools
       run: |
@@ -157,9 +157,9 @@ jobs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-1.25.7-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-1.26.0-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-1.25.7-
+          ${{ runner.os }}-go-1.26.0-
 
     - name: Download dependencies
       run: go mod download
@@ -180,7 +180,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25.7'
+        go-version: '1.26.0'
 
     - name: Cache Go modules
       uses: actions/cache@v4
@@ -188,9 +188,9 @@ jobs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-1.25.7-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-1.26.0-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-1.25.7-
+          ${{ runner.os }}-go-1.26.0-
 
     - name: Cache pinned e2e CLIs (kubectl, kind, clusterctl, virtctl)
       uses: actions/cache@v4
@@ -215,14 +215,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.25']  # go.mod requires go 1.25; 1.24 removed to avoid covdata/toolchain issues
+        go-version: ['1.26']  # go.mod requires go 1.26
     steps:
     - uses: actions/checkout@v4
 
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25.7'
+        go-version: '1.26.0'
 
     - name: Cache Go modules
       uses: actions/cache@v4
@@ -230,9 +230,9 @@ jobs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-1.25.7-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-1.26.0-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-1.25.7-
+          ${{ runner.os }}-go-1.26.0-
 
     - name: Download dependencies
       run: go mod download

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,10 @@ ideas/*
 .cursor/*
 !ideas/CAPK_PARITY_GAP_ANALYSIS.md
 CODEBASE_KNOWLEDGE.md
+
+# Local Claude Code tooling — agents, skills, grounding, settings.
+# These files are intentionally project-local and never pushed.
+# See .claude/PROJECT_CONTEXT.md (after creation) for what lives here.
+.claude/
+CLAUDE.md
+**/CLAUDE.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /workspace
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -4,7 +4,7 @@ This guide describes how to install the Kairos CAPI provider. All steps use `mak
 
 ## Prerequisites
 
-- Go 1.25+ toolchain
+- Go 1.26+ toolchain
 - A Kubernetes cluster as your management cluster (e.g. kind, minikube)
 - CAPI and an infrastructure provider (CAPD, CAPV, or CAPK) already installed
 - `kubectl` configured to use the management cluster

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -4,7 +4,7 @@ See [Install guide](INSTALL.md) for development install.
 
 ## Prerequisites
 
-- Go 1.25+ (see [Install guide](INSTALL.md))
+- Go 1.26+ (see [Install guide](INSTALL.md))
 
 ## Unit tests
 
@@ -26,4 +26,4 @@ make test-envtest
 
 `make test-envtest` installs setup-envtest if needed, downloads assets, and runs envtest-tagged tests.
 
-CI tests against Go 1.25.7. The 1.24/1.25 matrix was removed due to covdata/toolchain compatibility issues (golang/go#75031).
+CI tests against Go 1.26.0.

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/kairos-io/cluster-api-provider-kairos
 
-go 1.25
+go 1.26
 
-toolchain go1.25.7
+toolchain go1.26.0
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
## Summary
- Bumps the Go toolchain from 1.25 → 1.26 across `go.mod`, `Dockerfile`,
  the GitHub Actions CI matrix (all 5 jobs), and the docs.
- Adds a small `.gitignore` entry to keep local agent/tooling artifacts
  (e.g. `.claude/`, `CLAUDE.md`) from being accidentally committed.
  No tooling content is added to the repo.

## Verification
- `go vet ./...`, `go build ./...`, `go test -short ./...` all green
  locally on `go1.26.2` (system) and `go1.26.0` (toolchain).
- CI matrix bumped consistently; cache keys updated to invalidate the
  1.25-era cache on first run.

## Notes
- Dropped the stale `golang/go#75031` matrix-workaround note in
  `docs/TESTING.md` — no longer applicable on 1.26.
- DCO sign-off included on both commits.