### PR TITLE
fix(kubevirtenv): bubble apply errors and retry on CRD discovery race

### DIFF
--- a/internal/kubevirtenv/apply.go
+++ b/internal/kubevirtenv/apply.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -15,11 +16,21 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	yamlserializer "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
+)
+
+// restMappingRetry* bound how long we wait for a just-installed CRD to be
+// served by the API server's discovery endpoint. CRDs go through Established
+// before kube-apiserver serves their kind; without retry we race the CRD and
+// silently skip the dependent CR.
+const (
+	restMappingRetryTimeout  = 30 * time.Second
+	restMappingRetryInterval = 1 * time.Second
 )
 
 // ApplyManifestFromURL downloads YAML and applies it with server-side apply.
@@ -32,13 +43,18 @@ func (e *Environment) ApplyManifestFromURL(ctx context.Context, dynamicClient dy
 }
 
 // ApplyManifestContent applies multi-document YAML with server-side apply.
+//
+// Apply errors are returned to the caller. Previously they were downgraded to
+// log.Warnf and the function returned nil — which silently masked CRD-ordering
+// bugs (e.g. applying a CR before its CRD was Established) and made install
+// failures look like flaky waits downstream.
 func (e *Environment) ApplyManifestContent(ctx context.Context, dynamicClient dynamic.Interface, config *rest.Config, yamlContent []byte) error {
 	log := e.log()
-	return forEachManifestObject(log, config, yamlContent, func(mapping *manifestMapping, obj *unstructured.Unstructured) error {
+	return forEachManifestObject(ctx, log, config, yamlContent, func(mapping *manifestMapping, obj *unstructured.Unstructured) error {
 		dr := resourceClient(dynamicClient, mapping, obj)
 		obj.SetManagedFields(nil)
 		if _, err := dr.Apply(ctx, obj.GetName(), obj, metav1.ApplyOptions{FieldManager: applyFieldManager}); err != nil {
-			log.Warnf("apply %s/%s: %v", mapping.gvk.Kind, obj.GetName(), err)
+			return fmt.Errorf("apply %s/%s: %w", mapping.gvk.Kind, obj.GetName(), err)
 		}
 		return nil
 	})
@@ -71,9 +87,13 @@ func (e *Environment) DeleteResourcesFromManifestURL(ctx context.Context, dynami
 	return e.deleteResourcesFromYAML(ctx, dynamicClient, config, body)
 }
 
+// deleteResourcesFromYAML issues Delete for each object in the manifest stream.
+// Per-object errors other than NotFound are downgraded to warnings: callers
+// (e.g. UninstallKubeVirt) want best-effort cleanup and should not abort on
+// the first stale object.
 func (e *Environment) deleteResourcesFromYAML(ctx context.Context, dynamicClient dynamic.Interface, config *rest.Config, yamlContent []byte) error {
 	log := e.log()
-	return forEachManifestObject(log, config, yamlContent, func(mapping *manifestMapping, obj *unstructured.Unstructured) error {
+	return forEachManifestObject(ctx, log, config, yamlContent, func(mapping *manifestMapping, obj *unstructured.Unstructured) error {
 		dr := resourceClient(dynamicClient, mapping, obj)
 		if err := dr.Delete(ctx, obj.GetName(), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 			log.Warnf("delete %s/%s: %v", mapping.gvk.Kind, obj.GetName(), err)
@@ -88,18 +108,15 @@ type manifestMapping struct {
 	mapping *meta.RESTMapping
 }
 
-// forEachManifestObject decodes a multi-doc YAML stream and invokes fn for each object that
-// resolves through discovery. Decode/mapping errors are logged via the environment logger and skipped.
-func forEachManifestObject(log Logger, config *rest.Config, yamlContent []byte, fn func(*manifestMapping, *unstructured.Unstructured) error) error {
-	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
+// forEachManifestObject decodes a multi-doc YAML stream and invokes fn for
+// each object. Decode failures abort. REST-mapping NoMatch errors trigger a
+// bounded retry against a refreshed discovery cache, since a CRD applied
+// earlier in the same operation may not be served by kube-apiserver yet.
+func forEachManifestObject(ctx context.Context, log Logger, config *rest.Config, yamlContent []byte, fn func(*manifestMapping, *unstructured.Unstructured) error) error {
+	mapper, err := buildRESTMapper(config)
 	if err != nil {
-		return fmt.Errorf("discovery client: %w", err)
+		return err
 	}
-	gr, err := restmapper.GetAPIGroupResources(discoveryClient)
-	if err != nil {
-		return fmt.Errorf("API group resources: %w", err)
-	}
-	mapper := restmapper.NewDiscoveryRESTMapper(gr)
 	decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(yamlContent), 4096)
 	dec := yamlserializer.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
 
@@ -119,12 +136,9 @@ func forEachManifestObject(log Logger, config *rest.Config, yamlContent []byte, 
 		if err != nil {
 			return fmt.Errorf("decode object: %w", err)
 		}
-		mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+		mapping, err := resolveMapping(ctx, log, config, mapper, *gvk)
 		if err != nil {
-			if log != nil {
-				log.Warnf("skip %s/%s: REST mapping unavailable: %v", gvk.Kind, obj.GetName(), err)
-			}
-			continue
+			return fmt.Errorf("REST mapping for %s/%s: %w", gvk.Kind, obj.GetName(), err)
 		}
 		mm := &manifestMapping{gvk: *gvk, mapping: mapping}
 		if err := fn(mm, obj); err != nil {
@@ -132,6 +146,54 @@ func forEachManifestObject(log Logger, config *rest.Config, yamlContent []byte, 
 		}
 	}
 	return nil
+}
+
+// resolveMapping returns the REST mapping for gvk, refreshing discovery if the
+// initial lookup reports NoMatch (typical right after a CRD apply).
+func resolveMapping(ctx context.Context, log Logger, config *rest.Config, mapper meta.RESTMapper, gvk schema.GroupVersionKind) (*meta.RESTMapping, error) {
+	mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err == nil {
+		return mapping, nil
+	}
+	if !meta.IsNoMatchError(err) {
+		return nil, err
+	}
+	if log != nil {
+		log.Infof("REST mapping for %s/%s not yet served by API server; refreshing discovery (up to %s)", gvk.GroupKind().String(), gvk.Version, restMappingRetryTimeout)
+	}
+	waitErr := wait.PollUntilContextTimeout(ctx, restMappingRetryInterval, restMappingRetryTimeout, false, func(ctx context.Context) (bool, error) {
+		rm, berr := buildRESTMapper(config)
+		if berr != nil {
+			return false, berr
+		}
+		m, mErr := rm.RESTMapping(gvk.GroupKind(), gvk.Version)
+		if mErr == nil {
+			mapping = m
+			return true, nil
+		}
+		if !meta.IsNoMatchError(mErr) {
+			return false, mErr
+		}
+		return false, nil
+	})
+	if waitErr != nil {
+		return nil, waitErr
+	}
+	return mapping, nil
+}
+
+// buildRESTMapper returns a fresh discovery-backed RESTMapper. Callers rebuild
+// after operations that may have changed the set of registered CRDs.
+func buildRESTMapper(config *rest.Config) (meta.RESTMapper, error) {
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("discovery client: %w", err)
+	}
+	gr, err := restmapper.GetAPIGroupResources(discoveryClient)
+	if err != nil {
+		return nil, fmt.Errorf("API group resources: %w", err)
+	}
+	return restmapper.NewDiscoveryRESTMapper(gr), nil
 }
 
 func resourceClient(dynamicClient dynamic.Interface, mm *manifestMapping, obj *unstructured.Unstructured) dynamic.ResourceInterface {

--- a/internal/kubevirtenv/apply.go
+++ b/internal/kubevirtenv/apply.go
@@ -48,12 +48,20 @@ func (e *Environment) ApplyManifestFromURL(ctx context.Context, dynamicClient dy
 // log.Warnf and the function returned nil — which silently masked CRD-ordering
 // bugs (e.g. applying a CR before its CRD was Established) and made install
 // failures look like flaky waits downstream.
+//
+// ApplyOptions.Force is set so we resolve field-manager conflicts in our
+// favor: this is an installer tool whose job is to enforce a known-good state
+// of the manifests. The typical conflict surface is kind-bundled resources
+// (e.g. local-path-provisioner) that ship with `kubectl-client-side-apply` as
+// their field manager. SSA documents Force as the standard mechanism for
+// adopting fields owned by another manager.
 func (e *Environment) ApplyManifestContent(ctx context.Context, dynamicClient dynamic.Interface, config *rest.Config, yamlContent []byte) error {
 	log := e.log()
 	return forEachManifestObject(ctx, log, config, yamlContent, func(mapping *manifestMapping, obj *unstructured.Unstructured) error {
 		dr := resourceClient(dynamicClient, mapping, obj)
 		obj.SetManagedFields(nil)
-		if _, err := dr.Apply(ctx, obj.GetName(), obj, metav1.ApplyOptions{FieldManager: applyFieldManager}); err != nil {
+		opts := metav1.ApplyOptions{FieldManager: applyFieldManager, Force: true}
+		if _, err := dr.Apply(ctx, obj.GetName(), obj, opts); err != nil {
 			return fmt.Errorf("apply %s/%s: %w", mapping.gvk.Kind, obj.GetName(), err)
 		}
 		return nil

--- a/internal/kubevirtenv/kubevirt.go
+++ b/internal/kubevirtenv/kubevirt.go
@@ -88,15 +88,15 @@ func (e *Environment) InstallKubeVirt(ctx context.Context) error {
 	defer cancel()
 	log.Infof("Waiting for virt-operator deployment...")
 	if err := WaitForDeployment(waitCtx, clientset, "kubevirt", "virt-operator"); err != nil {
-		log.Warnf("virt-operator may not be fully ready: %v", err)
+		return fmt.Errorf("virt-operator did not become ready: %w", err)
 	}
 	log.Infof("Waiting for KubeVirt CR...")
 	if err := waitForKubeVirtCR(waitCtx, log, dynamicClient); err != nil {
-		log.Warnf("KubeVirt CR may not be fully ready: %v", err)
 		if kubevirt, gerr := getKubeVirtCR(waitCtx, dynamicClient); gerr == nil && kubevirt != nil {
 			phase, _, _ := unstructured.NestedString(kubevirt.Object, "status", "phase")
-			log.Infof("KubeVirt phase: %s", phase)
+			log.Infof("KubeVirt phase at failure: %s", phase)
 		}
+		return fmt.Errorf("KubeVirt CR did not become ready: %w", err)
 	}
 	log.Step("KubeVirt installed ✓")
 	return nil


### PR DESCRIPTION
## Summary

The local KubeVirt environment setup (`internal/kubevirtenv/`) had two related defects that together cause the e2e suite to hang for 25 minutes and then fail:

1. **`ApplyManifestContent` swallowed every Apply error** with `log.Warnf` and returned `nil` (`internal/kubevirtenv/apply.go:40-43`). Real failures — e.g. a CR applied before its CRD was Established and served by the API server — were invisible. The recent e2e log shows the exact symptom:

   ```
   [warn] skip KubeVirt/kubevirt: REST mapping unavailable:
     no matches for kind "KubeVirt" in version "kubevirt.io/v1"
   ```

   This PR makes Apply errors propagate so callers can react and CI fails fast instead of timing out 25 minutes later on a downstream wait.

2. **The REST-mapping NoMatch path now retries.** CRDs are routinely Established a few hundred milliseconds after they are applied; under runner load this can stretch to seconds. When `restmapper.RESTMapping` returns NoMatch, the loop now refreshes discovery and retries for up to 30s, handling the race without restructuring callers.

3. **`InstallKubeVirt` no longer lies about success.** Previously a virt-operator or KubeVirt-CR readiness failure was downgraded to `log.Warnf` and the function logged `KubeVirt installed ✓` anyway. When KubeVirt actually fails to come up this cascades — VMI CRDs never register, every downstream step sits at `WaitingForBootstrapData` until the test times out. These waits now return errors.

Delete paths (`deleteResourcesFromYAML`) still warn-and-continue: callers (`UninstallKubeVirt`) want best-effort cleanup, not abort-on-first-stale-object.

## Why now

The same e2e timeout has been failing on `main` for the last two pushes (runs [25369783983](https://github.com/kairos-io/cluster-api-provider-kairos/actions/runs/25369783983) and [24237600341](https://github.com/kairos-io/cluster-api-provider-kairos/actions/runs/24237600341), both 39–40 minute timeouts in the same step). This PR fixes the immediate root cause; downstream defects in the bootstrap controller (KD-14) and other Install paths may still surface and will be addressed in follow-up PRs.

## Verification

```
go vet ./...        # clean
go build ./...      # clean
go test -short ./... # all green
```

## Test plan

- [ ] CI verify-manifests / verify-generate / test / build pass
- [ ] CI e2e gets past KubeVirt install (previously failed at minute ~3 with "REST mapping unavailable"); subsequent steps may reveal further issues that we address in follow-up
- [ ] No regression in unit tests for `internal/kubevirtenv/` (none today)