### PR TITLE
fix(bootstrap): strip /sysroot/ prefix from paths in stages.initramfs

### DIFF
--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capk.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capk.yaml.tmpl
@@ -562,7 +562,7 @@ stages:
     - name: "Create k0s post-bootstrap service and script"
       files:
         {{- if or .Hostname .HostnamePrefix }}
-        - path: /sysroot/usr/local/etc/hostname
+        - path: /usr/local/etc/hostname
           permissions: "0644"
           owner: 0
           group: 0
@@ -573,7 +573,7 @@ stages:
             {{ .HostnamePrefix }}{{ "{{ trunc 4 .MachineID }}" }}
             {{- end }}
         {{- end }}
-        - path: /sysroot/etc/systemd/system/kairos-k0s-post-bootstrap.service
+        - path: /etc/systemd/system/kairos-k0s-post-bootstrap.service
           permissions: "0644"
           owner: 0
           group: 0
@@ -595,7 +595,7 @@ stages:
             
             [Install]
             WantedBy=multi-user.target
-        - path: /sysroot/etc/systemd/system/kairos-k0s-post-bootstrap-enable.service
+        - path: /etc/systemd/system/kairos-k0s-post-bootstrap-enable.service
           permissions: "0644"
           owner: 0
           group: 0
@@ -613,7 +613,7 @@ stages:
             
             [Install]
             WantedBy=multi-user.target
-        - path: /sysroot/usr/local/bin/kairos-k0s-post-bootstrap.sh
+        - path: /usr/local/bin/kairos-k0s-post-bootstrap.sh
           permissions: "0755"
           owner: 0
           group: 0
@@ -763,8 +763,8 @@ MANIFEST_EOF
             echo "k0s post-bootstrap tasks completed successfully"
       commands:
         # Create symlink to enable the helper service that enables the main service
-        - mkdir -p /sysroot/etc/systemd/system/multi-user.target.wants
-        - ln -sf /sysroot/etc/systemd/system/kairos-k0s-post-bootstrap-enable.service /sysroot/etc/systemd/system/multi-user.target.wants/kairos-k0s-post-bootstrap-enable.service || true
+        - mkdir -p /etc/systemd/system/multi-user.target.wants
+        - ln -sf /etc/systemd/system/kairos-k0s-post-bootstrap-enable.service /etc/systemd/system/multi-user.target.wants/kairos-k0s-post-bootstrap-enable.service || true
 
 runcmd:
 {{- if .IsKubeVirt }}

--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
@@ -140,7 +140,7 @@ stages:
     - name: "Create k0s post-bootstrap service and script"
       files:
         {{- if or .Hostname .HostnamePrefix }}
-        - path: /sysroot/usr/local/etc/hostname
+        - path: /usr/local/etc/hostname
           permissions: "0644"
           owner: 0
           group: 0
@@ -151,7 +151,7 @@ stages:
             {{ .HostnamePrefix }}{{ "{{ trunc 4 .MachineID }}" }}
             {{- end }}
         {{- end }}
-        - path: /sysroot/etc/systemd/system/kairos-k0s-post-bootstrap.service
+        - path: /etc/systemd/system/kairos-k0s-post-bootstrap.service
           permissions: "0644"
           owner: 0
           group: 0
@@ -173,7 +173,7 @@ stages:
             
             [Install]
             WantedBy=multi-user.target
-        - path: /sysroot/etc/systemd/system/kairos-k0s-post-bootstrap-enable.service
+        - path: /etc/systemd/system/kairos-k0s-post-bootstrap-enable.service
           permissions: "0644"
           owner: 0
           group: 0
@@ -191,7 +191,7 @@ stages:
             
             [Install]
             WantedBy=multi-user.target
-        - path: /sysroot/usr/local/bin/kairos-k0s-post-bootstrap.sh
+        - path: /usr/local/bin/kairos-k0s-post-bootstrap.sh
           permissions: "0755"
           owner: 0
           group: 0
@@ -270,5 +270,5 @@ MANIFEST_EOF
             echo "k0s post-bootstrap tasks completed successfully"
       commands:
         # Create symlink to enable the helper service that enables the main service
-        - mkdir -p /sysroot/etc/systemd/system/multi-user.target.wants
-        - ln -sf /sysroot/etc/systemd/system/kairos-k0s-post-bootstrap-enable.service /sysroot/etc/systemd/system/multi-user.target.wants/kairos-k0s-post-bootstrap-enable.service || true
+        - mkdir -p /etc/systemd/system/multi-user.target.wants
+        - ln -sf /etc/systemd/system/kairos-k0s-post-bootstrap-enable.service /etc/systemd/system/multi-user.target.wants/kairos-k0s-post-bootstrap-enable.service || true


### PR DESCRIPTION
## Summary

The k0s `capv` and `capk` cloud-config templates prefixed every file path in their `stages.initramfs.files` and `stages.initramfs.commands` entries with `/sysroot/`. This is wrong on every supported Kairos boot mode:

- **Non-UKI boot**: immucore runs `stages.initramfs` inside `chroot(/sysroot)` (`immucore/pkg/state/steps_shared.go:127-139` — `RunStageOp(\"initramfs\")` enters the chroot before invoking yip). Inside the chroot, `path: /sysroot/etc/systemd/system/...` resolves to `/sysroot/sysroot/etc/systemd/system/...` — a path that does not exist on the booted rootfs. yip happily creates the directories and writes the file inside the chroot, but the booted system sees nothing at the real path.
- **UKI boot**: `immucore/internal/utils/common.go:43-51` sets `Rootdir = \"/\"` and `steps_shared.go:130` skips the chroot. The `/sysroot/...` prefix then writes to a literal `/sysroot/` directory on the real rootfs — also wrong.

Upstream Kairos cloud-config examples (`kairos/examples/cloud-configs/{wifi,wifi-alpine,initramfs-stage}.yaml`) all use bare paths in `stages.initramfs`. That's the correct prefix.

## Why this was latent

The post-bootstrap script and systemd unit these files describe were largely cosmetic for the current single-node workflow — `kubectl patch providerID` was load-bearing and ran from `runcmd` / `bootstrap-success.complete` on the real rootfs. Anything that genuinely depended on these files (the systemd unit ordering, the hostname enforcement, the manifest-write helper) was silently broken. Fixing this is a prerequisite for KD-22 (replacing the hand-rolled post-bootstrap unit with the upstream `provider-kairos.bootstrap.after.*` hook) and for any future feature that relies on those files actually existing on the booted node.

## Diff

- `internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl`: 6 sites under `stages.initramfs`.
- `internal/bootstrap/templates/k0s_kairos_cloud_config_capk.yaml.tmpl`: same 6 sites.
- Two-line change per site (`/sysroot/path/...` → `/path/...`).

No equivalent issue in the two k3s templates: they put the same files in top-level `write_files:` (which runs on the real rootfs after pivot) rather than `stages.initramfs.files:`.

## Tests

No existing test assertion references `/sysroot/`. Existing unit + adversarial test suite (221 cases) still passes.

```
go vet ./...        # clean
go build ./...      # clean
go test -short ./... # all green
```

## Refs

Closes KD-21 (foundational + upstream review).