### PR TITLE
build: add release infrastructure for v0.1.0-alpha.1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,100 @@
+name: Release
+
+# Triggered by pushing a `v*` tag (e.g. `v0.1.0-alpha.1`). The workflow:
+#   1. Builds and pushes a multi-arch container image tagged with the tag name.
+#   2. Renders the all-in-one provider manifest (kustomize) against that image.
+#   3. Computes sha256 checksums.
+#   4. Publishes a GitHub release with the manifest + checksums attached, body
+#      taken from docs/release-notes/<tag>.md.
+#
+# Pre-conditions for a clean release:
+#   * The tag must point at a commit on `main` (or a release branch) whose
+#     CI is green.
+#   * docs/release-notes/<tag>.md must exist in the tagged commit.
+#   * The GHCR_TOKEN / GITHUB_TOKEN has packages:write to ghcr.io/kairos-io.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write  # create the GitHub release
+  packages: write  # push to ghcr.io
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      GOTOOLCHAIN: local
+      IMG_REGISTRY: ghcr.io/kairos-io/cluster-api-provider-kairos
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.3'
+
+      - name: Verify release notes exist
+        run: |
+          if [ ! -f "docs/release-notes/${GITHUB_REF_NAME}.md" ]; then
+            echo "::error::Missing release notes file at docs/release-notes/${GITHUB_REF_NAME}.md."
+            echo "::error::The release workflow requires a release-notes file per tag."
+            exit 1
+          fi
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push multi-arch image
+        run: |
+          VERSION="${GITHUB_REF_NAME}" \
+          IMG_REGISTRY="${IMG_REGISTRY}" \
+          make docker-buildx-release
+
+      - name: Render release manifest
+        run: |
+          VERSION="${GITHUB_REF_NAME}" \
+          IMG_REGISTRY="${IMG_REGISTRY}" \
+          make release-manifests
+
+      - name: Inspect rendered manifest
+        run: |
+          echo "== dist contents =="
+          ls -la dist/
+          echo
+          echo "== first lines =="
+          head -20 dist/kairos-capi-provider.yaml
+          echo
+          echo "== checksums =="
+          cat dist/sha256sums.txt
+          echo
+          echo "== image references =="
+          grep -nE "image:.*kairos-io" dist/kairos-capi-provider.yaml || true
+          echo
+          echo "== leftover placeholders (should be empty) =="
+          grep -nE "CERT_NAMESPACE|CERT_NAME[^=]|SERVICE_NAME[^S]|SERVICE_NAMESPACE" dist/kairos-capi-provider.yaml || echo "(none)"
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          body_path: docs/release-notes/${{ github.ref_name }}.md
+          prerelease: true
+          draft: false
+          files: |
+            dist/kairos-capi-provider.yaml
+            dist/sha256sums.txt

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,12 @@
 # Image URL to use all building/pushing image targets
 IMG ?= ghcr.io/kairos-io/cluster-api-provider-kairos:latest
+# Image registry (no tag) — used by the release-manifests target with VERSION below.
+IMG_REGISTRY ?= ghcr.io/kairos-io/cluster-api-provider-kairos
+# Version used by release-manifests / docker-buildx-release. Default derives from git;
+# CI overrides it with the tag name when triggered by a `v*` tag push.
+VERSION ?= $(shell git describe --tags --dirty --always 2>/dev/null || echo "dev")
+# Directory where release-manifests writes its artifacts.
+RELEASE_DIR ?= dist
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:generateEmbeddedObjectMeta=true"
 
@@ -143,6 +150,27 @@ deploy: manifests ## Deploy controller to the K8s cluster specified in ~/.kube/c
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	kustomize build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+
+##@ Release
+
+.PHONY: release-manifests
+release-manifests: manifests kustomize ## Render the all-in-one provider manifest into $(RELEASE_DIR)/kairos-capi-provider.yaml.
+	@mkdir -p $(RELEASE_DIR)
+	@# Render against a temporary copy of config/ so the source tree stays clean
+	@# (kustomize edit set image mutates config/manager/kustomization.yaml in place,
+	@# which would leave the working directory dirty after a local dry-run).
+	@tmp=$$(mktemp -d) && \
+	  cp -r config "$$tmp/config" && \
+	  (cd "$$tmp/config/manager" && $(KUSTOMIZE) edit set image controller=$(IMG_REGISTRY):$(VERSION)) && \
+	  $(KUSTOMIZE) build "$$tmp/config/default" > $(RELEASE_DIR)/kairos-capi-provider.yaml && \
+	  rm -rf "$$tmp"
+	@cd $(RELEASE_DIR) && sha256sum kairos-capi-provider.yaml > sha256sums.txt
+	@echo "Release artifacts in $(RELEASE_DIR):"
+	@ls -la $(RELEASE_DIR)
+
+.PHONY: docker-buildx-release
+docker-buildx-release: generate fmt vet ## Build and push the multi-arch image tagged with VERSION for a release.
+	docker buildx build --platform linux/amd64,linux/arm64 -t $(IMG_REGISTRY):$(VERSION) --push .
 
 ##@ Build Dependencies
 

--- a/README.md
+++ b/README.md
@@ -4,39 +4,62 @@
 
 **Repository:** [github.com/kairos-io/cluster-api-provider-kairos](https://github.com/kairos-io/cluster-api-provider-kairos)
 
-```bash
-git clone https://github.com/kairos-io/cluster-api-provider-kairos.git
-```
-
 ## Overview
 
 This project provides two Cluster API (CAPI) providers for managing Kubernetes clusters on Kairos:
 
-1. **Bootstrap Provider** (`bootstrap.cluster.x-k8s.io`) - Generates Kairos cloud-config bootstrap data
-2. **Control Plane Provider** (`controlplane.cluster.x-k8s.io`) - Manages Kairos-based Kubernetes control plane machines
+1. **Bootstrap Provider** (`bootstrap.cluster.x-k8s.io`) — generates Kairos cloud-config bootstrap data.
+2. **Control Plane Provider** (`controlplane.cluster.x-k8s.io`) — manages Kairos-based Kubernetes control-plane machines.
 
 ## Status
 
-Supports single-node k0s and k3s clusters with CAPD, CAPV, and CAPK.
+**Latest release**: [`v0.1.0-alpha.1`](https://github.com/kairos-io/cluster-api-provider-kairos/releases/tag/v0.1.0-alpha.1) — initial alpha. Pre-release; API surface may change before v0.1.0.
 
-## Target Versions
+Supports single-node k0s and k3s clusters with CAPD, CAPV, and CAPK. HA control planes and additional infrastructure providers (Metal3, Tinkerbell, hyperscalers) are on the v0.1 roadmap.
 
-- **Kubernetes**: v1.34+
-- **Cluster API**: v1.11+ (v1beta2 contracts)
-- **Kairos**: v3.6.0+
-- **Distributions**: k0s, k3s
+Read the [v0.1.0-alpha.1 release notes](docs/release-notes/v0.1.0-alpha.1.md) before using — there are important security caveats and known limitations.
+
+## Install (released version)
+
+> Requires [cert-manager](https://cert-manager.io) and Cluster API core installed on the management cluster. See the [release notes](docs/release-notes/v0.1.0-alpha.1.md#install) for the full prerequisite list.
+
+```bash
+kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-alpha.1/kairos-capi-provider.yaml
+```
+
+The provider is currently distributed as a flat manifest installable via `kubectl apply -f`. [clusterctl](https://cluster-api.sigs.k8s.io/clusterctl/overview) integration is planned for a future release.
+
+## Target versions
+
+| Component | Supported |
+| --- | --- |
+| Kubernetes (workload) | bundled in your Kairos image (k3s/k0s, typically v1.30+) |
+| Kubernetes (management) | v1.30+ |
+| Cluster API | v1.8.x (v1.11.x tracking is on the roadmap) |
+| Kairos | v3.6.0+ |
+| Distributions | k0s, k3s |
 
 ## Documentation
 
-- [Install guide](docs/INSTALL.md) - Development install using make
-- [API Reference](docs/API_REFERENCE.md) - CRD reference
-- [Testing](docs/TESTING.md) - How to run tests
+- [Install guide](docs/INSTALL.md) — installation paths (released artifact + developer install from source).
+- [API Reference](docs/API_REFERENCE.md) — CRD reference.
+- [Testing](docs/TESTING.md) — how to run tests.
 
 ### Quickstarts
 
 - [CAPD (Docker)](docs/QUICKSTART_CAPD.md)
 - [CAPV (vSphere)](docs/QUICKSTART_CAPV.md)
 - [CAPK (KubeVirt)](docs/QUICKSTART_CAPK.md)
+
+## Development
+
+```bash
+git clone https://github.com/kairos-io/cluster-api-provider-kairos.git
+cd cluster-api-provider-kairos
+make test
+```
+
+See [docs/INSTALL.md](docs/INSTALL.md) for the developer install path (`make deploy` from source).
 
 ## License
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,53 +1,105 @@
 # Install Guide
 
-This guide describes how to install the Kairos CAPI provider. All steps use `make` targets.
+Two install paths: the released artifact (recommended for users) and a developer install from source.
 
-## Prerequisites
+## Path 1 — Released artifact (`kubectl apply`)
 
-- Go 1.26+ toolchain
-- A Kubernetes cluster as your management cluster (e.g. kind, minikube)
-- CAPI and an infrastructure provider (CAPD, CAPV, or CAPK) already installed
-- `kubectl` configured to use the management cluster
+Use this if you want to consume a tagged release.
 
-## Install
+### Prerequisites
+
+1. A Kubernetes cluster acting as the management cluster (kind, EKS, GKE, AKS, etc.).
+2. **cert-manager v1.15+** installed:
+   ```bash
+   kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.15.2/cert-manager.yaml
+   kubectl wait --for=condition=Available --timeout=2m -n cert-manager deploy/cert-manager-webhook
+   ```
+3. **Cluster API core** installed. Easiest path:
+   ```bash
+   clusterctl init --infrastructure docker   # or vsphere, kubevirt, …
+   ```
+   `clusterctl init` installs Cluster API core as a side effect of installing the infrastructure provider.
+4. `kubectl` configured to use the management cluster.
+
+### Install
 
 ```bash
+kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-alpha.1/kairos-capi-provider.yaml
+```
+
+This applies the all-in-one provider manifest: CRDs, RBAC, webhook configurations, and the controller Deployment in the `kairos-capi-system` namespace.
+
+### Verify
+
+```bash
+kubectl get pods -n kairos-capi-system
+kubectl get crds | grep kairos
+```
+
+Expected: one Deployment `kairos-capi-controller-manager` in `kairos-capi-system` with status `Available`, and four CRDs:
+
+- `kairosconfigs.bootstrap.cluster.x-k8s.io`
+- `kairosconfigtemplates.bootstrap.cluster.x-k8s.io`
+- `kairoscontrolplanes.controlplane.cluster.x-k8s.io`
+- `kairoscontrolplanetemplates.controlplane.cluster.x-k8s.io`
+
+### Uninstall
+
+```bash
+kubectl delete -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-alpha.1/kairos-capi-provider.yaml
+```
+
+> **Note**: the provider's `reconcileDelete` does not yet clean up child resources (KairosConfig, owned secrets, InfraMachines) when a managed `Cluster` is deleted. Manually clean up any clusters created with this release before uninstalling the provider.
+
+---
+
+## Path 2 — Developer install (from source)
+
+Use this if you're hacking on the provider itself.
+
+### Prerequisites
+
+- Go 1.26+ toolchain.
+- A Kubernetes cluster acting as the management cluster.
+- cert-manager and Cluster API core installed (same as Path 1).
+- `kubectl` configured to use the management cluster.
+
+### Install
+
+```bash
+git clone https://github.com/kairos-io/cluster-api-provider-kairos.git
+cd cluster-api-provider-kairos
 make deploy
 ```
 
 This installs CRDs, RBAC, webhooks, and the controller to the `kairos-capi-system` namespace. The controller uses the image from `IMG` (default: `ghcr.io/kairos-io/cluster-api-provider-kairos:latest`). To use a different image:
 
 ```bash
-IMG=MY_REGISTRY/cluster-api-provider-kairos:v1.0 make deploy
+IMG=MY_REGISTRY/cluster-api-provider-kairos:dev make deploy
 ```
 
-## Verify
-
-```bash
-kubectl get pods -n kairos-capi-system
-kubectl get crd | grep kairos
-```
-
-## Run locally (optional)
+### Run the controller on your host (optional)
 
 To run the controller on your host instead of deploying to the cluster:
 
 ```bash
-make install
-make run
+make install     # installs only the CRDs
+make run         # runs the controller in the foreground against your kubeconfig
 ```
 
-`make install` applies only the CRDs. Ensure your kubeconfig points to the management cluster. The controller will run in the foreground.
-
-## Uninstall
+### Uninstall
 
 ```bash
 make undeploy
 make uninstall
 ```
 
-## Next Steps
+---
 
-- [CAPD Quickstart](QUICKSTART_CAPD.md) - Create a cluster with Docker
-- [CAPV Quickstart](QUICKSTART_CAPV.md) - Create a cluster with vSphere
-- [CAPK Quickstart](QUICKSTART_CAPK.md) - Create a cluster with KubeVirt
+## Next steps
+
+- [CAPD Quickstart](QUICKSTART_CAPD.md) — create a cluster with Docker (development only).
+- [CAPV Quickstart](QUICKSTART_CAPV.md) — create a cluster with vSphere.
+- [CAPK Quickstart](QUICKSTART_CAPK.md) — create a cluster with KubeVirt.
+
+For the current release status, known issues, and security caveats, read the [release notes](release-notes/v0.1.0-alpha.1.md).

--- a/docs/release-notes/v0.1.0-alpha.1.md
+++ b/docs/release-notes/v0.1.0-alpha.1.md
@@ -1,0 +1,136 @@
+# v0.1.0-alpha.1 — initial alpha
+
+First public release of the Kairos Cluster API provider. Two providers ship together:
+
+- **Bootstrap provider** (`bootstrap.cluster.x-k8s.io/v1beta2`) — renders Kairos cloud-config bootstrap data from `KairosConfig` / `KairosConfigTemplate`.
+- **Control-plane provider** (`controlplane.cluster.x-k8s.io/v1beta2`) — manages Kairos-based Kubernetes control-plane Machines via `KairosControlPlane` / `KairosControlPlaneTemplate`.
+
+This is an **alpha**. The API surface, defaults, and on-disk layout may change before v0.1.0 ships. The release is intended for early adopters who can read the source and the release notes carefully.
+
+---
+
+## ⚠️ Security notices (read before using)
+
+### Default credentials are insecure
+
+If you don't override `spec.userPassword`, the cloud-config bootstraps the node user with **`kairos:kairos`**. Combined with `PasswordAuthentication yes` injected into `/etc/ssh/sshd_config`, every node is reachable over SSH with known credentials. Internal management of remote nodes also currently uses `ssh.InsecureIgnoreHostKey()` (no host-key verification).
+
+**Both behaviors will be removed in `v0.1.0-alpha.2`.** Until then, for any non-lab use:
+
+- Always set `spec.userPassword` to a strong value (or use `spec.userPasswordSecretRef` when that ships).
+- Always provide an explicit `spec.sshPublicKey` or `spec.gitHubUser`.
+- Treat the network where your management cluster and Kairos nodes communicate as if it were trusted (it is, by this code).
+
+### `replicas > 1` is not yet rejected
+
+`KairosControlPlane.spec.replicas > 1` is **not** rejected by the validating webhook in this release. Setting it to a value greater than 1 produces **N independent single-node clusters**, not an HA control plane. **Stay on `replicas: 1` for this release.**
+
+A webhook rejection lands in `v0.1.0-alpha.2`; full HA control-plane support is on the v0.1 roadmap.
+
+### Webhook CA injection currently uses kustomize replacements
+
+The rendered manifest sets `cert-manager.io/inject-ca-from` annotations correctly via kustomize replacements. Cert-manager's CA-injector populates the webhook configs at runtime. The legacy `hack/post-install-webhook-ca-injection.sh` script is **not** required for this install path.
+
+---
+
+## What works
+
+- **Single-node** k0s and k3s clusters via:
+  - **CAPD** (Docker, development only)
+  - **CAPV** (vSphere, single-node)
+  - **CAPK** (KubeVirt, single-node)
+- Bootstrap-secret generation from `KairosConfig` / `KairosConfigTemplate`.
+- Control-plane lifecycle: machine creation, kubeconfig publication, basic status reconciliation.
+- Cloud-config field escaping with adversarial-input round-trip tests (221 cases passing). User-controlled strings are YAML-quoted; `ProviderID` is regex-validated against shell-injection payloads.
+- `/sysroot/` prefix bug in `stages.initramfs` fixed across both k0s templates.
+- kubevirt-env tooling for local e2e development cluster setup.
+
+## What does not work yet
+
+- **HA control planes** (`replicas > 1`). See security notice above.
+- **`reconcileDelete`** does not clean up child resources (KairosConfig, owned secrets, InfraMachines) on `Cluster` deletion. Manual cleanup required if you delete a cluster managed by this release.
+- **Metal3 (CAPM3), Tinkerbell, hyperscalers** — infrastructure providers beyond CAPV/CAPK/CAPD are not yet exercised.
+- **`spec.kubernetesVersion`** is advisory. The k8s version actually installed is whatever is bundled in your Kairos image at build time. This will be reconciled in a future release; for now, ensure your image matches what you put in the spec.
+
+## Install
+
+### Prerequisites
+
+1. A management Kubernetes cluster (kind, EKS, etc.).
+2. [**cert-manager**](https://cert-manager.io) **v1.15+** installed:
+   ```bash
+   kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.15.2/cert-manager.yaml
+   kubectl wait --for=condition=Available --timeout=2m -n cert-manager deploy/cert-manager-webhook
+   ```
+3. **Cluster API core** installed (one option: `clusterctl init` with your chosen infrastructure provider, which installs CAPI core as a side effect):
+   ```bash
+   clusterctl init --infrastructure docker   # or vsphere, kubevirt, …
+   ```
+
+### Install the Kairos CAPI provider
+
+```bash
+kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-alpha.1/kairos-capi-provider.yaml
+```
+
+Verify:
+
+```bash
+kubectl get pods -n kairos-capi-system
+kubectl get crds | grep kairos
+```
+
+You should see the `kairos-capi-controller-manager` Deployment ready and four CRDs:
+`kairosconfigs.bootstrap.cluster.x-k8s.io`,
+`kairosconfigtemplates.bootstrap.cluster.x-k8s.io`,
+`kairoscontrolplanes.controlplane.cluster.x-k8s.io`,
+`kairoscontrolplanetemplates.controlplane.cluster.x-k8s.io`.
+
+### Quickstarts
+
+- [CAPD (Docker) quickstart](https://github.com/kairos-io/cluster-api-provider-kairos/blob/v0.1.0-alpha.1/docs/QUICKSTART_CAPD.md)
+- [CAPV (vSphere) quickstart](https://github.com/kairos-io/cluster-api-provider-kairos/blob/v0.1.0-alpha.1/docs/QUICKSTART_CAPV.md)
+- [CAPK (KubeVirt) quickstart](https://github.com/kairos-io/cluster-api-provider-kairos/blob/v0.1.0-alpha.1/docs/QUICKSTART_CAPK.md)
+
+## Compatibility
+
+| Component | Tested version |
+| --- | --- |
+| Cluster API | v1.8.x |
+| Kubernetes (workload) | bundled in the Kairos image (k3s/k0s, typically v1.30+) |
+| Kubernetes (management) | v1.30+ |
+| Kairos | v3.6.0+ |
+| Go (build) | 1.26.3 |
+| cert-manager | v1.15+ |
+
+Future releases will bump the Cluster API contract dependency to v1.11.x.
+
+## Artifacts
+
+The release ships two files:
+
+| File | Description |
+| --- | --- |
+| `kairos-capi-provider.yaml` | All-in-one manifest: CRDs, RBAC, webhook configs, manager Deployment. |
+| `sha256sums.txt` | SHA-256 checksum of the manifest. |
+
+Container image:
+`ghcr.io/kairos-io/cluster-api-provider-kairos:v0.1.0-alpha.1` (linux/amd64, linux/arm64).
+
+## Distribution
+
+This alpha is distributed as a flat YAML manifest installable via `kubectl apply -f`. [clusterctl](https://cluster-api.sigs.k8s.io/clusterctl/overview) integration is planned for a future release; nothing in this alpha precludes that migration.
+
+## Verifying artifacts
+
+```bash
+curl -LO https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-alpha.1/kairos-capi-provider.yaml
+curl -LO https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-alpha.1/sha256sums.txt
+sha256sum -c sha256sums.txt
+```
+
+Image signing (cosign), SBOMs, and SLSA provenance will land in a subsequent alpha.
+
+## Acknowledgements
+
+Thanks to the early users who asked for a tagged release and to the upstream Kairos maintainers whose `provider-kairos`, `immucore`, and `kairos-operator` repositories informed the cloud-config and operator-integration designs.


### PR DESCRIPTION
## Summary

Adds the minimal pieces to publish a tagged release as an all-in-one `kubectl apply`-installable manifest. `clusterctl` integration is intentionally **out of scope** for this PR — it can be added in a later release without breaking anything here.

After this PR merges, tagging `v0.1.0-alpha.1` on `main` triggers the release workflow and ships:

- Multi-arch container image: `ghcr.io/kairos-io/cluster-api-provider-kairos:v0.1.0-alpha.1` (linux/amd64, linux/arm64)
- GitHub release with `kairos-capi-provider.yaml` + `sha256sums.txt` attached
- Release body sourced from `docs/release-notes/v0.1.0-alpha.1.md`

## What's in this PR

### `Makefile`

- `IMG_REGISTRY`, `VERSION`, `RELEASE_DIR` variables.
- `make release-manifests` — renders `config/default` via kustomize against a temporary copy of `config/`, swaps the image tag to `$(IMG_REGISTRY):$(VERSION)`, writes `dist/kairos-capi-provider.yaml` and `dist/sha256sums.txt`. The temp-copy keeps the source tree clean on local dry-runs.
- `make docker-buildx-release` — multi-arch image build pinned to `VERSION` (no `:latest` floating).

### `.github/workflows/release.yaml`

Triggered by `push: tags: ['v*']`. Pre-checks that `docs/release-notes/<tag>.md` exists (surfaces the missing-file case loudly). Builds and pushes the image, renders the manifest, sha256s it, creates the GitHub release with `prerelease: true`.

### `docs/release-notes/v0.1.0-alpha.1.md`

Release notes for the initial alpha. Calls out, prominently:
- `userPassword` defaults to `kairos` and `ssh.InsecureIgnoreHostKey` is in use (both removed in alpha-2);
- `replicas > 1` is **not** rejected and produces N independent single-node clusters;
- `reconcileDelete` does not clean up child resources;
- `spec.kubernetesVersion` is advisory only.

### `README.md`

- New \"Latest release\" + \"Install (released version)\" sections.
- Honest target-versions table (Cluster API v1.8.x today; v1.11.x is roadmap, not shipped).
- Splits from-source instructions into a Development section.

### `docs/INSTALL.md`

Restructured around two paths: released artifact (`kubectl apply`) and developer install (`make deploy`). Each lists its own prerequisites and uninstall instructions.

## Local dry-run

```
VERSION=v0.1.0-alpha.1 make release-manifests
```

Result:
- `dist/kairos-capi-provider.yaml` (85128 bytes)
- Image: `ghcr.io/kairos-io/cluster-api-provider-kairos:v0.1.0-alpha.1`
- 0 leftover `CERT_NAMESPACE` / `SERVICE_NAME` placeholders
- SHA: `abbcbbabb82d6c1b0f2f91a6c47a08c793a494120bcb67952b0b6b6a08bc87aa`
- `git status` after dry-run: still clean (source tree untouched).

## Test plan

- [ ] CI passes on this PR (no controller code changed; this is a build / docs change).
- [ ] After merge, tag `v0.1.0-alpha.1` on `main`:
  ```bash
  git tag -s v0.1.0-alpha.1 -m \"v0.1.0-alpha.1 — initial alpha release\"
  git push upstream v0.1.0-alpha.1
  ```
- [ ] Release workflow runs in GitHub Actions and:
  - [ ] Pushes `ghcr.io/kairos-io/cluster-api-provider-kairos:v0.1.0-alpha.1` (linux/amd64, linux/arm64)
  - [ ] Creates a GitHub release at `https://github.com/kairos-io/cluster-api-provider-kairos/releases/tag/v0.1.0-alpha.1` with `kairos-capi-provider.yaml` and `sha256sums.txt` attached.
- [ ] Smoke test on a fresh kind cluster:
  ```bash
  kind create cluster --name capi-alpha-test
  kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.15.2/cert-manager.yaml
  clusterctl init --infrastructure docker
  kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-alpha.1/kairos-capi-provider.yaml
  kubectl get pods -n kairos-capi-system    # controller Running
  kubectl get crds | grep kairos             # 4 CRDs present
  ```

## Notes

- No controller or CRD code changed by this PR.
- `clusterctl init` integration is a separate, additive change that can land in any future release.
- Image signing (cosign), SBOMs, and SLSA provenance are deferred to alpha-2 (tracked as KD-20).