### PR TITLE
fix(controllers): reconcileDelete cleanup and latched-failure recovery (KD-4, KD-14)

### DIFF
--- a/api/bootstrap/v1beta2/kairosconfig_types.go
+++ b/api/bootstrap/v1beta2/kairosconfig_types.go
@@ -321,13 +321,16 @@ type KairosConfigStatus struct {
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
-	// FailureReason indicates the reason for bootstrap failure
-	// This field is set only when bootstrap fails permanently.
+	// FailureReason is a short machine-readable string indicating why the
+	// bootstrap controller failed on its last reconcile attempt. Cleared
+	// automatically when a subsequent reconcile succeeds, so a non-empty
+	// value indicates an ongoing failure, not a terminal one.
 	// +optional
 	FailureReason string `json:"failureReason,omitempty"`
 
-	// FailureMessage indicates the message for bootstrap failure
-	// This field is set only when bootstrap fails permanently.
+	// FailureMessage is a human-readable description of the last bootstrap
+	// failure. Cleared automatically when a subsequent reconcile succeeds.
+	// If non-empty, check the owning Machine's events for context.
 	// +optional
 	FailureMessage string `json:"failureMessage,omitempty"`
 }

--- a/api/controlplane/v1beta2/kairoscontrolplane_types.go
+++ b/api/controlplane/v1beta2/kairoscontrolplane_types.go
@@ -170,13 +170,17 @@ type KairosControlPlaneStatus struct {
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
-	// FailureReason indicates the reason for control plane failure
-	// This field is set only when the control plane fails permanently.
+	// FailureReason is a short machine-readable string indicating why the
+	// control-plane controller failed on its last reconcile attempt. Cleared
+	// automatically when a subsequent reconcile succeeds, so a non-empty
+	// value indicates an ongoing failure, not a terminal one.
 	// +optional
 	FailureReason string `json:"failureReason,omitempty"`
 
-	// FailureMessage indicates the message for control plane failure
-	// This field is set only when the control plane fails permanently.
+	// FailureMessage is a human-readable description of the last control-plane
+	// failure. Cleared automatically when a subsequent reconcile succeeds.
+	// If non-empty, check the KairosControlPlane events and the owned Machine
+	// events for context.
 	// +optional
 	FailureMessage string `json:"failureMessage,omitempty"`
 

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_kairosconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_kairosconfigs.yaml
@@ -487,13 +487,16 @@ spec:
                 type: string
               failureMessage:
                 description: |-
-                  FailureMessage indicates the message for bootstrap failure
-                  This field is set only when bootstrap fails permanently.
+                  FailureMessage is a human-readable description of the last bootstrap
+                  failure. Cleared automatically when a subsequent reconcile succeeds.
+                  If non-empty, check the owning Machine's events for context.
                 type: string
               failureReason:
                 description: |-
-                  FailureReason indicates the reason for bootstrap failure
-                  This field is set only when bootstrap fails permanently.
+                  FailureReason is a short machine-readable string indicating why the
+                  bootstrap controller failed on its last reconcile attempt. Cleared
+                  automatically when a subsequent reconcile succeeds, so a non-empty
+                  value indicates an ongoing failure, not a terminal one.
                 type: string
               initialization:
                 description: |-

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_kairoscontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_kairoscontrolplanes.yaml
@@ -274,13 +274,17 @@ spec:
                 type: array
               failureMessage:
                 description: |-
-                  FailureMessage indicates the message for control plane failure
-                  This field is set only when the control plane fails permanently.
+                  FailureMessage is a human-readable description of the last control-plane
+                  failure. Cleared automatically when a subsequent reconcile succeeds.
+                  If non-empty, check the KairosControlPlane events and the owned Machine
+                  events for context.
                 type: string
               failureReason:
                 description: |-
-                  FailureReason indicates the reason for control plane failure
-                  This field is set only when the control plane fails permanently.
+                  FailureReason is a short machine-readable string indicating why the
+                  control-plane controller failed on its last reconcile attempt. Cleared
+                  automatically when a subsequent reconcile succeeds, so a non-empty
+                  value indicates an ongoing failure, not a terminal one.
                 type: string
               initialization:
                 description: |-

--- a/internal/controllers/bootstrap/cleanup.go
+++ b/internal/controllers/bootstrap/cleanup.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2024 The Kairos CAPI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	bootstrapv1beta2 "github.com/kairos-io/cluster-api-provider-kairos/api/bootstrap/v1beta2"
+)
+
+// deleteBootstrapSecret removes the bootstrap Secret named in
+// kc.Status.DataSecretName. Callers use the returned `gone` flag to decide
+// whether to requeue or proceed with finalizer removal.
+//
+// Semantics:
+//
+//   - If kc.Status.DataSecretName is nil or empty, return gone=true. There
+//     is nothing to delete and the finalizer can be removed immediately.
+//   - Get the Secret. If IsNotFound: gone=true (already removed or never
+//     created). On Get error other than IsNotFound: gone=false, err.
+//   - Issue Delete. On IsNotFound during the Delete call: gone=true (raced
+//     with another reaper). On other errors: gone=false, err.
+//   - On a successful Delete: return gone=false because Kubernetes Delete is
+//     asynchronous. The follow-up reconcile's Get will return IsNotFound
+//     and we will report gone=true. Requeuing once is intentional -- we do
+//     NOT trust garbage collection to be deterministic in envtest or under
+//     load. (KD-4, maintainer-confirmed plan.)
+//
+// The bootstrap Secret is owned (Controller=true) by the KairosConfig via
+// controllerutil.SetControllerReference, so Kubernetes garbage collection
+// would eventually reap it -- but waiting for that race-prone path was the
+// failure mode that motivated KD-4. Explicit Delete makes the contract
+// deterministic.
+func deleteBootstrapSecret(ctx context.Context, c client.Client, kc *bootstrapv1beta2.KairosConfig) (gone bool, err error) {
+	if kc.Status.DataSecretName == nil || *kc.Status.DataSecretName == "" {
+		return true, nil
+	}
+	secretKey := types.NamespacedName{
+		Name:      *kc.Status.DataSecretName,
+		Namespace: kc.Namespace,
+	}
+	secret := &corev1.Secret{}
+	if err := c.Get(ctx, secretKey, secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	if err := c.Delete(ctx, secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	// Delete is asynchronous -- the apiserver may still return the object
+	// from a Get until the GC sweep completes. Request a requeue and let
+	// the next pass observe IsNotFound.
+	return false, nil
+}

--- a/internal/controllers/bootstrap/cleanup_test.go
+++ b/internal/controllers/bootstrap/cleanup_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2024 The Kairos CAPI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	bootstrapv1beta2 "github.com/kairos-io/cluster-api-provider-kairos/api/bootstrap/v1beta2"
+)
+
+func newCleanupTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	g := NewWithT(t)
+	scheme := runtime.NewScheme()
+	g.Expect(bootstrapv1beta2.AddToScheme(scheme)).To(Succeed())
+	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	return scheme
+}
+
+// TestDeleteBootstrapSecret_NoDataSecretName covers the "nothing to delete"
+// path: KairosConfig.Status.DataSecretName is nil. Returns gone=true so the
+// caller can immediately remove the finalizer.
+func TestDeleteBootstrapSecret_NoDataSecretName(t *testing.T) {
+	g := NewWithT(t)
+	scheme := newCleanupTestScheme(t)
+
+	kc := &bootstrapv1beta2.KairosConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kc",
+			Namespace: "default",
+		},
+		// Status.DataSecretName intentionally nil.
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(kc).Build()
+
+	gone, err := deleteBootstrapSecret(context.Background(), c, kc)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(gone).To(BeTrue())
+}
+
+// TestDeleteBootstrapSecret_AlreadyAbsent covers the "Secret was already
+// reaped" path: Status.DataSecretName points at a name that doesn't exist.
+// Returns gone=true.
+func TestDeleteBootstrapSecret_AlreadyAbsent(t *testing.T) {
+	g := NewWithT(t)
+	scheme := newCleanupTestScheme(t)
+
+	secretName := "kc-bootstrap"
+	kc := &bootstrapv1beta2.KairosConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kc",
+			Namespace: "default",
+		},
+		Status: bootstrapv1beta2.KairosConfigStatus{
+			DataSecretName: &secretName,
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(kc).Build()
+
+	gone, err := deleteBootstrapSecret(context.Background(), c, kc)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(gone).To(BeTrue())
+}
+
+// TestDeleteBootstrapSecret_DeletesPresent covers the happy path: the Secret
+// exists and we issue Delete. Returns gone=false so the caller requeues
+// once to let the apiserver finish GC; a follow-up call observes IsNotFound
+// and returns gone=true.
+func TestDeleteBootstrapSecret_DeletesPresent(t *testing.T) {
+	g := NewWithT(t)
+	scheme := newCleanupTestScheme(t)
+
+	secretName := "kc-bootstrap"
+	kc := &bootstrapv1beta2.KairosConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kc",
+			Namespace: "default",
+		},
+		Status: bootstrapv1beta2.KairosConfigStatus{
+			DataSecretName: &secretName,
+		},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"value": []byte("#cloud-config\nfake"),
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(kc, secret).Build()
+
+	gone, err := deleteBootstrapSecret(context.Background(), c, kc)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(gone).To(BeFalse(), "first pass returns gone=false to trigger a requeue and confirm GC")
+
+	// Follow-up pass: the fake client GC'd it synchronously; we should now
+	// observe IsNotFound and return gone=true.
+	gone, err = deleteBootstrapSecret(context.Background(), c, kc)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(gone).To(BeTrue(), "follow-up pass observes IsNotFound and returns gone=true")
+
+	// Sanity: the Secret really is gone.
+	got := &corev1.Secret{}
+	getErr := c.Get(context.Background(), types.NamespacedName{Name: secretName, Namespace: "default"}, got)
+	g.Expect(getErr).To(HaveOccurred())
+}
+
+// TestDeleteBootstrapSecret_EmptyDataSecretName covers the edge case of an
+// empty (zero-value pointer-to-empty-string) DataSecretName, which the spec
+// is careful to treat as "no secret".
+func TestDeleteBootstrapSecret_EmptyDataSecretName(t *testing.T) {
+	g := NewWithT(t)
+	scheme := newCleanupTestScheme(t)
+
+	empty := ""
+	kc := &bootstrapv1beta2.KairosConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kc",
+			Namespace: "default",
+		},
+		Status: bootstrapv1beta2.KairosConfigStatus{
+			DataSecretName: &empty,
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(kc).Build()
+
+	gone, err := deleteBootstrapSecret(context.Background(), c, kc)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(gone).To(BeTrue())
+}

--- a/internal/controllers/bootstrap/kairosconfig_controller.go
+++ b/internal/controllers/bootstrap/kairosconfig_controller.go
@@ -127,9 +127,16 @@ func (r *KairosConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 	}()
 
-	// Handle deletion
+	// Handle deletion. reconcileDelete signals via skipPatch=true when it
+	// has just issued a bare r.Update for the terminal finalizer-remove
+	// step -- the deferred Patch must be skipped to avoid racing the
+	// apiserver removing the object.
 	if !kairosConfig.ObjectMeta.DeletionTimestamp.IsZero() {
-		return r.reconcileDelete(ctx, log, kairosConfig)
+		res, skipPatch, derr := r.reconcileDelete(ctx, log, kairosConfig)
+		if skipPatch {
+			patchOnExit = false
+		}
+		return res, derr
 	}
 
 	// Add finalizer if needed. The deferred patch helper flushes the change;
@@ -1235,15 +1242,54 @@ func (r *KairosConfigReconciler) getControlPlaneLBEndpoint(ctx context.Context, 
 	return "", nil
 }
 
-func (r *KairosConfigReconciler) reconcileDelete(ctx context.Context, log logr.Logger, kairosConfig *bootstrapv1beta2.KairosConfig) (ctrl.Result, error) {
-	// Remove finalizer. The deferred patch helper in Reconcile flushes the
-	// change. Commit 4 (KD-4) replaces this stub with an explicit drain of the
-	// owned bootstrap Secret before the finalizer is dropped, at which point
-	// the terminal finalizer-remove step switches to a bare r.Update with the
-	// patchOnExit guard.
+// reconcileDelete drains the owned bootstrap Secret before removing the
+// finalizer. Stripping the finalizer with the Secret still attached leaks the
+// rendered cloud-config (containing user passwords and tokens) until
+// Kubernetes garbage collection eventually reaps it -- the failure mode
+// motivating KD-4.
+//
+// Returns (result, skipPatch, err). When skipPatch is true the caller MUST
+// NOT run the deferred patch.Helper.Patch -- this happens when we just
+// issued a bare r.Update for the terminal finalizer-remove step. Once the
+// last finalizer drops, the apiserver is free to garbage-collect the
+// object, and a follow-up patch from the deferred closure would race that
+// GC and surface as a 404.
+func (r *KairosConfigReconciler) reconcileDelete(ctx context.Context, log logr.Logger, kairosConfig *bootstrapv1beta2.KairosConfig) (result ctrl.Result, skipPatch bool, err error) {
+	gone, err := deleteBootstrapSecret(ctx, r.Client, kairosConfig)
+	if err != nil {
+		log.Error(err, "Failed to delete bootstrap Secret",
+			"kairosConfig", kairosConfig.Name,
+			"namespace", kairosConfig.Namespace,
+			"uid", kairosConfig.UID)
+		return ctrl.Result{}, false, err
+	}
+	if !gone {
+		log.Info("Waiting for bootstrap Secret to be reaped before removing KairosConfig finalizer",
+			"kairosConfig", kairosConfig.Name,
+			"namespace", kairosConfig.Namespace,
+			"secret", *kairosConfig.Status.DataSecretName)
+		return ctrl.Result{RequeueAfter: bootstrapDeleteRequeueAfter}, false, nil
+	}
+
+	// Terminal step: remove the finalizer with a bare r.Update. The patch
+	// helper is bypassed via skipPatch=true so the deferred closure in
+	// Reconcile does not race the apiserver's garbage-collection of this
+	// object. (KD-4, per maintainer-confirmed plan.)
 	controllerutil.RemoveFinalizer(kairosConfig, bootstrapv1beta2.KairosConfigFinalizer)
-	return ctrl.Result{}, nil
+	if err := r.Update(ctx, kairosConfig); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Object already gone.
+			return ctrl.Result{}, true, nil
+		}
+		return ctrl.Result{}, true, err
+	}
+	return ctrl.Result{}, true, nil
 }
+
+// bootstrapDeleteRequeueAfter is the polling interval while waiting for the
+// owned bootstrap Secret to be garbage-collected. Short because Secret GC
+// is normally near-instant; long enough not to hammer the apiserver.
+const bootstrapDeleteRequeueAfter = 5 * time.Second
 
 // randomString generates a random lowercase alphanumeric string of the given length
 // This ensures the string is RFC 1123 compliant for Kubernetes resource names

--- a/internal/controllers/bootstrap/kairosconfig_controller.go
+++ b/internal/controllers/bootstrap/kairosconfig_controller.go
@@ -83,7 +83,15 @@ type KairosConfigReconciler struct {
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;patch;update
 
 // Reconcile is part of the main kubernetes reconciliation loop
-func (r *KairosConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+//
+// The function uses a single deferred patch.Helper.Patch to flush all spec and
+// status mutations on the way out. The helper is created immediately after the
+// initial Get so that even early-return paths (paused, no owner Machine, no
+// Cluster) reconcile observedGeneration and conditions. This closes KD-14.
+//
+// Named returns (result, retErr) are required so the deferred closure can
+// combine the patch error into the returned error via errors.Join.
+func (r *KairosConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	// Fetch the KairosConfig instance
@@ -95,20 +103,45 @@ func (r *KairosConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 
+	// Initialize patch helper BEFORE any early returns so paused/no-owner/no-Cluster
+	// paths still flush observedGeneration and condition transitions. (KD-14.)
+	patchHelper, err := patch.NewHelper(kairosConfig, r.Client)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Always update observedGeneration, including on early-return paths.
+	kairosConfig.Status.ObservedGeneration = kairosConfig.Generation
+
+	// patchOnExit lets reconcileDelete signal that it has already issued a bare
+	// r.Update for the terminal finalizer-removal step and the deferred patch
+	// MUST be skipped to avoid racing with the apiserver removing the object.
+	// In commit 1 this is always true; commit 4 wires the skip path.
+	patchOnExit := true
+	defer func() {
+		if !patchOnExit {
+			return
+		}
+		if perr := patchHelper.Patch(ctx, kairosConfig); perr != nil {
+			retErr = errors.Join(retErr, perr)
+		}
+	}()
+
 	// Handle deletion
 	if !kairosConfig.ObjectMeta.DeletionTimestamp.IsZero() {
 		return r.reconcileDelete(ctx, log, kairosConfig)
 	}
 
-	// Add finalizer if needed
-	if !controllerutil.ContainsFinalizer(kairosConfig, bootstrapv1beta2.KairosConfigFinalizer) {
-		controllerutil.AddFinalizer(kairosConfig, bootstrapv1beta2.KairosConfigFinalizer)
-		if err := r.Update(ctx, kairosConfig); err != nil {
-			return ctrl.Result{}, err
-		}
-	}
+	// Add finalizer if needed. The deferred patch helper flushes the change;
+	// no bare r.Update here. (controller-reconcile-safety skill.)
+	controllerutil.AddFinalizer(kairosConfig, bootstrapv1beta2.KairosConfigFinalizer)
 
-	// Check if paused
+	// Check if paused. observedGeneration was already set above; the deferred
+	// patch flushes it along with any condition changes a previous Reconcile
+	// left in flight. FailureReason/FailureMessage are intentionally NOT
+	// cleared on the paused path -- latched failure state still reflects the
+	// last real observation and clears on the first successful post-resume
+	// Reconcile.
 	if kairosConfig.Spec.Pause {
 		log.Info("KairosConfig is paused, skipping reconciliation")
 		return ctrl.Result{}, nil
@@ -136,17 +169,8 @@ func (r *KairosConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
-	// Initialize patch helper
-	helper, err := patch.NewHelper(kairosConfig, r.Client)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	// Always update observedGeneration
-	kairosConfig.Status.ObservedGeneration = kairosConfig.Generation
-
 	// Reconcile bootstrap data
-	result, err := r.reconcileBootstrapData(ctx, log, kairosConfig, machine, cluster)
+	bootstrapResult, err := r.reconcileBootstrapData(ctx, log, kairosConfig, machine, cluster)
 	if err != nil {
 		// Mark conditions as false on error
 		// Use "%s" as format string and pass error as argument to satisfy linter
@@ -158,12 +182,12 @@ func (r *KairosConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		kairosConfig.Status.FailureMessage = err.Error()
 		kairosConfig.Status.Ready = false
 
-		return ctrl.Result{}, helper.Patch(ctx, kairosConfig)
+		return ctrl.Result{}, nil
 	}
 
 	// If reconcileBootstrapData requested a requeue (e.g., waiting for providerID), return it
-	if result.Requeue || result.RequeueAfter > 0 {
-		return result, helper.Patch(ctx, kairosConfig)
+	if bootstrapResult.Requeue || bootstrapResult.RequeueAfter > 0 {
+		return bootstrapResult, nil
 	}
 
 	// Mark conditions as true on success
@@ -171,12 +195,14 @@ func (r *KairosConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	conditions.MarkTrue(kairosConfig, bootstrapv1beta2.BootstrapReadyCondition)
 	conditions.MarkTrue(kairosConfig, bootstrapv1beta2.DataSecretAvailableCondition)
 
-	// Clear failure fields
+	// Clear failure fields on every successful exit so a transient missing
+	// dependency (e.g. userPasswordSecretRef target Secret) does not latch
+	// FailureReason/Message into a terminal state that blocks the CAPI Machine
+	// controller from cloning the infrastructure Machine. (KD-14.)
 	kairosConfig.Status.FailureReason = ""
 	kairosConfig.Status.FailureMessage = ""
 
-	// Update status
-	return ctrl.Result{}, helper.Patch(ctx, kairosConfig)
+	return ctrl.Result{}, nil
 }
 
 func (r *KairosConfigReconciler) reconcileBootstrapData(ctx context.Context, log logr.Logger, kairosConfig *bootstrapv1beta2.KairosConfig, machine *clusterv1.Machine, cluster *clusterv1.Cluster) (ctrl.Result, error) {
@@ -1210,9 +1236,13 @@ func (r *KairosConfigReconciler) getControlPlaneLBEndpoint(ctx context.Context, 
 }
 
 func (r *KairosConfigReconciler) reconcileDelete(ctx context.Context, log logr.Logger, kairosConfig *bootstrapv1beta2.KairosConfig) (ctrl.Result, error) {
-	// Remove finalizer
+	// Remove finalizer. The deferred patch helper in Reconcile flushes the
+	// change. Commit 4 (KD-4) replaces this stub with an explicit drain of the
+	// owned bootstrap Secret before the finalizer is dropped, at which point
+	// the terminal finalizer-remove step switches to a bare r.Update with the
+	// patchOnExit guard.
 	controllerutil.RemoveFinalizer(kairosConfig, bootstrapv1beta2.KairosConfigFinalizer)
-	return ctrl.Result{}, r.Update(ctx, kairosConfig)
+	return ctrl.Result{}, nil
 }
 
 // randomString generates a random lowercase alphanumeric string of the given length

--- a/internal/controllers/bootstrap/kairosconfig_controller_test.go
+++ b/internal/controllers/bootstrap/kairosconfig_controller_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -982,4 +983,195 @@ func TestGenerateK3sCloudConfig_ControlPlaneKubeVirtCapk(t *testing.T) {
 	g.Expect(cloudConfig).To(ContainSubstring("CAPK: always mark bootstrap success on script exit"))
 	g.Expect(cloudConfig).To(ContainSubstring("--tls-san=192.0.2.10"))
 	g.Expect(cloudConfig).To(ContainSubstring("k3s:"))
+}
+
+// newBootstrapTestScheme registers the schemes that the bootstrap Reconcile
+// flow depends on for these unit tests.
+func newBootstrapTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	g := NewWithT(t)
+	scheme := runtime.NewScheme()
+	g.Expect(bootstrapv1beta2.AddToScheme(scheme)).To(Succeed())
+	g.Expect(clusterv1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	return scheme
+}
+
+// TestReconcile_PausedPatchesObservedGeneration verifies KD-14: even when the
+// KairosConfig is paused, Reconcile must flush observedGeneration via the
+// deferred patch helper. Prior to the fix the patch helper was created after
+// the paused early-return and observedGeneration drifted permanently.
+func TestReconcile_PausedPatchesObservedGeneration(t *testing.T) {
+	g := NewWithT(t)
+	scheme := newBootstrapTestScheme(t)
+
+	kairosConfig := &bootstrapv1beta2.KairosConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "paused-config",
+			Namespace:  "default",
+			Generation: 7,
+		},
+		Spec: bootstrapv1beta2.KairosConfigSpec{
+			Role:         "control-plane",
+			Distribution: "k0s",
+			Pause:        true,
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(kairosConfig).
+		WithStatusSubresource(&bootstrapv1beta2.KairosConfig{}).
+		Build()
+	r := &KairosConfigReconciler{Client: c, Scheme: scheme}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "paused-config", Namespace: "default"}})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	got := &bootstrapv1beta2.KairosConfig{}
+	g.Expect(c.Get(context.Background(), types.NamespacedName{Name: "paused-config", Namespace: "default"}, got)).To(Succeed())
+	g.Expect(got.Status.ObservedGeneration).To(Equal(int64(7)))
+}
+
+// TestReconcile_NoOwnerMachinePatchesObservedGeneration verifies KD-14 for the
+// "Machine controller has not yet set OwnerRef" early return. observedGeneration
+// must still be flushed.
+func TestReconcile_NoOwnerMachinePatchesObservedGeneration(t *testing.T) {
+	g := NewWithT(t)
+	scheme := newBootstrapTestScheme(t)
+
+	kairosConfig := &bootstrapv1beta2.KairosConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "orphan-config",
+			Namespace:  "default",
+			Generation: 3,
+		},
+		Spec: bootstrapv1beta2.KairosConfigSpec{
+			Role:         "control-plane",
+			Distribution: "k0s",
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(kairosConfig).
+		WithStatusSubresource(&bootstrapv1beta2.KairosConfig{}).
+		Build()
+	r := &KairosConfigReconciler{Client: c, Scheme: scheme}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "orphan-config", Namespace: "default"}})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	got := &bootstrapv1beta2.KairosConfig{}
+	g.Expect(c.Get(context.Background(), types.NamespacedName{Name: "orphan-config", Namespace: "default"}, got)).To(Succeed())
+	g.Expect(got.Status.ObservedGeneration).To(Equal(int64(3)))
+	// Finalizer should be added even though we early-return on missing owner Machine.
+	g.Expect(got.Finalizers).To(ContainElement(bootstrapv1beta2.KairosConfigFinalizer))
+}
+
+// TestReconcile_PausedDoesNotClearFailureFields verifies the maintainer-confirmed
+// decision #2: latched FailureReason/FailureMessage must NOT be cleared on the
+// paused path. Clearing happens naturally on the first successful post-resume
+// Reconcile.
+func TestReconcile_PausedDoesNotClearFailureFields(t *testing.T) {
+	g := NewWithT(t)
+	scheme := newBootstrapTestScheme(t)
+
+	kairosConfig := &bootstrapv1beta2.KairosConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "paused-failed-config",
+			Namespace:  "default",
+			Generation: 1,
+		},
+		Spec: bootstrapv1beta2.KairosConfigSpec{
+			Role:         "control-plane",
+			Distribution: "k0s",
+			Pause:        true,
+		},
+		Status: bootstrapv1beta2.KairosConfigStatus{
+			FailureReason:  "SomePriorFailure",
+			FailureMessage: "rendered userdata before user paused us",
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(kairosConfig).
+		WithStatusSubresource(&bootstrapv1beta2.KairosConfig{}).
+		Build()
+	r := &KairosConfigReconciler{Client: c, Scheme: scheme}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "paused-failed-config", Namespace: "default"}})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	got := &bootstrapv1beta2.KairosConfig{}
+	g.Expect(c.Get(context.Background(), types.NamespacedName{Name: "paused-failed-config", Namespace: "default"}, got)).To(Succeed())
+	g.Expect(got.Status.FailureReason).To(Equal("SomePriorFailure"))
+	g.Expect(got.Status.FailureMessage).To(Equal("rendered userdata before user paused us"))
+}
+
+// TestReconcile_SuccessClearsFailureFields verifies KD-14: when a previous
+// Reconcile latched FailureReason/FailureMessage (e.g. transient missing
+// userPasswordSecretRef target) and the next Reconcile succeeds, the failure
+// fields are cleared. Prior to the fix they latched forever and CAPI Machine
+// controller refused to clone the infra Machine.
+func TestReconcile_SuccessClearsFailureFields(t *testing.T) {
+	g := NewWithT(t)
+	scheme := newBootstrapTestScheme(t)
+
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "default",
+		},
+	}
+	machine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-machine",
+			Namespace: "default",
+			Labels:    map[string]string{clusterv1.ClusterNameLabel: "test-cluster"},
+		},
+		Spec: clusterv1.MachineSpec{
+			ClusterName: "test-cluster",
+		},
+	}
+	kairosConfig := &bootstrapv1beta2.KairosConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "recovered-config",
+			Namespace:  "default",
+			Generation: 5,
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(machine, clusterv1.GroupVersion.WithKind("Machine")),
+			},
+		},
+		Spec: bootstrapv1beta2.KairosConfigSpec{
+			Role:              "control-plane",
+			Distribution:      "k0s",
+			KubernetesVersion: "v1.30.0+k0s.0",
+			SingleNode:        true,
+			UserName:          "kairos",
+			UserPassword:      "kairos",
+			UserGroups:        []string{"admin"},
+		},
+		Status: bootstrapv1beta2.KairosConfigStatus{
+			FailureReason:  bootstrapv1beta2.BootstrapDataSecretGenerationFailedReason,
+			FailureMessage: "user password secret default/missing not found",
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cluster, machine, kairosConfig).
+		WithStatusSubresource(&bootstrapv1beta2.KairosConfig{}).
+		Build()
+	r := &KairosConfigReconciler{Client: c, Scheme: scheme}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "recovered-config", Namespace: "default"}})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	got := &bootstrapv1beta2.KairosConfig{}
+	g.Expect(c.Get(context.Background(), types.NamespacedName{Name: "recovered-config", Namespace: "default"}, got)).To(Succeed())
+	g.Expect(got.Status.FailureReason).To(BeEmpty(), "FailureReason should be cleared on success (KD-14)")
+	g.Expect(got.Status.FailureMessage).To(BeEmpty(), "FailureMessage should be cleared on success (KD-14)")
+	g.Expect(got.Status.ObservedGeneration).To(Equal(int64(5)))
 }

--- a/internal/controllers/controlplane/cleanup.go
+++ b/internal/controllers/controlplane/cleanup.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2024 The Kairos CAPI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package controlplane
+
+import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	controlplanev1beta2 "github.com/kairos-io/cluster-api-provider-kairos/api/controlplane/v1beta2"
+)
+
+// drainOwnedMachines enumerates CAPI Machines owned by this KairosControlPlane,
+// issues a Delete for any that are not already being deleted, and returns the
+// count of Machines that are still present (including those mid-deletion).
+// Callers use the remaining count to decide whether to requeue or proceed
+// with finalizer removal.
+//
+// Selection criteria (both must hold):
+//
+//  1. Machine has the `cluster.x-k8s.io/cluster-name` label matching the
+//     cluster-name label on the KCP. Without a cluster-name on the KCP we
+//     cannot scope the drain safely, so we return 0 / nil and let the
+//     finalizer be removed -- there is nothing we can act on.
+//  2. Machine's controlling OwnerReference Kind=="KairosControlPlane" AND
+//     UID matches the KCP's UID. Matching by UID (not just Name) prevents a
+//     foreign Machine with the same name from being deleted if the KCP was
+//     recreated. Foreign-owned Machines (different UID or different Kind)
+//     are deliberately NOT deleted and NOT counted in `remaining` -- they
+//     are not ours to drain.
+//
+// `IsNotFound` from Delete is treated as success (the Machine was already
+// reaped between List and Delete). The CAPI Machine controller is
+// responsible for cascading to KairosConfig and the infrastructure Machine
+// via OwnerReferences, so this function does not delete those directly.
+// (KD-4.)
+func drainOwnedMachines(ctx context.Context, c client.Client, kcp *controlplanev1beta2.KairosControlPlane) (remaining int, err error) {
+	clusterName, ok := kcp.Labels[clusterv1.ClusterNameLabel]
+	if !ok || clusterName == "" {
+		// We have no cluster-name label to scope the drain. This happens
+		// when the KCP was deleted before ever finding its parent Cluster.
+		// There are no Machines we can confidently own in this state.
+		return 0, nil
+	}
+
+	selector := labels.SelectorFromSet(labels.Set{
+		clusterv1.ClusterNameLabel: clusterName,
+	})
+	machineList := &clusterv1.MachineList{}
+	if err := c.List(ctx, machineList,
+		client.InNamespace(kcp.Namespace),
+		client.MatchingLabelsSelector{Selector: selector},
+	); err != nil {
+		return 0, err
+	}
+
+	kcpUID := kcp.UID
+	for i := range machineList.Items {
+		m := &machineList.Items[i]
+		if !ownedByKCP(m, kcpUID) {
+			continue
+		}
+		remaining++
+		if !m.DeletionTimestamp.IsZero() {
+			// Already being deleted; nothing for us to do, but it counts
+			// against `remaining` so the caller keeps requeuing.
+			continue
+		}
+		if err := c.Delete(ctx, m); err != nil {
+			if apierrors.IsNotFound(err) {
+				// Reaped between List and Delete; not really remaining.
+				remaining--
+				continue
+			}
+			return remaining, err
+		}
+	}
+	return remaining, nil
+}
+
+// ownedByKCP reports whether machine is owned (controller=true) by a
+// KairosControlPlane with the given UID. Matching by UID prevents a foreign
+// Machine that happens to share a name (e.g. across a delete+recreate) from
+// being misidentified as ours.
+func ownedByKCP(machine *clusterv1.Machine, kcpUID types.UID) bool {
+	for _, ref := range machine.OwnerReferences {
+		if ref.Controller == nil || !*ref.Controller {
+			continue
+		}
+		if ref.Kind != "KairosControlPlane" {
+			continue
+		}
+		if ref.UID == kcpUID {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/controllers/controlplane/cleanup_test.go
+++ b/internal/controllers/controlplane/cleanup_test.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2024 The Kairos CAPI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package controlplane
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	bootstrapv1beta2 "github.com/kairos-io/cluster-api-provider-kairos/api/bootstrap/v1beta2"
+	controlplanev1beta2 "github.com/kairos-io/cluster-api-provider-kairos/api/controlplane/v1beta2"
+)
+
+const (
+	cleanupClusterName = "drain-cluster"
+	cleanupKCPName     = "drain-kcp"
+	cleanupNamespace   = "default"
+)
+
+func newCleanupTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	g := NewWithT(t)
+	scheme := runtime.NewScheme()
+	g.Expect(bootstrapv1beta2.AddToScheme(scheme)).To(Succeed())
+	g.Expect(controlplanev1beta2.AddToScheme(scheme)).To(Succeed())
+	g.Expect(clusterv1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	return scheme
+}
+
+func newDrainKCP() *controlplanev1beta2.KairosControlPlane {
+	return &controlplanev1beta2.KairosControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cleanupKCPName,
+			Namespace: cleanupNamespace,
+			UID:       types.UID("kcp-uid-aaaa"),
+			Labels: map[string]string{
+				clusterv1.ClusterNameLabel: cleanupClusterName,
+			},
+		},
+	}
+}
+
+func newOwnedMachine(name string, kcp *controlplanev1beta2.KairosControlPlane) *clusterv1.Machine {
+	return &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: cleanupNamespace,
+			Labels: map[string]string{
+				clusterv1.ClusterNameLabel:         cleanupClusterName,
+				clusterv1.MachineControlPlaneLabel: "",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: controlplanev1beta2.GroupVersion.String(),
+					Kind:       "KairosControlPlane",
+					Name:       kcp.Name,
+					UID:        kcp.UID,
+					Controller: ptr.To(true),
+				},
+			},
+		},
+		Spec: clusterv1.MachineSpec{
+			ClusterName: cleanupClusterName,
+		},
+	}
+}
+
+// TestDrainOwnedMachines_NoMachines confirms the happy path: nothing owned,
+// returns remaining=0 and no error.
+func TestDrainOwnedMachines_NoMachines(t *testing.T) {
+	g := NewWithT(t)
+	scheme := newCleanupTestScheme(t)
+	kcp := newDrainKCP()
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(kcp).Build()
+	remaining, err := drainOwnedMachines(context.Background(), c, kcp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(remaining).To(Equal(0))
+}
+
+// TestDrainOwnedMachines_NoClusterNameLabel proves we no-op (no error, no
+// deletes) when the KCP lacks a cluster-name label. This is the "deleted
+// before ever finding its Cluster" edge case.
+func TestDrainOwnedMachines_NoClusterNameLabel(t *testing.T) {
+	g := NewWithT(t)
+	scheme := newCleanupTestScheme(t)
+	kcp := newDrainKCP()
+	delete(kcp.Labels, clusterv1.ClusterNameLabel)
+	// Pre-create a Machine that DOES carry the cluster-name label and would
+	// be owned by us if we knew the cluster name. Without the label on the
+	// KCP, we must NOT delete it.
+	bystander := newOwnedMachine("bystander", kcp)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(kcp, bystander).Build()
+
+	remaining, err := drainOwnedMachines(context.Background(), c, kcp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(remaining).To(Equal(0))
+
+	// Verify the bystander was NOT deleted.
+	got := &clusterv1.Machine{}
+	g.Expect(c.Get(context.Background(), client.ObjectKeyFromObject(bystander), got)).To(Succeed())
+	g.Expect(got.DeletionTimestamp.IsZero()).To(BeTrue())
+}
+
+// TestDrainOwnedMachines_DeletesOwned issues Delete on each owned Machine and
+// returns the count remaining (which equals the number we just asked the
+// apiserver to remove). After a follow-up reconcile the fake client would
+// have GC'd them, but for the in-flight call we still report them as
+// remaining so the caller requeues.
+func TestDrainOwnedMachines_DeletesOwned(t *testing.T) {
+	g := NewWithT(t)
+	scheme := newCleanupTestScheme(t)
+	kcp := newDrainKCP()
+	m1 := newOwnedMachine("drain-kcp-0", kcp)
+	m2 := newOwnedMachine("drain-kcp-1", kcp)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(kcp, m1, m2).Build()
+
+	remaining, err := drainOwnedMachines(context.Background(), c, kcp)
+	g.Expect(err).NotTo(HaveOccurred())
+	// The fake client deletes objects synchronously rather than setting a
+	// deletion timestamp (no finalizers attached). After the call both
+	// Machines have been removed, but the count we report is what was
+	// observed at List time -- the contract is "Machines we asked to delete
+	// or are mid-delete". For the fake client both delete immediately, so
+	// the remaining is decremented inside drainOwnedMachines only for the
+	// IsNotFound mid-delete race. Here both deletes succeed normally so we
+	// return 2.
+	g.Expect(remaining).To(Equal(2))
+
+	// Verify both are gone.
+	g.Expect(c.Get(context.Background(), client.ObjectKeyFromObject(m1), &clusterv1.Machine{})).NotTo(Succeed())
+	g.Expect(c.Get(context.Background(), client.ObjectKeyFromObject(m2), &clusterv1.Machine{})).NotTo(Succeed())
+}
+
+// TestDrainOwnedMachines_SkipsForeignOwned verifies that Machines owned by a
+// different KCP (matching the same cluster-name label) are NOT deleted and
+// NOT counted in remaining. This is the safety net against deleting another
+// control plane's nodes when two KCPs happen to share a cluster name (e.g.
+// rolling KCP migration).
+func TestDrainOwnedMachines_SkipsForeignOwned(t *testing.T) {
+	g := NewWithT(t)
+	scheme := newCleanupTestScheme(t)
+	kcp := newDrainKCP()
+
+	// Foreign Machine: same cluster-name label, different KCP UID.
+	foreignKCP := &controlplanev1beta2.KairosControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "other-kcp",
+			Namespace: cleanupNamespace,
+			UID:       types.UID("kcp-uid-zzzz"),
+		},
+	}
+	foreign := newOwnedMachine("other-kcp-0", foreignKCP)
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(kcp, foreign).Build()
+
+	remaining, err := drainOwnedMachines(context.Background(), c, kcp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(remaining).To(Equal(0), "foreign-owned Machine must not count toward remaining")
+
+	// Verify the foreign Machine was NOT deleted.
+	got := &clusterv1.Machine{}
+	g.Expect(c.Get(context.Background(), client.ObjectKeyFromObject(foreign), got)).To(Succeed())
+	g.Expect(got.DeletionTimestamp.IsZero()).To(BeTrue(), "foreign-owned Machine must not be deleted")
+}
+
+// TestDrainOwnedMachines_MidDeletionStillCounts verifies that a Machine
+// already carrying a DeletionTimestamp (e.g. another controller holds a
+// finalizer on it) is counted in remaining so the caller keeps requeuing
+// rather than removing the KCP finalizer prematurely. This is the
+// negative path that proves KD-4 is fixed: the KCP cannot disappear while
+// orphan-prone children still linger.
+func TestDrainOwnedMachines_MidDeletionStillCounts(t *testing.T) {
+	g := NewWithT(t)
+	scheme := newCleanupTestScheme(t)
+	kcp := newDrainKCP()
+
+	// Build a Machine that is mid-deletion: has DeletionTimestamp set and a
+	// foreign finalizer holding it. The fake client requires a finalizer to
+	// preserve DeletionTimestamp; otherwise it would GC immediately.
+	mid := newOwnedMachine("drain-kcp-mid", kcp)
+	mid.Finalizers = []string{"foreign-controller.example.com/wait"}
+	now := metav1.NewTime(time.Now())
+	mid.DeletionTimestamp = &now
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(kcp, mid).
+		Build()
+
+	remaining, err := drainOwnedMachines(context.Background(), c, kcp)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(remaining).To(Equal(1), "mid-deletion Machine must still count toward remaining so the KCP finalizer is held")
+
+	// And the Machine is still present (still holding the foreign finalizer).
+	got := &clusterv1.Machine{}
+	g.Expect(c.Get(context.Background(), client.ObjectKeyFromObject(mid), got)).To(Succeed())
+}

--- a/internal/controllers/controlplane/kairoscontrolplane_controller.go
+++ b/internal/controllers/controlplane/kairoscontrolplane_controller.go
@@ -19,6 +19,7 @@ package controlplane
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -42,6 +43,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -74,7 +76,18 @@ const controlPlaneLBServiceSuffix = "control-plane-lb"
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop
-func (r *KairosControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+//
+// Scope-limit: this PR (KD-14) introduces a deferred patch.Helper.Patch that
+// ONLY fires on the early-exit paths (no-Cluster, delete). The hot path
+// continues to issue r.Status().Update directly because it relies on
+// Update-not-Patch semantics for zero-valued status fields (see the
+// "Status().Update() vs Patch()" comment further down). Unifying the hot path
+// behind the patch helper is tracked as KD-37 and lands on
+// refactor/kcp-patch-helper-unify post-alpha-2.
+//
+// Named returns (result, retErr) are required so the deferred Patch closure
+// can combine its error into retErr via errors.Join.
+func (r *KairosControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	// Fetch the KairosControlPlane instance
@@ -86,17 +99,64 @@ func (r *KairosControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, err
 	}
 
+	// Initialize patch helper BEFORE any early returns so paths that don't run
+	// the hot-path r.Status().Update still flush observedGeneration and
+	// condition transitions. (KD-14.)
+	patchHelper, err := patch.NewHelper(kcp, r.Client)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Always set observedGeneration so even early-return paths reconcile it.
+	kcp.Status.ObservedGeneration = kcp.Generation
+
+	// patchOnExit controls whether the deferred Patch fires. It defaults to
+	// false because the hot path issues its own r.Status().Update and a
+	// follow-up Patch with a stale resourceVersion would conflict. Every
+	// early-exit path that wants the observedGeneration/condition changes
+	// persisted MUST set patchOnExit = true immediately before returning.
+	// The reconcileDelete path also sets this for its non-terminal returns;
+	// the terminal finalizer-remove step (added in the KD-4 commit) uses a
+	// bare r.Update and leaves patchOnExit false to avoid racing with the
+	// apiserver removing the object after the last finalizer drops.
+	patchOnExit := false
+	defer func() {
+		if !patchOnExit {
+			return
+		}
+		if perr := patchHelper.Patch(ctx, kcp); perr != nil {
+			retErr = errors.Join(retErr, perr)
+		}
+	}()
+
 	// Handle deletion
 	if !kcp.ObjectMeta.DeletionTimestamp.IsZero() {
 		return r.reconcileDelete(ctx, log, kcp)
 	}
 
-	// Add finalizer if needed
+	// Add finalizer if needed. Kept as a bare r.Update so this spec write is
+	// flushed independently of the deferred Patch (which only runs on early
+	// exits). After the bare Update we re-anchor the patch helper against
+	// the post-Update in-memory state, then re-apply the observedGeneration
+	// mutation so the deferred Patch on early-exit paths still produces a
+	// diff. Cleanup is part of KD-37.
 	if !controllerutil.ContainsFinalizer(kcp, controlplanev1beta2.KairosControlPlaneFinalizer) {
 		controllerutil.AddFinalizer(kcp, controlplanev1beta2.KairosControlPlaneFinalizer)
+		// Snapshot the desired status before the bare Update wipes our local
+		// observedGeneration mutation from the patch-helper diff base.
+		desiredObservedGeneration := kcp.Status.ObservedGeneration
 		if err := r.Update(ctx, kcp); err != nil {
 			return ctrl.Result{}, err
 		}
+		// r.Update rewrote kcp from the server response, clobbering our
+		// in-memory Status.ObservedGeneration. Re-create the patch helper
+		// against the fresh state, then re-set the field so the deferred
+		// Patch still flushes it on early-exit paths.
+		patchHelper, err = patch.NewHelper(kcp, r.Client)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		kcp.Status.ObservedGeneration = desiredObservedGeneration
 	}
 
 	// Find the owning Cluster
@@ -126,7 +186,9 @@ func (r *KairosControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 					return ctrl.Result{}, err
 				}
 				log.Info("Set cluster-name label on KairosControlPlane", "cluster", cluster.Name)
-				// Return to trigger a new reconcile with the label set
+				// Return to trigger a new reconcile with the label set.
+				// The r.Update above already persisted the spec change AND
+				// bumped resourceVersion; do NOT fire the deferred patch.
 				return ctrl.Result{Requeue: true}, nil
 			}
 		} else {
@@ -136,11 +198,10 @@ func (r *KairosControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 	if cluster == nil {
 		log.Info("Cluster is not available yet")
+		// Flush observedGeneration via the deferred Patch.
+		patchOnExit = true
 		return ctrl.Result{}, nil
 	}
-
-	// Always update observedGeneration
-	kcp.Status.ObservedGeneration = kcp.Generation
 
 	// Reconcile control plane machines
 	if err := r.reconcileMachines(ctx, log, kcp, cluster); err != nil {
@@ -155,6 +216,15 @@ func (r *KairosControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 		return ctrl.Result{}, nil
 	}
+
+	// reconcileMachines returned nil -- clear any latched failure status
+	// unconditionally. Maintainer-confirmed decision #3: gating on
+	// ReadyReplicas > 0 conflated "API server not ready yet" with "failure
+	// observed", forcing operators to manually clear failureReason/Message
+	// to unblock orchestration. API readiness is a v1beta2 condition
+	// concern, not a failure-fields concern. (KD-14.)
+	kcp.Status.FailureReason = ""
+	kcp.Status.FailureMessage = ""
 
 	// Track previous initialized state to detect transitions
 	wasInitialized := kcp.Status.Initialized
@@ -320,11 +390,9 @@ func (r *KairosControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		conditions.MarkFalse(kcp, controlplanev1beta2.AvailableCondition, controlplanev1beta2.WaitingForMachinesReason, clusterv1.ConditionSeverityInfo, "Waiting for control plane initialization")
 	}
 
-	// Clear failure fields if successful
-	if kcp.Status.ReadyReplicas > 0 {
-		kcp.Status.FailureReason = ""
-		kcp.Status.FailureMessage = ""
-	}
+	// Failure fields were cleared above immediately after reconcileMachines
+	// returned nil (KD-14, maintainer-confirmed decision #3). The previous
+	// `if ReadyReplicas > 0` gate at this location is intentionally removed.
 
 	// Use Status().Update() instead of Patch() to ensure all status fields are included
 	// This is important because Patch() with omitempty tags may omit zero values,

--- a/internal/controllers/controlplane/kairoscontrolplane_controller.go
+++ b/internal/controllers/controlplane/kairoscontrolplane_controller.go
@@ -2370,11 +2370,54 @@ func (r *KairosControlPlaneReconciler) triggerClusterReconciliation(ctx context.
 	return nil
 }
 
+// reconcileDelete drains the CAPI Machines owned by this KairosControlPlane
+// before removing the finalizer. Stripping the finalizer with live owned
+// Machines still attached causes the parent Cluster to disappear with
+// orphaned children, which is the failure mode that produced KD-4: the CAPI
+// machine.cluster.x-k8s.io finalizer never cleared because the Machine
+// controller could not find its parent Cluster, requiring a manual
+// `kubectl patch --type=json` to unblock.
+//
+// KairosConfig and the infrastructure Machine are NOT deleted directly --
+// they cascade via the CAPI Machine's OwnerReferences (KD-11 keeps the
+// Machine as the controller of both children). Deleting them here would
+// race with the CAPI Machine controller's own delete flow.
 func (r *KairosControlPlaneReconciler) reconcileDelete(ctx context.Context, log logr.Logger, kcp *controlplanev1beta2.KairosControlPlane) (ctrl.Result, error) {
-	// Remove finalizer
+	remaining, err := drainOwnedMachines(ctx, r.Client, kcp)
+	if err != nil {
+		log.Error(err, "Failed to drain owned Machines",
+			"kcp", kcp.Name, "namespace", kcp.Namespace, "uid", kcp.UID)
+		return ctrl.Result{}, err
+	}
+	if remaining > 0 {
+		log.Info("Waiting for owned Machines to be reaped before removing KCP finalizer",
+			"kcp", kcp.Name, "namespace", kcp.Namespace, "remaining", remaining)
+		return ctrl.Result{RequeueAfter: kcpDeleteRequeueAfter}, nil
+	}
+
+	// Terminal step: remove the finalizer with a bare r.Update. The patch
+	// helper is NOT used here -- once the last finalizer drops, the apiserver
+	// is free to garbage-collect the object, and a follow-up patch from the
+	// deferred closure in Reconcile would race that GC and surface as a
+	// 404. The patchOnExit guard in Reconcile is left at its default
+	// (false), so the deferred Patch is a no-op on this path.
+	// (KD-4, per maintainer-confirmed plan.)
 	controllerutil.RemoveFinalizer(kcp, controlplanev1beta2.KairosControlPlaneFinalizer)
-	return ctrl.Result{}, r.Update(ctx, kcp)
+	if err := r.Update(ctx, kcp); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Object already gone -- nothing to do.
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
 }
+
+// kcpDeleteRequeueAfter is the polling interval while waiting for owned
+// Machines to be reaped during reconcileDelete. Short enough to be
+// responsive, long enough to avoid hammering the apiserver while the CAPI
+// Machine controller does its work.
+const kcpDeleteRequeueAfter = 10 * time.Second
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *KairosControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/internal/controllers/controlplane/kairoscontrolplane_controller.go
+++ b/internal/controllers/controlplane/kairoscontrolplane_controller.go
@@ -115,9 +115,9 @@ func (r *KairosControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// follow-up Patch with a stale resourceVersion would conflict. Every
 	// early-exit path that wants the observedGeneration/condition changes
 	// persisted MUST set patchOnExit = true immediately before returning.
-	// The reconcileDelete path also sets this for its non-terminal returns;
-	// the terminal finalizer-remove step (added in the KD-4 commit) uses a
-	// bare r.Update and leaves patchOnExit false to avoid racing with the
+	// reconcileDelete signals via skipPatch=true when it has already issued
+	// a bare r.Update for the terminal finalizer-remove step; in that case
+	// the deferred Patch must be bypassed to avoid racing with the
 	// apiserver removing the object after the last finalizer drops.
 	patchOnExit := false
 	defer func() {
@@ -129,9 +129,16 @@ func (r *KairosControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 	}()
 
-	// Handle deletion
+	// Handle deletion. reconcileDelete signals via skipPatch=true when it
+	// has already finalized the object via a bare r.Update; otherwise the
+	// deferred Patch should flush observedGeneration/conditions on the
+	// non-terminal drain-requeue path.
 	if !kcp.ObjectMeta.DeletionTimestamp.IsZero() {
-		return r.reconcileDelete(ctx, log, kcp)
+		res, skipPatch, derr := r.reconcileDelete(ctx, log, kcp)
+		if !skipPatch {
+			patchOnExit = true
+		}
+		return res, derr
 	}
 
 	// Add finalizer if needed. Kept as a bare r.Update so this spec write is
@@ -2382,35 +2389,38 @@ func (r *KairosControlPlaneReconciler) triggerClusterReconciliation(ctx context.
 // they cascade via the CAPI Machine's OwnerReferences (KD-11 keeps the
 // Machine as the controller of both children). Deleting them here would
 // race with the CAPI Machine controller's own delete flow.
-func (r *KairosControlPlaneReconciler) reconcileDelete(ctx context.Context, log logr.Logger, kcp *controlplanev1beta2.KairosControlPlane) (ctrl.Result, error) {
+//
+// Returns (result, skipPatch, err). When skipPatch is true the caller MUST
+// bypass the deferred Patch -- this path has already finalized the object
+// via a bare r.Update and a follow-up Patch would race with apiserver GC.
+func (r *KairosControlPlaneReconciler) reconcileDelete(ctx context.Context, log logr.Logger, kcp *controlplanev1beta2.KairosControlPlane) (ctrl.Result, bool, error) {
 	remaining, err := drainOwnedMachines(ctx, r.Client, kcp)
 	if err != nil {
 		log.Error(err, "Failed to drain owned Machines",
 			"kcp", kcp.Name, "namespace", kcp.Namespace, "uid", kcp.UID)
-		return ctrl.Result{}, err
+		return ctrl.Result{}, false, err
 	}
 	if remaining > 0 {
 		log.Info("Waiting for owned Machines to be reaped before removing KCP finalizer",
 			"kcp", kcp.Name, "namespace", kcp.Namespace, "remaining", remaining)
-		return ctrl.Result{RequeueAfter: kcpDeleteRequeueAfter}, nil
+		// Non-terminal requeue: let the deferred Patch flush
+		// observedGeneration/conditions while we wait for the drain.
+		return ctrl.Result{RequeueAfter: kcpDeleteRequeueAfter}, false, nil
 	}
 
 	// Terminal step: remove the finalizer with a bare r.Update. The patch
-	// helper is NOT used here -- once the last finalizer drops, the apiserver
-	// is free to garbage-collect the object, and a follow-up patch from the
-	// deferred closure in Reconcile would race that GC and surface as a
-	// 404. The patchOnExit guard in Reconcile is left at its default
-	// (false), so the deferred Patch is a no-op on this path.
+	// helper is bypassed via skipPatch=true so the deferred closure in
+	// Reconcile does not race apiserver GC once the last finalizer drops.
 	// (KD-4, per maintainer-confirmed plan.)
 	controllerutil.RemoveFinalizer(kcp, controlplanev1beta2.KairosControlPlaneFinalizer)
 	if err := r.Update(ctx, kcp); err != nil {
 		if apierrors.IsNotFound(err) {
 			// Object already gone -- nothing to do.
-			return ctrl.Result{}, nil
+			return ctrl.Result{}, true, nil
 		}
-		return ctrl.Result{}, err
+		return ctrl.Result{}, true, err
 	}
-	return ctrl.Result{}, nil
+	return ctrl.Result{}, true, nil
 }
 
 // kcpDeleteRequeueAfter is the polling interval while waiting for owned

--- a/internal/controllers/controlplane/kairoscontrolplane_controller_test.go
+++ b/internal/controllers/controlplane/kairoscontrolplane_controller_test.go
@@ -28,7 +28,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -337,4 +339,154 @@ func TestGetNodeIP_KubevirtVMIFallback(t *testing.T) {
 	ip, err := reconciler.getNodeIP(context.Background(), log.Log, machine)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(ip).To(Equal("192.168.100.10"))
+}
+
+// newKCPTestScheme registers the schemes the KCP Reconcile flow depends on
+// for these unit tests.
+func newKCPTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	g := NewWithT(t)
+	scheme := runtime.NewScheme()
+	g.Expect(bootstrapv1beta2.AddToScheme(scheme)).To(Succeed())
+	g.Expect(controlplanev1beta2.AddToScheme(scheme)).To(Succeed())
+	g.Expect(clusterv1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	return scheme
+}
+
+// TestReconcile_NoClusterFlushesObservedGeneration verifies KD-14: when a KCP
+// has no associated Cluster yet (cluster-name label missing and no Cluster
+// references it via ControlPlaneRef), the deferred patch.Helper still flushes
+// observedGeneration. Prior to the fix the patch helper was created after the
+// no-cluster early-return and observedGeneration drifted permanently.
+func TestReconcile_NoClusterFlushesObservedGeneration(t *testing.T) {
+	g := NewWithT(t)
+	scheme := newKCPTestScheme(t)
+
+	kcp := &controlplanev1beta2.KairosControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "orphan-kcp",
+			Namespace:  "default",
+			Generation: 4,
+		},
+		Spec: controlplanev1beta2.KairosControlPlaneSpec{
+			Replicas: ptr.To(int32(1)),
+			Version:  "v1.30.0+k0s.0",
+			MachineTemplate: controlplanev1beta2.KairosControlPlaneMachineTemplate{
+				InfrastructureRef: corev1.ObjectReference{
+					APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+					Kind:       "DockerMachineTemplate",
+					Name:       "test-template",
+					Namespace:  "default",
+				},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(kcp).
+		WithStatusSubresource(&controlplanev1beta2.KairosControlPlane{}).
+		Build()
+	r := &KairosControlPlaneReconciler{Client: c, Scheme: scheme}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "orphan-kcp", Namespace: "default"}})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	got := &controlplanev1beta2.KairosControlPlane{}
+	g.Expect(c.Get(context.Background(), types.NamespacedName{Name: "orphan-kcp", Namespace: "default"}, got)).To(Succeed())
+	g.Expect(got.Status.ObservedGeneration).To(Equal(int64(4)))
+	// Finalizer should be added even though the Cluster wasn't found.
+	g.Expect(got.Finalizers).To(ContainElement(controlplanev1beta2.KairosControlPlaneFinalizer))
+}
+
+// TestReconcile_FailureFieldsClearedOnSuccess verifies KD-14 maintainer-
+// confirmed decision #3: when reconcileMachines returns nil, latched
+// FailureReason/FailureMessage are cleared unconditionally (no
+// ReadyReplicas > 0 gate). Prior to the fix a transient failure during
+// reconcileMachines would set FailureReason and a follow-up successful
+// reconcile would not clear it unless at least one machine became ready --
+// operators had to manually patch the status.
+func TestReconcile_FailureFieldsClearedOnSuccess(t *testing.T) {
+	g := NewWithT(t)
+	scheme := newKCPTestScheme(t)
+
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "recover-cluster",
+			Namespace: "default",
+		},
+		Spec: clusterv1.ClusterSpec{
+			ControlPlaneRef: &corev1.ObjectReference{
+				APIVersion: controlplanev1beta2.GroupVersion.String(),
+				Kind:       "KairosControlPlane",
+				Name:       "recover-kcp",
+				Namespace:  "default",
+			},
+		},
+	}
+	kcp := &controlplanev1beta2.KairosControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "recover-kcp",
+			Namespace:  "default",
+			Generation: 9,
+			Labels: map[string]string{
+				clusterv1.ClusterNameLabel: "recover-cluster",
+			},
+		},
+		Spec: controlplanev1beta2.KairosControlPlaneSpec{
+			Replicas: ptr.To(int32(1)),
+			Version:  "v1.30.0+k0s.0",
+			MachineTemplate: controlplanev1beta2.KairosControlPlaneMachineTemplate{
+				InfrastructureRef: corev1.ObjectReference{
+					APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+					Kind:       "DockerMachineTemplate",
+					Name:       "test-template",
+					Namespace:  "default",
+				},
+			},
+		},
+		Status: controlplanev1beta2.KairosControlPlaneStatus{
+			FailureReason:  controlplanev1beta2.ControlPlaneInitializationFailedReason,
+			FailureMessage: "transient: KairosConfigTemplate not found on first attempt",
+		},
+	}
+	// Pre-create a matching control-plane Machine so reconcileMachines is a no-op.
+	// Machine has no NodeRef -- ReadyReplicas stays 0. Under the OLD code path
+	// the FailureReason/FailureMessage gate (ReadyReplicas > 0) would keep
+	// failureReason latched; under the NEW code path it MUST be cleared.
+	machine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "recover-kcp-0",
+			Namespace: "default",
+			Labels: map[string]string{
+				clusterv1.ClusterNameLabel:         "recover-cluster",
+				clusterv1.MachineControlPlaneLabel: "",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(kcp, controlplanev1beta2.GroupVersion.WithKind("KairosControlPlane")),
+			},
+		},
+		Spec: clusterv1.MachineSpec{
+			ClusterName: "recover-cluster",
+			Version:     ptr.To("v1.30.0+k0s.0"),
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cluster, kcp, machine).
+		WithStatusSubresource(&controlplanev1beta2.KairosControlPlane{}, &clusterv1.Cluster{}).
+		Build()
+	r := &KairosControlPlaneReconciler{Client: c, Scheme: scheme}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "recover-kcp", Namespace: "default"}})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	got := &controlplanev1beta2.KairosControlPlane{}
+	g.Expect(c.Get(context.Background(), types.NamespacedName{Name: "recover-kcp", Namespace: "default"}, got)).To(Succeed())
+	g.Expect(got.Status.FailureReason).To(BeEmpty(), "FailureReason should be cleared on successful reconcileMachines, regardless of ReadyReplicas (KD-14)")
+	g.Expect(got.Status.FailureMessage).To(BeEmpty(), "FailureMessage should be cleared on successful reconcileMachines, regardless of ReadyReplicas (KD-14)")
+	g.Expect(got.Status.ReadyReplicas).To(Equal(int32(0)), "ReadyReplicas should still be 0 since the Machine has no NodeRef -- proving the clear is unconditional")
+	g.Expect(got.Status.ObservedGeneration).To(Equal(int64(9)))
 }

--- a/test/envtest/bootstrap_integration_test.go
+++ b/test/envtest/bootstrap_integration_test.go
@@ -208,3 +208,181 @@ func TestBootstrapIntegration(t *testing.T) {
 	g.Expect(cloudConfig).To(ContainSubstring("enabled: true"))
 	g.Expect(cloudConfig).To(ContainSubstring("--single"))
 }
+
+// TestBootstrapIntegration_LatchedFailureClearsOnRecovery verifies the KD-14
+// flow end-to-end against a real apiserver:
+//
+//  1. Create a KairosConfig with userPasswordSecretRef pointing at a
+//     non-existent Secret.
+//  2. Assert Status.FailureReason and Status.FailureMessage get set.
+//  3. Create the missing Secret.
+//  4. Assert FailureReason/FailureMessage get cleared on the next Reconcile.
+//
+// Prior to PR-2 the failure fields latched permanently and the CAPI Machine
+// controller refused to clone the infra Machine. The KCP-side companion
+// test for KD-4 + KD-14 lives in controlplane_integration_test.go.
+func TestBootstrapIntegration_LatchedFailureClearsOnRecovery(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	g := NewWithT(t)
+
+	// Setup envtest environment
+	crdPaths := []string{
+		"../../config/crd/bases",
+	}
+	if _, err := os.Stat("../../test/crd/capi/cluster-api-components.yaml"); err == nil {
+		crdPaths = append(crdPaths, "../../test/crd/capi")
+	}
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths:     crdPaths,
+		ErrorIfCRDPathMissing: false,
+	}
+	cfg, err := testEnv.Start()
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(cfg).NotTo(BeNil())
+	defer func() {
+		g.Expect(testEnv.Stop()).To(Succeed())
+	}()
+
+	scheme := runtime.NewScheme()
+	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(clusterv1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(bootstrapv1beta2.AddToScheme(scheme)).To(Succeed())
+
+	mgr, err := manager.New(cfg, manager.Options{Scheme: scheme, Logger: log.Log})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	reconciler := &bootstrap.KairosConfigReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}
+	g.Expect(reconciler.SetupWithManager(mgr)).To(Succeed())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mgrErrCh := make(chan error, 1)
+	go func() {
+		mgrErrCh <- mgr.Start(ctx)
+	}()
+
+	g.Eventually(func() bool {
+		return mgr.GetCache().WaitForCacheSync(ctx)
+	}, 10*time.Second).Should(BeTrue())
+
+	const (
+		nsName            = "kd14-recover"
+		clusterName       = "kd14-cluster"
+		machineName       = "kd14-machine"
+		kcName            = "kd14-kc"
+		missingSecretName = "kd14-user-password"
+	)
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
+	g.Expect(mgr.GetClient().Create(ctx, ns)).To(Succeed())
+
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: nsName},
+		Spec: clusterv1.ClusterSpec{
+			InfrastructureRef: &corev1.ObjectReference{
+				APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				Kind:       "DockerCluster",
+				Name:       clusterName,
+			},
+		},
+	}
+	g.Expect(mgr.GetClient().Create(ctx, cluster)).To(Succeed())
+
+	machine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      machineName,
+			Namespace: nsName,
+			Labels:    map[string]string{clusterv1.ClusterNameLabel: clusterName},
+		},
+		Spec: clusterv1.MachineSpec{
+			ClusterName: clusterName,
+			Bootstrap: clusterv1.Bootstrap{
+				ConfigRef: &corev1.ObjectReference{
+					APIVersion: bootstrapv1beta2.GroupVersion.String(),
+					Kind:       "KairosConfig",
+					Name:       kcName,
+					Namespace:  nsName,
+				},
+			},
+		},
+	}
+	g.Expect(mgr.GetClient().Create(ctx, machine)).To(Succeed())
+
+	// KairosConfig with a userPasswordSecretRef pointing at a Secret that
+	// does NOT exist yet. The controller's first reconcile will fail when
+	// resolveUserPassword tries to fetch the Secret and set the failure
+	// fields.
+	kc := &bootstrapv1beta2.KairosConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kcName,
+			Namespace: nsName,
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(machine, clusterv1.GroupVersion.WithKind("Machine")),
+			},
+		},
+		Spec: bootstrapv1beta2.KairosConfigSpec{
+			Role:              "control-plane",
+			Distribution:      "k0s",
+			KubernetesVersion: "v1.30.0+k0s.0",
+			SingleNode:        true,
+			UserName:          "kairos",
+			UserPasswordSecretRef: &bootstrapv1beta2.UserPasswordSecretReference{
+				Name: missingSecretName,
+			},
+			UserGroups: []string{"admin"},
+		},
+	}
+	g.Expect(mgr.GetClient().Create(ctx, kc)).To(Succeed())
+
+	// Assert FailureReason / FailureMessage get set.
+	g.Eventually(func() string {
+		got := &bootstrapv1beta2.KairosConfig{}
+		if err := mgr.GetClient().Get(ctx, types.NamespacedName{Name: kcName, Namespace: nsName}, got); err != nil {
+			return ""
+		}
+		return got.Status.FailureReason
+	}, 30*time.Second, 1*time.Second).ShouldNot(BeEmpty(), "FailureReason should be set after Secret-missing failure")
+
+	got := &bootstrapv1beta2.KairosConfig{}
+	g.Expect(mgr.GetClient().Get(ctx, types.NamespacedName{Name: kcName, Namespace: nsName}, got)).To(Succeed())
+	g.Expect(got.Status.FailureMessage).NotTo(BeEmpty(), "FailureMessage should be set alongside FailureReason")
+
+	// Create the missing Secret to unblock resolveUserPassword.
+	pwSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: missingSecretName, Namespace: nsName},
+		Data:       map[string][]byte{"password": []byte("hunter2")},
+	}
+	g.Expect(mgr.GetClient().Create(ctx, pwSecret)).To(Succeed())
+
+	// Assert FailureReason / FailureMessage get cleared on the next
+	// successful reconcile (KD-14). Bump the KairosConfig generation so the
+	// controller reconciles promptly rather than waiting for the next
+	// rate-limited requeue.
+	g.Expect(mgr.GetClient().Get(ctx, types.NamespacedName{Name: kcName, Namespace: nsName}, got)).To(Succeed())
+	if got.Annotations == nil {
+		got.Annotations = map[string]string{}
+	}
+	got.Annotations["kairos.io/kd14-poke"] = "1"
+	g.Expect(mgr.GetClient().Update(ctx, got)).To(Succeed())
+
+	g.Eventually(func() string {
+		got := &bootstrapv1beta2.KairosConfig{}
+		if err := mgr.GetClient().Get(ctx, types.NamespacedName{Name: kcName, Namespace: nsName}, got); err != nil {
+			return "(get error)"
+		}
+		return got.Status.FailureReason
+	}, 30*time.Second, 1*time.Second).Should(BeEmpty(), "FailureReason should be cleared after successful reconcile (KD-14)")
+
+	g.Expect(mgr.GetClient().Get(ctx, types.NamespacedName{Name: kcName, Namespace: nsName}, got)).To(Succeed())
+	g.Expect(got.Status.FailureMessage).To(BeEmpty(), "FailureMessage should be cleared alongside FailureReason")
+
+	cancel()
+	// Drain manager goroutine; ignore Canceled.
+	<-mgrErrCh
+}

--- a/test/envtest/controlplane_integration_test.go
+++ b/test/envtest/controlplane_integration_test.go
@@ -18,16 +18,19 @@ package envtest
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"os"
+	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -209,4 +212,313 @@ func TestControlPlaneIntegration(t *testing.T) {
 	// Note: Full Machine and KairosConfig creation testing requires infrastructure provider CRDs.
 	// The unit tests (TestCreateControlPlaneMachine_SingleNode) verify the SingleNode logic
 	// with mocked infrastructure. For full integration testing, use a real infrastructure provider.
+}
+
+// startKCPEnvtest spins up a fresh envtest + manager + KCP reconciler. Returns
+// a cancel-and-wait teardown closure. Each KD-4 delete-flow test sets up its
+// own envtest because envtest start/stop is slow but parallelization across
+// tests is unsafe (shared apiserver port).
+func startKCPEnvtest(t *testing.T) (context.Context, client.Client, func()) {
+	t.Helper()
+	g := NewWithT(t)
+
+	crdPaths := []string{"../../config/crd/bases"}
+	if _, err := os.Stat("../../test/crd/capi/cluster-api-components.yaml"); err == nil {
+		crdPaths = append(crdPaths, "../../test/crd/capi")
+	}
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths:     crdPaths,
+		ErrorIfCRDPathMissing: false,
+	}
+	cfg, err := testEnv.Start()
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(cfg).NotTo(BeNil())
+
+	scheme := runtime.NewScheme()
+	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(clusterv1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(bootstrapv1beta2.AddToScheme(scheme)).To(Succeed())
+	g.Expect(controlplanev1beta2.AddToScheme(scheme)).To(Succeed())
+
+	mgr, err := manager.New(cfg, manager.Options{Scheme: scheme, Logger: log.Log})
+	g.Expect(err).NotTo(HaveOccurred())
+
+	bootstrapReconciler := &bootstrap.KairosConfigReconciler{
+		Client: mgr.GetClient(), Scheme: mgr.GetScheme(),
+	}
+	g.Expect(bootstrapReconciler.SetupWithManager(mgr)).To(Succeed())
+
+	cpReconciler := &controlplane.KairosControlPlaneReconciler{
+		Client: mgr.GetClient(), Scheme: mgr.GetScheme(),
+	}
+	g.Expect(cpReconciler.SetupWithManager(mgr)).To(Succeed())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	mgrErrCh := make(chan error, 1)
+	go func() { mgrErrCh <- mgr.Start(ctx) }()
+
+	g.Eventually(func() bool {
+		return mgr.GetCache().WaitForCacheSync(ctx)
+	}, 10*time.Second).Should(BeTrue())
+
+	teardown := func() {
+		cancel()
+		<-mgrErrCh
+		g.Expect(testEnv.Stop()).To(Succeed())
+	}
+	return ctx, mgr.GetClient(), teardown
+}
+
+// TestControlPlaneIntegration_DeleteDrainsOwnedMachine verifies KD-4:
+//
+//  1. Create a Cluster, KCP, and a CAPI Machine owned by the KCP (controller
+//     OwnerReference) with the cluster-name label.
+//  2. Delete the KCP.
+//  3. Assert the Machine is deleted, the KCP finalizer is removed, and the
+//     KCP itself is reaped.
+//
+// Prior to the fix the KCP finalizer was removed immediately, leaving the
+// Machine without a parent KCP to coordinate its delete flow.
+func TestControlPlaneIntegration_DeleteDrainsOwnedMachine(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	g := NewWithT(t)
+	ctx, c, teardown := startKCPEnvtest(t)
+	defer teardown()
+
+	const (
+		nsName      = "kd4-drain"
+		clusterName = "kd4-drain-cluster"
+		kcpName     = "kd4-drain-kcp"
+		machineName = "kd4-drain-kcp-0"
+	)
+
+	g.Expect(c.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}})).To(Succeed())
+
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: nsName},
+		Spec: clusterv1.ClusterSpec{
+			ControlPlaneRef: &corev1.ObjectReference{
+				APIVersion: controlplanev1beta2.GroupVersion.String(),
+				Kind:       "KairosControlPlane",
+				Name:       kcpName,
+				Namespace:  nsName,
+			},
+		},
+	}
+	g.Expect(c.Create(ctx, cluster)).To(Succeed())
+
+	kcp := &controlplanev1beta2.KairosControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kcpName,
+			Namespace: nsName,
+			Labels:    map[string]string{clusterv1.ClusterNameLabel: clusterName},
+		},
+		Spec: controlplanev1beta2.KairosControlPlaneSpec{
+			Replicas: ptr.To(int32(1)),
+			Version:  "v1.30.0+k0s.0",
+			MachineTemplate: controlplanev1beta2.KairosControlPlaneMachineTemplate{
+				InfrastructureRef: corev1.ObjectReference{
+					APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+					Kind:       "DockerMachineTemplate",
+					Name:       "not-installed",
+					Namespace:  nsName,
+				},
+			},
+		},
+	}
+	g.Expect(c.Create(ctx, kcp)).To(Succeed())
+
+	// Wait for the controller to add the finalizer.
+	g.Eventually(func() bool {
+		got := &controlplanev1beta2.KairosControlPlane{}
+		if err := c.Get(ctx, types.NamespacedName{Name: kcpName, Namespace: nsName}, got); err != nil {
+			return false
+		}
+		for _, f := range got.Finalizers {
+			if f == controlplanev1beta2.KairosControlPlaneFinalizer {
+				return true
+			}
+		}
+		return false
+	}, 15*time.Second, 500*time.Millisecond).Should(BeTrue(), "KCP finalizer must be added before delete")
+
+	// Pre-create a Machine owned by this KCP. Match the labels and
+	// controller OwnerReference so drainOwnedMachines picks it up.
+	gotKCP := &controlplanev1beta2.KairosControlPlane{}
+	g.Expect(c.Get(ctx, types.NamespacedName{Name: kcpName, Namespace: nsName}, gotKCP)).To(Succeed())
+
+	machine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      machineName,
+			Namespace: nsName,
+			Labels: map[string]string{
+				clusterv1.ClusterNameLabel:         clusterName,
+				clusterv1.MachineControlPlaneLabel: "",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(gotKCP, controlplanev1beta2.GroupVersion.WithKind("KairosControlPlane")),
+			},
+		},
+		Spec: clusterv1.MachineSpec{
+			ClusterName: clusterName,
+			Version:     ptr.To("v1.30.0+k0s.0"),
+		},
+	}
+	g.Expect(c.Create(ctx, machine)).To(Succeed())
+
+	// Delete the KCP.
+	g.Expect(c.Delete(ctx, gotKCP)).To(Succeed())
+
+	// Eventually the owned Machine is deleted.
+	g.Eventually(func() bool {
+		got := &clusterv1.Machine{}
+		err := c.Get(ctx, types.NamespacedName{Name: machineName, Namespace: nsName}, got)
+		return apierrors.IsNotFound(err)
+	}, 30*time.Second, 1*time.Second).Should(BeTrue(), "owned Machine must be deleted before KCP finalizer is removed (KD-4)")
+
+	// And then the KCP itself is reaped.
+	g.Eventually(func() bool {
+		got := &controlplanev1beta2.KairosControlPlane{}
+		err := c.Get(ctx, types.NamespacedName{Name: kcpName, Namespace: nsName}, got)
+		return apierrors.IsNotFound(err)
+	}, 30*time.Second, 1*time.Second).Should(BeTrue(), "KCP must be reaped once its owned Machine is gone")
+}
+
+// TestControlPlaneIntegration_DeleteHeldByForeignFinalizerOnMachine verifies
+// KD-4 negative path: when an owned Machine has a foreign finalizer holding
+// it (so the Machine cannot be fully deleted), reconcileDelete must keep
+// requeuing and the KCP finalizer must stay attached. The KCP itself must
+// NOT disappear.
+//
+// This is the property that prevents the orphan-Cluster failure mode that
+// motivated KD-4: stripping the KCP finalizer prematurely leaves the parent
+// Cluster reapable while owned children still depend on it.
+func TestControlPlaneIntegration_DeleteHeldByForeignFinalizerOnMachine(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	g := NewWithT(t)
+	ctx, c, teardown := startKCPEnvtest(t)
+	defer teardown()
+
+	const (
+		nsName            = "kd4-held"
+		clusterName       = "kd4-held-cluster"
+		kcpName           = "kd4-held-kcp"
+		machineName       = "kd4-held-kcp-0"
+		foreignFinalizer  = "foreign-controller.example.com/wait"
+	)
+
+	g.Expect(c.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}})).To(Succeed())
+
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: nsName},
+		Spec: clusterv1.ClusterSpec{
+			ControlPlaneRef: &corev1.ObjectReference{
+				APIVersion: controlplanev1beta2.GroupVersion.String(),
+				Kind:       "KairosControlPlane",
+				Name:       kcpName,
+				Namespace:  nsName,
+			},
+		},
+	}
+	g.Expect(c.Create(ctx, cluster)).To(Succeed())
+
+	kcp := &controlplanev1beta2.KairosControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kcpName,
+			Namespace: nsName,
+			Labels:    map[string]string{clusterv1.ClusterNameLabel: clusterName},
+		},
+		Spec: controlplanev1beta2.KairosControlPlaneSpec{
+			Replicas: ptr.To(int32(1)),
+			Version:  "v1.30.0+k0s.0",
+			MachineTemplate: controlplanev1beta2.KairosControlPlaneMachineTemplate{
+				InfrastructureRef: corev1.ObjectReference{
+					APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+					Kind:       "DockerMachineTemplate",
+					Name:       "not-installed",
+					Namespace:  nsName,
+				},
+			},
+		},
+	}
+	g.Expect(c.Create(ctx, kcp)).To(Succeed())
+
+	g.Eventually(func() bool {
+		got := &controlplanev1beta2.KairosControlPlane{}
+		if err := c.Get(ctx, types.NamespacedName{Name: kcpName, Namespace: nsName}, got); err != nil {
+			return false
+		}
+		for _, f := range got.Finalizers {
+			if f == controlplanev1beta2.KairosControlPlaneFinalizer {
+				return true
+			}
+		}
+		return false
+	}, 15*time.Second, 500*time.Millisecond).Should(BeTrue())
+
+	gotKCP := &controlplanev1beta2.KairosControlPlane{}
+	g.Expect(c.Get(ctx, types.NamespacedName{Name: kcpName, Namespace: nsName}, gotKCP)).To(Succeed())
+
+	// Pre-create the Machine with a foreign finalizer. When the KCP delete
+	// flow issues Delete on this Machine the apiserver will mark its
+	// DeletionTimestamp but the finalizer prevents actual removal.
+	machine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      machineName,
+			Namespace: nsName,
+			Labels: map[string]string{
+				clusterv1.ClusterNameLabel:         clusterName,
+				clusterv1.MachineControlPlaneLabel: "",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(gotKCP, controlplanev1beta2.GroupVersion.WithKind("KairosControlPlane")),
+			},
+			Finalizers: []string{foreignFinalizer},
+		},
+		Spec: clusterv1.MachineSpec{
+			ClusterName: clusterName,
+			Version:     ptr.To("v1.30.0+k0s.0"),
+		},
+	}
+	g.Expect(c.Create(ctx, machine)).To(Succeed())
+
+	// Delete the KCP.
+	g.Expect(c.Delete(ctx, gotKCP)).To(Succeed())
+
+	// Give the controller time to attempt the delete drain a few times.
+	// The Machine must enter mid-deletion (DeletionTimestamp set) but stay
+	// present (foreign finalizer holding it).
+	g.Eventually(func() bool {
+		got := &clusterv1.Machine{}
+		if err := c.Get(ctx, types.NamespacedName{Name: machineName, Namespace: nsName}, got); err != nil {
+			return false
+		}
+		return !got.DeletionTimestamp.IsZero()
+	}, 30*time.Second, 1*time.Second).Should(BeTrue(), "Machine must be marked for deletion by drainOwnedMachines")
+
+	// Consistently: the KCP must NOT disappear while the Machine lingers.
+	// 8s is long enough for several reconciles at the 10s requeue
+	// interval to land without the test stalling CI.
+	g.Consistently(func() bool {
+		got := &controlplanev1beta2.KairosControlPlane{}
+		err := c.Get(ctx, types.NamespacedName{Name: kcpName, Namespace: nsName}, got)
+		return err == nil
+	}, 8*time.Second, 1*time.Second).Should(BeTrue(), "KCP must NOT be reaped while owned Machine has a foreign finalizer (KD-4 negative path)")
+
+	// Cleanup: drop the foreign finalizer so the Machine can be reaped and
+	// the KCP can finish its delete flow before teardown.
+	gotMachine := &clusterv1.Machine{}
+	g.Expect(c.Get(ctx, types.NamespacedName{Name: machineName, Namespace: nsName}, gotMachine)).To(Succeed())
+	gotMachine.Finalizers = nil
+	g.Expect(c.Update(ctx, gotMachine)).To(Succeed())
+
+	g.Eventually(func() bool {
+		got := &controlplanev1beta2.KairosControlPlane{}
+		err := c.Get(ctx, types.NamespacedName{Name: kcpName, Namespace: nsName}, got)
+		return apierrors.IsNotFound(err)
+	}, 30*time.Second, 1*time.Second).Should(BeTrue(), "KCP must be reaped once the foreign finalizer drops and the Machine is gone")
 }


### PR DESCRIPTION
## Summary

- Closes **KD-4**: both controllers now drain their owned children before removing their own finalizer, eliminating the orphan-Machine failure mode.
- Closes **KD-14**: both controllers now create the `patch.Helper` before any early returns and clear `failureReason` / `failureMessage` unconditionally on every successful reconcile, eliminating the latched-failure failure mode.
- Adds envtest integration cases that reproduce both bugs and confirm the fix.
- No CRD spec/status field added or removed. No CLI flags changed. No sample manifests changed. Behavioral change is desirable — existing operator workarounds are no longer needed.

## What this fixes

### KD-4 — Orphan Machine finalizers after cluster deletion

Reproduced during PR #49 lab validation: when a `Cluster` is deleted before its `Machine`'s delete flow completes, the CAPI core `machine.cluster.x-k8s.io` finalizer never clears because the Machine controller cannot find its parent Cluster. The KCP had already stripped its own finalizer, so nothing was left to coordinate the Machine's delete. The only recovery was:

```bash
kubectl patch <Machine> --type=json \
  -p='[{"op":"remove","path":"/metadata/finalizers"}]'
```

On the bootstrap side, the `KairosConfig` finalizer was similarly stripped without cleaning up the bootstrap Secret (which contains the rendered cloud-config including user passwords and tokens), leaving that Secret reachable until Kubernetes GC eventually reaped it — non-deterministic in envtest and under load.

### KD-14 — Latched failureReason/failureMessage blocks orchestration

Reproduced during PR #49 lab validation: when `spec.userPasswordSecretRef` points at a Secret that does not yet exist, the first reconcile sets `status.failureReason` and `status.failureMessage`. The CAPI Machine controller treats any non-empty `failureReason` as terminal and refuses to clone the infrastructure Machine. Even after the Secret was created, the failure fields were never cleared. Recovery required:

```bash
kubectl patch <KairosConfig> --subresource=status --type=merge \
  -p='{"status":{"failureReason":"","failureMessage":""}}'
```

## Implementation notes

Six commits, each independently reviewable:

1. `6592804` — Bootstrap controller: `patch.Helper` before early returns, `defer`-Patch with `patchOnExit` guard, clear failure fields on success. (`reconcileDelete` is left as a stub for commit 4.)
2. `3e72b13` — KCP controller: same `patch.Helper` + `patchOnExit` pattern. Lifts the `ReadyReplicas > 0` gate on failure-field clearing. Hot path retains `r.Status().Update` — the dual-write unification is **KD-37**, deferred to a post-alpha-2 cleanup branch.
3. `46d8fd7` — KCP controller: `reconcileDelete` now calls `drainOwnedMachines`, requeues while `remaining > 0`, then issues a bare `r.Update` for the terminal finalizer-remove step (bypassing the deferred patch to avoid a post-GC 404 race).
4. `6e89adf` — Bootstrap controller: `reconcileDelete` now calls `deleteBootstrapSecret`, requeues while not gone, then issues a bare `r.Update` for the terminal step. Wires the `skipPatch` signal from `reconcileDelete` back into the `patchOnExit` guard from commit 1.
5. `977f5b0` — envtest: `TestBootstrapIntegration_LatchedFailureClearsOnRecovery`, `TestControlPlaneIntegration_DeleteDrainsOwnedMachine`, `TestControlPlaneIntegration_DeleteHeldByForeignFinalizerOnMachine`.
6. `0b8a939` — Doc-comment cleanup on `failureReason`/`failureMessage` (no longer "permanent") + aligns KCP `reconcileDelete` signature with bootstrap's `(Result, skipPatch, error)` so `observedGeneration` flushes during a long drain.

**KD-37 scope-limit (maintainer-confirmed):** The KCP hot path still issues `r.Status().Update` directly. Mixing that with `patch.Helper` in the same `Reconcile` is a dual-write footgun. The unification is intentionally deferred to a `refactor/kcp-patch-helper-unify` branch after alpha-2 ships. See the KD-37 entry in the punch list (project-local) and the in-code comment on `Reconcile`.

## Validation

```
go vet ./...                                                       PASS
go build ./...                                                     PASS
go test -short ./internal/controllers/... ./api/...                PASS
make test-envtest                                                  PASS
```

Envtest run summary (local; CI envtest job still gated via KD-19):

```
TestBootstrapIntegration                                           PASS  ( 8.12s)
TestBootstrapIntegration_LatchedFailureClearsOnRecovery            PASS  ( 9.15s)
TestControlPlaneIntegration                                        PASS  ( 7.33s)
TestControlPlaneIntegration_DeleteDrainsOwnedMachine               PASS  ( 8.08s)
TestControlPlaneIntegration_DeleteHeldByForeignFinalizerOnMachine  PASS (17.85s)
```

## Out of scope

**KD-37**: The KCP hot path (`reconcileMachines` and the `r.Status().Update` calls following it) is not touched by this PR. The dual-write between `r.Status().Update` and `patch.Helper` is a known issue tracked separately for a post-alpha-2 cleanup branch.
