### PR TITLE
docs: catch-up docs, samples, READMEs after alpha-1 (post-#49, post-#50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This project provides two Cluster API (CAPI) providers for managing Kubernetes c
 
 **Latest release**: [`v0.1.0-alpha.1`](https://github.com/kairos-io/cluster-api-provider-kairos/releases/tag/v0.1.0-alpha.1) — initial alpha. Pre-release; API surface may change before v0.1.0.
 
-Supports single-node k0s and k3s clusters with CAPD, CAPV, and CAPK. HA control planes and additional infrastructure providers (Metal3, Tinkerbell, hyperscalers) are on the v0.1 roadmap.
+Supports single-node k0s and k3s clusters with CAPD, CAPV, and CAPK. `spec.replicas > 1` is currently webhook-rejected; HA control planes are on the roadmap (KD-5b / KD-25). Additional infrastructure providers (Metal3, Tinkerbell, hyperscalers) are also on the roadmap.
 
 Read the [v0.1.0-alpha.1 release notes](docs/release-notes/v0.1.0-alpha.1.md) before using — there are important security caveats and known limitations.
 
@@ -27,7 +27,11 @@ Read the [v0.1.0-alpha.1 release notes](docs/release-notes/v0.1.0-alpha.1.md) be
 kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-alpha.1/kairos-capi-provider.yaml
 ```
 
-The provider is currently distributed as a flat manifest installable via `kubectl apply -f`. [clusterctl](https://cluster-api.sigs.k8s.io/clusterctl/overview) integration is planned for a future release.
+The provider is distributed as a flat manifest installable via `kubectl apply -f`. [clusterctl](https://cluster-api.sigs.k8s.io/clusterctl/overview) integration is planned for a future release.
+
+## Credentials
+
+Provide node credentials via `userPasswordSecretRef` (recommended) or `sshPublicKey` / `githubUser`. The validating webhook rejects any `KairosConfig` that specifies no credential. Inline `userPassword` is accepted but discouraged — the value is stored in the resource spec and readable by anyone with access to KairosConfig objects.
 
 ## Target versions
 
@@ -35,7 +39,7 @@ The provider is currently distributed as a flat manifest installable via `kubect
 | --- | --- |
 | Kubernetes (workload) | bundled in your Kairos image (k3s/k0s, typically v1.30+) |
 | Kubernetes (management) | v1.30+ |
-| Cluster API | v1.8.x (v1.11.x tracking is on the roadmap) |
+| Cluster API | v1.8.x (v1.11.x tracking is on the roadmap, KD-13) |
 | Kairos | v3.6.0+ |
 | Distributions | k0s, k3s |
 
@@ -56,7 +60,9 @@ The provider is currently distributed as a flat manifest installable via `kubect
 ```bash
 git clone https://github.com/kairos-io/cluster-api-provider-kairos.git
 cd cluster-api-provider-kairos
-make test
+make test               # unit tests
+make test-envtest       # integration tests (envtest)
+make test-kubevirt      # end-to-end (requires Docker + kubevirt-env setup)
 ```
 
 See [docs/INSTALL.md](docs/INSTALL.md) for the developer install path (`make deploy` from source).

--- a/config/samples/bootstrap/kairosconfig.yaml
+++ b/config/samples/bootstrap/kairosconfig.yaml
@@ -1,3 +1,38 @@
+# ============================================================================
+# Bootstrap Samples: Standalone KairosConfig and KairosConfigTemplate examples
+# ============================================================================
+#
+# These are illustrative standalone resources. In practice, KairosConfig
+# objects are created by the KairosControlPlane controller (for control-plane
+# nodes) or by a MachineDeployment using a KairosConfigTemplate (for workers).
+#
+# PREREQUISITES:
+#   - Kairos CAPI provider installed (see docs/INSTALL.md)
+#   - Secret 'kairos-user-password' created in the same namespace:
+#       kubectl create secret generic kairos-user-password \
+#         --from-literal=password=$(openssl rand -base64 32)
+#
+# NOTE: This sample is intentionally incomplete — it omits Cluster, infra, and
+# MachineDeployment resources. Combine with a provider-specific sample from
+# config/samples/capd/, config/samples/capk/, or config/samples/capv/.
+#
+# ============================================================================
+
+# Secret providing the node user password.
+# IMPORTANT: replace the placeholder with a strong value before applying.
+# `openssl rand -base64 32` is suitable. Do not commit real passwords.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kairos-user-password
+  namespace: default
+type: Opaque
+stringData:
+  password: REPLACE_WITH_A_STRONG_PASSWORD
+---
+# Control-plane KairosConfig example.
+# In a real cluster this object is created by the KairosControlPlane controller;
+# you would set these fields on the KairosConfigTemplate instead.
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KairosConfig
 metadata:
@@ -6,13 +41,27 @@ metadata:
 spec:
   role: control-plane
   distribution: k0s
-  kubernetesVersion: "v1.30.0+k0s.0"
+  # Pin a version your Kairos image bundles; the value is informational
+  # (KD-24 makes this advisory in alpha-2).
+  kubernetesVersion: "v1.34.1+k0s.1"
+  userName: kairos
+  # Password comes from a Secret. Inline userPassword is discouraged —
+  # it is stored in the resource and visible to anyone with read access.
+  userPasswordSecretRef:
+    name: kairos-user-password
+  userGroups:
+    - admin
+  # preCommands and postCommands are reserved for future use and are not
+  # yet rendered into the cloud-config.
   preCommands:
-    - echo "Pre-install commands"
+    - echo "Pre-install placeholder"
   postCommands:
-    - echo "Post-install commands"
+    - echo "Post-install placeholder"
 
 ---
+# Worker KairosConfig example.
+# For k0s workers, set workerTokenSecretRef with the join token from the
+# control-plane node.
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KairosConfig
 metadata:
@@ -21,14 +70,22 @@ metadata:
 spec:
   role: worker
   distribution: k0s
-  kubernetesVersion: "v1.30.0+k0s.0"
+  # Pin a version your Kairos image bundles (informational; see KD-24).
+  kubernetesVersion: "v1.34.1+k0s.1"
   serverAddress: "https://control-plane.example.com:6443"
+  userName: kairos
+  userPasswordSecretRef:
+    name: kairos-user-password
+  userGroups:
+    - admin
   workerTokenSecretRef:
     name: k0s-token
     key: token
     namespace: default
 
 ---
+# Worker KairosConfigTemplate example.
+# Referenced by a MachineDeployment to produce per-Machine KairosConfig objects.
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KairosConfigTemplate
 metadata:
@@ -39,8 +96,13 @@ spec:
     spec:
       role: worker
       distribution: k0s
-      kubernetesVersion: "v1.30.0+k0s.0"
+      # Pin a version your Kairos image bundles (informational; see KD-24).
+      kubernetesVersion: "v1.34.1+k0s.1"
+      userName: kairos
+      userPasswordSecretRef:
+        name: kairos-user-password
+      userGroups:
+        - admin
       workerTokenSecretRef:
         name: k0s-token
         key: token
-

--- a/config/samples/capd/kairos_cluster_k0s_single_node.yaml
+++ b/config/samples/capd/kairos_cluster_k0s_single_node.yaml
@@ -40,6 +40,8 @@ metadata:
   namespace: default
 spec:
   replicas: 1
+  # Pin a version your Kairos image bundles; the value is informational
+  # (KD-24 makes this advisory in alpha-2).
   version: "v1.30.0+k0s.0"
   machineTemplate:
     infrastructureRef:
@@ -73,6 +75,8 @@ spec:
     spec:
       role: control-plane
       distribution: k0s
+      # Pin a version your Kairos image bundles; the value is informational
+      # (KD-24 makes this advisory in alpha-2).
       kubernetesVersion: "v1.30.0+k0s.0"
       userName: kairos
       # Password comes from a Secret (defined at the top of this file).

--- a/config/samples/capd/kairos_cluster_k0s_with_workers.yaml
+++ b/config/samples/capd/kairos_cluster_k0s_with_workers.yaml
@@ -41,6 +41,8 @@ metadata:
   namespace: default
 spec:
   replicas: 1
+  # Pin a version your Kairos image bundles; the value is informational
+  # (KD-24 makes this advisory in alpha-2).
   version: "v1.30.0+k0s.0"
   machineTemplate:
     infrastructureRef:

--- a/config/samples/capk/kairos-install-disk.yaml
+++ b/config/samples/capk/kairos-install-disk.yaml
@@ -1,3 +1,18 @@
+# Blank install-target DataVolume for the Kairos 2-disk installer pattern.
+#
+# Apply this BEFORE the cluster manifest:
+#   kubectl apply -f config/samples/capk/kairos-install-disk.yaml
+#
+# The Kairos image DataVolumes (kairos-rootdisk, kairos-k3s-rootdisk) are
+# live-installer images that boot to a live shell. This blank disk is the
+# actual installation target — the cloud-config's install.device points at
+# /dev/vda (the virtio disk backed by this DV).
+#
+# storageClassName: choose one that exists on your cluster.
+# - kubevirt-env default: local-path (set by local-path-provisioner)
+# - Longhorn environments: uncomment the longhorn line below
+# - Leave blank to use the cluster's default StorageClass
+#
 apiVersion: cdi.kubevirt.io/v1beta1
 kind: DataVolume
 metadata:
@@ -11,4 +26,5 @@ spec:
     resources:
       requests:
         storage: 40Gi
-    storageClassName: longhorn
+    # storageClassName: longhorn
+    # storageClassName: local-path

--- a/config/samples/capk/kubevirt_cluster_k0s_single_node.yaml
+++ b/config/samples/capk/kubevirt_cluster_k0s_single_node.yaml
@@ -4,17 +4,22 @@
 #
 # SETUP INSTRUCTIONS:
 #
-# 1. Run ./bin/kubevirt-env (see docs/QUICKSTART_CAPK.md) — creates the env and uploads the Kairos image to CDI.
+# 1. Run ./bin/kubevirt-env (see docs/QUICKSTART_CAPK.md) — creates the env and
+#    uploads the Kairos image to CDI. Non-lab users: skip kubevirt-env and apply
+#    the manifests directly against your own management cluster.
+#
+# 1.5. Apply the blank install-target DataVolume BEFORE the cluster manifest:
+#    kubectl apply -f config/samples/capk/kairos-install-disk.yaml
+#    (Kairos image DVs are live-installer images. The blank disk is the
+#    actual install target for the OS. See docs/QUICKSTART_CAPK.md.)
 #
 # 2. Update the KubeVirtMachineTemplate below:
 #    - Adjust CPU/memory/disk sizes
-#    - nodeSelector and DataVolume names are environment-specific; customize for your cluster
-#    - If using a cloud disk image, set the rootdisk DataVolume name to that image
-#    - If using an ISO, set installeriso to the ISO DataVolume and
-#      create a blank install disk DataVolume (kairos-install-disk)
+#    - nodeSelector is environment-specific; see note in the template below
+#    - DataVolume names reference the Kairos image DV and the blank install disk
 #
 # 3. Apply the manifest:
-#    - kubectl apply -f config/samples/capk/kubevirt_cluster_k0s_single_node.yaml
+#    kubectl apply -f config/samples/capk/kubevirt_cluster_k0s_single_node.yaml
 #
 # ============================================================================
 
@@ -90,9 +95,11 @@ spec:
               labels:
                 kubevirt.io/domain: kairos-control-plane-template
             spec:
-              # Schedule on a node with KVM. Customize for your environment (e.g., remove or set to your node name).
-              nodeSelector:
-                kubernetes.io/hostname: grogu
+              # Schedule on a KVM-capable node. Remove this selector entirely if
+              # all nodes support KVM, or replace the hostname value with one
+              # that matches a KVM-capable node in your cluster.
+              # nodeSelector:
+              #   kubernetes.io/hostname: YOUR-KVM-NODE-HOSTNAME
               domain:
                 cpu:
                   cores: 8

--- a/config/samples/capk/kubevirt_cluster_k3s_single_node.yaml
+++ b/config/samples/capk/kubevirt_cluster_k3s_single_node.yaml
@@ -4,17 +4,22 @@
 #
 # SETUP INSTRUCTIONS:
 #
-# 1. Run ./bin/kubevirt-env (see docs/QUICKSTART_CAPK.md) — creates the env and uploads the Kairos image to CDI.
+# 1. Run ./bin/kubevirt-env (see docs/QUICKSTART_CAPK.md) — creates the env and
+#    uploads the Kairos image to CDI. Non-lab users: skip kubevirt-env and apply
+#    the manifests directly against your own management cluster.
+#
+# 1.5. Apply the blank install-target DataVolume BEFORE the cluster manifest:
+#    kubectl apply -f config/samples/capk/kairos-install-disk.yaml
+#    (Kairos image DVs are live-installer images. The blank disk is the
+#    actual install target for the OS. See docs/QUICKSTART_CAPK.md.)
 #
 # 2. Update the KubeVirtMachineTemplate below:
 #    - Adjust CPU/memory/disk sizes
-#    - nodeSelector and DataVolume names are environment-specific; customize for your cluster
-#    - If using a cloud disk image, set the rootdisk DataVolume name to that image
-#    - If using an ISO, set installeriso to the ISO DataVolume and
-#      create a blank install disk DataVolume (kairos-install-disk)
+#    - nodeSelector is environment-specific; see note in the template below
+#    - DataVolume names reference the Kairos image DV and the blank install disk
 #
 # 3. Apply the manifest:
-#    - kubectl apply -f config/samples/capk/kubevirt_cluster_k3s_single_node.yaml
+#    kubectl apply -f config/samples/capk/kubevirt_cluster_k3s_single_node.yaml
 #
 # ============================================================================
 
@@ -67,7 +72,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: "v1.30.0+k3s.0"
+  version: "v1.33.5+k3s1"
   distribution: k3s
   machineTemplate:
     infrastructureRef:
@@ -97,9 +102,11 @@ spec:
               labels:
                 kubevirt.io/domain: kairos-control-plane-template
             spec:
-              # Schedule on a node with KVM. Customize for your environment (e.g., remove or set to your node name).
-              nodeSelector:
-                kubernetes.io/hostname: grogu
+              # Schedule on a KVM-capable node. Remove this selector entirely if
+              # all nodes support KVM, or replace the hostname value with one
+              # that matches a KVM-capable node in your cluster.
+              # nodeSelector:
+              #   kubernetes.io/hostname: YOUR-KVM-NODE-HOSTNAME
               domain:
                 cpu:
                   cores: 8
@@ -156,7 +163,7 @@ spec:
     spec:
       role: control-plane
       distribution: k3s
-      kubernetesVersion: "v1.30.0+k3s.0"
+      kubernetesVersion: "v1.33.5+k3s1"
       install:
         auto: true
         device: "/dev/vda"
@@ -205,7 +212,7 @@ spec:
         cluster.x-k8s.io/cluster-name: kairos-cluster-kv
         cluster.x-k8s.io/deployment-name: kairos-workers
     spec:
-      version: "v1.30.0+k3s.0"
+      version: "v1.33.5+k3s1"
       bootstrap:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
@@ -232,9 +239,11 @@ spec:
               labels:
                 kubevirt.io/domain: kairos-worker-template
             spec:
-              # Schedule on a node with KVM. Customize for your environment.
-              nodeSelector:
-                kubernetes.io/hostname: grogu
+              # Schedule on a KVM-capable node. Remove this selector entirely if
+              # all nodes support KVM, or replace the hostname value with one
+              # that matches a KVM-capable node in your cluster.
+              # nodeSelector:
+              #   kubernetes.io/hostname: YOUR-KVM-NODE-HOSTNAME
               domain:
                 cpu:
                   cores: 4
@@ -285,7 +294,7 @@ spec:
     spec:
       role: worker
       distribution: k3s
-      kubernetesVersion: "v1.30.0+k3s.0"
+      kubernetesVersion: "v1.33.5+k3s1"
       k3sTokenSecretRef:
         name: kairos-k3s-worker-token
         key: token

--- a/config/samples/capv/kairos_cluster_k0s_single_node.yaml
+++ b/config/samples/capv/kairos_cluster_k0s_single_node.yaml
@@ -56,7 +56,7 @@ spec:
   # IMPORTANT: Use only the hostname or IP address, NOT a URL with protocol/path
   # Correct: "vcenter.example.com" or "172.16.56.10"
   # Wrong: "https://vcenter.example.com" or "https://172.16.56.10/sdk"
-  server: "vcsa.lab.k8"
+  server: "TODO-YOUR-VCENTER-HOSTNAME"
   
   # Optional: SSL thumbprint for vCenter certificate validation
   # thumbprint: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
@@ -83,7 +83,8 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: "v1.30.0+k0s.0"
+  # Pin a version your Kairos image bundles (informational; see KD-24).
+  version: "v1.34.1+k0s.1"
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -94,6 +95,7 @@ spec:
     name: kairos-config-template-control-plane
     # Note: namespace is NOT specified here - it defaults to the same namespace as KairosControlPlane
 ---
+# Uncomment and customize for your vSphere environment.
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereMachineTemplate
 metadata:
@@ -126,7 +128,8 @@ spec:
     spec:
       role: control-plane
       distribution: k0s
-      kubernetesVersion: "v1.30.0+k0s.0"
+      # Pin a version your Kairos image bundles (informational; see KD-24).
+      kubernetesVersion: "v1.34.1+k0s.1"
       userName: kairos
       # Password comes from a Secret (defined at the top of this file).
       # Alternative: set `sshPublicKey:` and omit `userPasswordSecretRef`.
@@ -141,6 +144,7 @@ spec:
 ---
 # ============================================================================
 # VSphere Credentials Setup (REQUIRED - apply this BEFORE the cluster manifest)
+# See Step 1 in the SETUP INSTRUCTIONS at the top of this file.
 # ============================================================================
 # 
 # Step 1: Create a Secret with your vSphere credentials

--- a/config/samples/capv/kairos_cluster_k3s_single_node.yaml
+++ b/config/samples/capv/kairos_cluster_k3s_single_node.yaml
@@ -61,7 +61,7 @@ spec:
   # IMPORTANT: Use only the hostname or IP address, NOT a URL with protocol/path
   # Correct: "vcenter.example.com" or "172.16.56.10"
   # Wrong: "https://vcenter.example.com" or "https://172.16.56.10/sdk"
-  server: "vcsa.lab.k8"
+  server: "TODO-YOUR-VCENTER-HOSTNAME"
   
   # Optional: SSL thumbprint for vCenter certificate validation
   # thumbprint: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD"
@@ -88,7 +88,8 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: "v1.30.0+k3s.0"
+  # Pin a version your Kairos image bundles (informational; see KD-24).
+  version: "v1.35.0+k3s1"
   distribution: k3s
   machineTemplate:
     infrastructureRef:
@@ -100,6 +101,7 @@ spec:
     name: kairos-config-template-control-plane
     # Note: namespace is NOT specified here - it defaults to the same namespace as KairosControlPlane
 ---
+# Uncomment and customize for your vSphere environment.
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereMachineTemplate
 metadata:
@@ -132,7 +134,8 @@ spec:
     spec:
       role: control-plane
       distribution: k3s
-      kubernetesVersion: "v1.30.0+k3s.0"
+      # Pin a version your Kairos image bundles (informational; see KD-24).
+      kubernetesVersion: "v1.35.0+k3s1"
       install:
         auto: true
         device: "auto"
@@ -178,7 +181,7 @@ spec:
         cluster.x-k8s.io/cluster-name: kairos-cluster
         cluster.x-k8s.io/deployment-name: kairos-workers
     spec:
-      version: "v1.30.0+k3s.0"
+      version: "v1.35.0+k3s1"
       bootstrap:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
@@ -221,7 +224,8 @@ spec:
     spec:
       role: worker
       distribution: k3s
-      kubernetesVersion: "v1.30.0+k3s.0"
+      # Pin a version your Kairos image bundles (informational; see KD-24).
+      kubernetesVersion: "v1.35.0+k3s1"
       k3sTokenSecretRef:
         name: kairos-k3s-worker-token
         key: token

--- a/config/samples/controlplane/kairoscontrolplane.yaml
+++ b/config/samples/controlplane/kairoscontrolplane.yaml
@@ -1,12 +1,51 @@
+# ============================================================================
+# Control Plane Sample: KairosControlPlane + KairosConfigTemplate
+# ============================================================================
+#
+# INTENTIONALLY INCOMPLETE: this sample shows the KairosControlPlane and its
+# companion KairosConfigTemplate in isolation. The infrastructureRef below
+# points at a VSphereMachineTemplate that is not defined in this file.
+# To deploy a real cluster, combine this with the matching CAPV sample:
+#   config/samples/capv/kairos_cluster_k0s_single_node.yaml
+#
+# PREREQUISITES:
+#   - Kairos CAPI provider installed (see docs/INSTALL.md)
+#   - CAPV (or substitute infra provider) installed and configured
+#   - Secret 'kairos-user-password' created in the same namespace:
+#       kubectl create secret generic kairos-user-password \
+#         --from-literal=password=$(openssl rand -base64 32)
+#   - A VSphereMachineTemplate named 'control-plane-template' in namespace
+#     'default' (see config/samples/capv/kairos_cluster_k0s_single_node.yaml)
+#
+# ============================================================================
+
+# Secret providing the node user password.
+# IMPORTANT: replace the placeholder with a strong value before applying.
+# `openssl rand -base64 32` is suitable. Do not commit real passwords.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kairos-user-password
+  namespace: default
+type: Opaque
+stringData:
+  password: REPLACE_WITH_A_STRONG_PASSWORD
+---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: KairosControlPlane
 metadata:
   name: kairos-control-plane
   namespace: default
 spec:
+  # Only replicas: 1 is supported. The webhook rejects values > 1.
+  # HA control planes are on the roadmap (KD-5b / KD-25).
   replicas: 1
-  version: "v1.30.0+k0s.0"
+  # Pin a version your Kairos image bundles (informational; see KD-24).
+  version: "v1.34.1+k0s.1"
   machineTemplate:
+    # infrastructureRef must point at a VSphereMachineTemplate (or substitute)
+    # that exists in the same namespace. See the CAPV sample for a complete
+    # definition.
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: VSphereMachineTemplate
@@ -17,7 +56,7 @@ spec:
         cluster.x-k8s.io/control-plane: ""
   kairosConfigTemplate:
     name: kairos-config-template-control-plane
-    # Note: namespace defaults to the same namespace as KairosControlPlane
+    # namespace defaults to the same namespace as KairosControlPlane
 
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
@@ -30,5 +69,12 @@ spec:
     spec:
       role: control-plane
       distribution: k0s
-      kubernetesVersion: "v1.30.0+k0s.0"
-
+      # Pin a version your Kairos image bundles (informational; see KD-24).
+      kubernetesVersion: "v1.34.1+k0s.1"
+      userName: kairos
+      # Password comes from a Secret. Inline userPassword is discouraged —
+      # it is stored in the resource and visible to anyone with read access.
+      userPasswordSecretRef:
+        name: kairos-user-password
+      userGroups:
+        - admin

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,5 +1,7 @@
 # API Reference
 
+Last verified against: Kairos v3.6.0+, CAPI v1.8.x (go.mod), provider release v0.1.0-alpha.1 / v0.1.0-alpha.2.
+
 This document provides a reference for all Custom Resource Definitions (CRDs) provided by the Kairos CAPI Provider. See [Install guide](INSTALL.md) for development install. Quickstarts: [CAPD](QUICKSTART_CAPD.md), [CAPV](QUICKSTART_CAPV.md), [CAPK](QUICKSTART_CAPK.md).
 
 ## Table of Contents
@@ -8,13 +10,14 @@ This document provides a reference for all Custom Resource Definitions (CRDs) pr
 - [KairosConfigTemplate](#kairosconfigtemplate)
 - [KairosControlPlane](#kairoscontrolplane)
 - [KairosControlPlaneTemplate](#kairoscontrolplanetemplate)
+- [Notes](#notes)
 
 ---
 
 ## KairosConfig
 
-**API Group:** `bootstrap.cluster.x-k8s.io`  
-**API Version:** `v1beta2`  
+**API Group:** `bootstrap.cluster.x-k8s.io`
+**API Version:** `v1beta2`
 **Kind:** `KairosConfig`
 
 `KairosConfig` is a BootstrapConfig resource that generates Kairos cloud-config for bootstrapping Kubernetes nodes (control-plane or worker) using k0s or k3s.
@@ -23,54 +26,107 @@ This document provides a reference for all Custom Resource Definitions (CRDs) pr
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `role` | `string` | Yes | `"worker"` | Node role: `"control-plane"` or `"worker"` |
-| `distribution` | `string` | No | `"k0s"` | Kubernetes distribution: `"k0s"` or `"k3s"` |
-| `kubernetesVersion` | `string` | Yes | - | Kubernetes version to install (e.g., `"v1.30.0+k0s.0"` or `"v1.30.0+k3s.0"`) |
-| `singleNode` | `bool` | No | `false` | For control-plane: if `true`, configures k0s with `--single` flag for single-node mode |
-| `userName` | `string` | No | `"kairos"` | Username for the default user |
-| `userPassword` | `string` | No | `"kairos"` | Password for the default user. Change for non-dev use. |
-| `userGroups` | `[]string` | No | `["admin"]` | Groups for the default user |
-| `githubUser` | `string` | No | - | GitHub username for SSH key access (fetches keys from GitHub) |
-| `sshPublicKey` | `string` | No | - | Raw SSH public key (alternative to `githubUser`) |
-| `workerToken` | `string` | No* | - | Inline worker join token (k0s). *Required for k0s workers if `workerTokenSecretRef` is not set |
-| `workerTokenSecretRef` | `WorkerTokenSecretReference` | No* | - | Reference to Secret containing worker token (k0s). *Required for k0s workers if `workerToken` is not set. Prefer this over inline token for security |
-| `k3sToken` | `string` | No* | - | Inline k3s join token. *Required for k3s workers if `k3sTokenSecretRef` is not set |
-| `k3sTokenSecretRef` | `WorkerTokenSecretReference` | No* | - | Reference to Secret containing k3s join token. *Required for k3s workers if `k3sToken` is not set. Prefer this over inline token for security |
-| `manifests` | `[]Manifest` | No | - | Kubernetes manifests to deploy. k0s: `/var/lib/k0s/manifests/{name}/`. k3s: `/var/lib/rancher/k3s/server/manifests/{name}/` |
-| `preCommands` | `[]string` | No | - | Commands to run before k0s/k3s installation. Reserved for future use; not yet rendered in cloud-config |
-| `postCommands` | `[]string` | No | - | Commands to run after k0s/k3s installation. Reserved for future use; not yet rendered in cloud-config |
-| `pause` | `bool` | No | `false` | If `true`, pauses reconciliation |
+| `role` | `string` | Yes | `"worker"` | Node role: `"control-plane"` or `"worker"`. |
+| `distribution` | `string` | No | `"k0s"` | Kubernetes distribution: `"k0s"` or `"k3s"`. |
+| `kubernetesVersion` | `string` | Yes | — | Kubernetes version string (e.g., `"v1.34.1+k0s.1"`). The value is informational — the actual version is pinned in the Kairos image at build time and cannot be changed by this field. See KD-24. |
+| `singleNode` | `bool` | No | `false` | Signals single-node mode to the cloud-config renderer. For k0s, this adds `--single`; for k3s, it enables cluster-init mode. The KairosControlPlane controller derives this from `replicas==1`, so manual overrides are typically unnecessary. Applies to both k0s and k3s distributions. Tracked as a deprecation candidate in KD-39. |
+| `userName` | `string` | No | `"kairos"` | Username for the default OS user. |
+| `userPassword` | `string` | No | — | Password for the default OS user, specified inline. Inline values are stored in the resource and visible to anyone with read access to KairosConfig objects. Prefer `userPasswordSecretRef`. At least one of `userPassword`, `userPasswordSecretRef`, `sshPublicKey`, or `githubUser` must be set; the validating webhook enforces this. If both `userPassword` and `userPasswordSecretRef` are set, `userPasswordSecretRef` takes precedence. |
+| `userPasswordSecretRef` | `UserPasswordSecretReference` | No | — | Reference to a Secret containing the OS user password. The Secret must have a key matching `userPasswordSecretRef.key` (default: `"password"`). Preferred over inline `userPassword`. |
+| `userGroups` | `[]string` | No | `["admin"]` | Groups for the default OS user. |
+| `githubUser` | `string` | No | — | GitHub username for SSH key access. The Kairos image fetches the user's public keys from `https://github.com/<githubUser>.keys` at boot. |
+| `sshPublicKey` | `string` | No | — | Raw SSH public key (alternative to `githubUser`). |
+| `serverAddress` | `string` | No | — | Kubernetes API server address for worker nodes to join (e.g., `"https://10.0.0.1:6443"`). |
+| `token` | `string` | No | — | Generic join token for worker nodes (inline). Prefer `tokenSecretRef`. |
+| `tokenSecretRef` | `ObjectReference` | No | — | Reference to a Secret containing a generic join token. |
+| `workerToken` | `string` | No | — | k0s worker join token, inline. Prefer `workerTokenSecretRef`. If both are set, `workerTokenSecretRef` takes precedence. |
+| `workerTokenSecretRef` | `WorkerTokenSecretReference` | No | — | Reference to a Secret containing the k0s worker join token. Required for k0s workers; prefer this over inline `workerToken`. |
+| `k3sToken` | `string` | No | — | k3s join token, inline. Prefer `k3sTokenSecretRef`. If both are set, `k3sTokenSecretRef` takes precedence. |
+| `k3sTokenSecretRef` | `WorkerTokenSecretReference` | No | — | Reference to a Secret containing the k3s join token. Required for k3s workers; prefer this over inline `k3sToken`. |
+| `caCertHashes` | `[]string` | No | — | CA certificate hashes for secure node join. |
+| `caCertSecretRef` | `ObjectReference` | No | — | Reference to a Secret containing the CA certificate. |
+| `hostname` | `string` | No | — | Hostname to set on the node inside the VM. Takes precedence over `hostnamePrefix` when both are set. |
+| `hostnamePrefix` | `string` | No | `"metal-"` | Prefix for the auto-generated hostname. The final hostname is `{hostnamePrefix}{4-char-machine-id}`. |
+| `dnsServers` | `[]string` | No | — | DNS resolvers configured for early boot, before cluster DNS is ready (useful for pulling CNI images). |
+| `podCIDR` | `string` | No | — | Pod network CIDR for k0s. Uses k0s defaults when unset. |
+| `serviceCIDR` | `string` | No | — | Service network CIDR for k0s. Uses k0s defaults when unset. |
+| `primaryIP` | `string` | No | — | Overrides the detected node IP used for TLS certificate SANs and endpoint configuration (sets `KAIROS_PRIMARY_IP`). Useful in KubeVirt environments where the detected IP is a pod network address rather than the VM's accessible address. |
+| `install` | `InstallConfig` | No | — | Controls Kairos OS installation to disk. Required when using the 2-disk installer pattern (see `config/samples/capk/`). |
+| `files` | `[]File` | No | — | Additional files to write in the cloud-config. |
+| `manifests` | `[]Manifest` | No | — | Kubernetes manifests placed in the distribution's auto-apply directory. k0s: `/var/lib/k0s/manifests/{name}/{file}`. k3s: `/var/lib/rancher/k3s/server/manifests/{name}/{file}`. Applied automatically by the distribution at cluster startup. |
+| `preCommands` | `[]string` | No | — | Reserved; not yet rendered into the cloud-config. |
+| `postCommands` | `[]string` | No | — | Reserved; not yet rendered into the cloud-config. |
+| `pause` | `bool` | No | `false` | When `true`, pauses reconciliation of this KairosConfig. |
+
+#### UserPasswordSecretReference
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | `string` | Yes | — | Name of the Secret. |
+| `key` | `string` | No | `"password"` | Key within the Secret that contains the password. |
+| `namespace` | `string` | No | Same as KairosConfig | Namespace of the Secret. |
 
 #### WorkerTokenSecretReference
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `name` | `string` | Yes | - | Name of the Secret |
-| `key` | `string` | No | `"token"` | Key within the Secret containing the token |
-| `namespace` | `string` | No | Same as KairosConfig | Namespace of the Secret |
+| `name` | `string` | Yes | — | Name of the Secret. |
+| `key` | `string` | No | `"token"` | Key within the Secret containing the token. |
+| `namespace` | `string` | No | Same as KairosConfig | Namespace of the Secret. |
+
+#### InstallConfig
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `auto` | `*bool` | No | `true` | When `true`, Kairos installs to disk automatically at first boot. |
+| `device` | `string` | No | `"auto"` | Target device for installation (e.g., `"/dev/vda"`). `"auto"` selects the first available disk. |
+| `reboot` | `*bool` | No | `true` | When `true`, the system reboots automatically after installation completes. |
+
+#### File
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `path` | `string` | Yes | Absolute path where the file is written on the node. |
+| `content` | `string` | Yes | File content. |
+| `permissions` | `string` | No | Octal permission string (e.g., `"0644"`). |
+| `owner` | `string` | No | Owner in `user:group` format (e.g., `"root:root"`). |
 
 #### Manifest
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `name` | `string` | Yes | Directory name. k0s: `/var/lib/k0s/manifests/{name}/{file}`. k3s: `/var/lib/rancher/k3s/server/manifests/{name}/{file}` |
-| `file` | `string` | Yes | Filename within the directory |
-| `content` | `string` | Yes | YAML content of the manifest |
+| `name` | `string` | Yes | Directory name under the distribution's manifest path. |
+| `file` | `string` | Yes | Filename within the directory. |
+| `content` | `string` | Yes | YAML content of the manifest. |
 
 ### Status Fields
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `ready` | `bool` | Indicates bootstrap data has been generated and is ready |
-| `dataSecretName` | `string` | Name of the Secret containing bootstrap data (cloud-config) |
-| `conditions` | `[]Condition` | Standard CAPI conditions: `Ready`, `BootstrapReady`, `DataSecretAvailable` |
-| `observedGeneration` | `int64` | Most recent generation observed by the controller |
-| `failureReason` | `string` | Reason for bootstrap failure (if any) |
-| `failureMessage` | `string` | Human-readable failure message (if any) |
+| `ready` | `bool` | `true` when bootstrap data has been generated and the bootstrap Secret is available for the CAPI Machine controller. |
+| `dataSecretName` | `*string` | Name of the Secret containing the bootstrap cloud-config. |
+| `initialization.dataSecretCreated` | `bool` | v1beta2 contract field: `true` when the bootstrap Secret has been created. |
+| `conditions` | `[]Condition` | Standard CAPI conditions: `Ready`, `BootstrapReady`, `DataSecretAvailable`. |
+| `observedGeneration` | `int64` | Most recent generation observed by the controller. |
+| `failureReason` | `string` | Short machine-readable string indicating the last failure reason. Cleared automatically when the next reconcile succeeds — a non-empty value indicates an ongoing failure, not a terminal one. |
+| `failureMessage` | `string` | Human-readable description of the last failure. Cleared automatically on the next successful reconcile. If non-empty, check the owning Machine's events for context. |
 
 ### Example
 
 ```yaml
+# Secret referenced by userPasswordSecretRef below.
+# Create before applying the KairosConfig:
+#   kubectl create secret generic kairos-user-password \
+#     --from-literal=password=$(openssl rand -base64 32)
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kairos-user-password
+  namespace: default
+type: Opaque
+stringData:
+  password: REPLACE_WITH_A_STRONG_PASSWORD
+---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KairosConfig
 metadata:
@@ -79,16 +135,16 @@ metadata:
 spec:
   role: control-plane
   distribution: k0s
-  kubernetesVersion: "v1.30.0+k0s.0"
+  kubernetesVersion: "v1.34.1+k0s.1"
   singleNode: true
   userName: kairos
-  userPassword: kairos
+  userPasswordSecretRef:
+    name: kairos-user-password
   userGroups:
     - admin
-  githubUser: "octocat"
 ```
 
-For k3s workers, use `k3sTokenSecretRef` (or `k3sToken`):
+For k3s workers, use `k3sTokenSecretRef`:
 
 ```yaml
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
@@ -99,7 +155,9 @@ metadata:
 spec:
   role: worker
   distribution: k3s
-  kubernetesVersion: "v1.30.0+k3s.0"
+  kubernetesVersion: "v1.35.0+k3s1"
+  userPasswordSecretRef:
+    name: kairos-user-password
   k3sTokenSecretRef:
     name: k3s-worker-token
     key: token
@@ -109,8 +167,8 @@ spec:
 
 ## KairosConfigTemplate
 
-**API Group:** `bootstrap.cluster.x-k8s.io`  
-**API Version:** `v1beta2`  
+**API Group:** `bootstrap.cluster.x-k8s.io`
+**API Version:** `v1beta2`
 **Kind:** `KairosConfigTemplate`
 
 `KairosConfigTemplate` is a template for creating `KairosConfig` resources. Used by `MachineDeployment` and `KairosControlPlane` to create per-machine bootstrap configurations.
@@ -119,14 +177,14 @@ spec:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `template` | `KairosConfigTemplateResource` | Yes | Template for creating `KairosConfig` resources |
+| `template` | `KairosConfigTemplateResource` | Yes | Template for creating `KairosConfig` resources. |
 
 #### KairosConfigTemplateResource
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `metadata` | `ObjectMeta` | No | Metadata to apply to created `KairosConfig` resources |
-| `spec` | `KairosConfigSpec` | Yes | Spec to apply to created `KairosConfig` resources (see [KairosConfig Spec](#spec-fields)) |
+| `metadata` | `ObjectMeta` | No | Metadata to apply to created `KairosConfig` resources. |
+| `spec` | `KairosConfigSpec` | Yes | Spec applied to created `KairosConfig` resources. See [KairosConfig Spec](#spec-fields). |
 
 ### Example
 
@@ -141,7 +199,9 @@ spec:
     spec:
       role: worker
       distribution: k0s
-      kubernetesVersion: "v1.30.0+k0s.0"
+      kubernetesVersion: "v1.34.1+k0s.1"
+      userPasswordSecretRef:
+        name: kairos-user-password
       workerTokenSecretRef:
         name: worker-token
         key: token
@@ -151,67 +211,69 @@ spec:
 
 ## KairosControlPlane
 
-**API Group:** `controlplane.cluster.x-k8s.io`  
-**API Version:** `v1beta2`  
+**API Group:** `controlplane.cluster.x-k8s.io`
+**API Version:** `v1beta2`
 **Kind:** `KairosControlPlane`
 
-`KairosControlPlane` manages the control plane machines for a Kubernetes cluster using Kairos and k0s.
+`KairosControlPlane` manages the control plane machines for a Kubernetes cluster running on Kairos OS with k0s or k3s.
 
 ### Spec Fields
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `replicas` | `*int32` | No | `1` | Number of control plane machines. Must be >= 1. When `replicas == 1`, single-node mode is enabled |
-| `version` | `string` | Yes | - | Kubernetes version (e.g., `"v1.30.0+k0s.0"`) |
-| `machineTemplate` | `KairosControlPlaneMachineTemplate` | Yes | - | Template for creating control plane machines |
-| `kairosConfigTemplate` | `KairosConfigTemplateReference` | Yes | - | Reference to `KairosConfigTemplate` for bootstrap configuration |
-| `rolloutStrategy` | `RolloutStrategy` | No | - | Strategy for rolling out updates (optional) |
+| `replicas` | `*int32` | No | `1` | Number of control plane machines. Must be exactly `1`. The validating webhook rejects values greater than 1 — the current bootstrap logic would otherwise produce N independent single-node clusters. HA control planes are tracked for a future release (KD-5b / KD-25). |
+| `version` | `string` | Yes | — | Kubernetes version string (e.g., `"v1.34.1+k0s.1"`). Informational; the actual k8s version is pinned in the Kairos image. |
+| `distribution` | `string` | No | `"k0s"` | Kubernetes distribution for this control plane: `"k0s"` or `"k3s"`. |
+| `machineTemplate` | `KairosControlPlaneMachineTemplate` | Yes | — | Template for creating control plane Machines. |
+| `kairosConfigTemplate` | `KairosConfigTemplateReference` | Yes | — | Reference to a `KairosConfigTemplate` that provides the bootstrap configuration for each Machine. |
+| `rolloutStrategy` | `RolloutStrategy` | No | — | Strategy for rolling out updates. |
 
 #### KairosControlPlaneMachineTemplate
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `infrastructureRef` | `ObjectReference` | Yes | Reference to infrastructure template (e.g., `DockerMachineTemplate`, `VSphereMachineTemplate`) |
-| `nodeDrainTimeout` | `Duration` | No | Timeout for draining nodes during updates |
-| `metadata` | `ObjectMeta` | No | Metadata to apply to created machines |
+| `infrastructureRef` | `ObjectReference` | Yes | Reference to the infrastructure template (e.g., `DockerMachineTemplate`, `VSphereMachineTemplate`, `KubevirtMachineTemplate`). |
+| `nodeDrainTimeout` | `Duration` | No | Timeout for draining nodes during updates. |
+| `metadata` | `ObjectMeta` | No | Metadata to apply to created Machines. |
 
 #### KairosConfigTemplateReference
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `name` | `string` | Yes | Name of the `KairosConfigTemplate` |
-| `apiVersion` | `string` | No | API version (defaults to `bootstrap.cluster.x-k8s.io/v1beta2`) |
-| `kind` | `string` | No | Kind (defaults to `KairosConfigTemplate`) |
+| `name` | `string` | Yes | Name of the `KairosConfigTemplate`. |
+| `apiVersion` | `string` | No | API version (defaults to `bootstrap.cluster.x-k8s.io/v1beta2`). |
+| `kind` | `string` | No | Kind (defaults to `KairosConfigTemplate`). |
 
-**Note:** The `namespace` field is not part of this reference. The namespace defaults to the same namespace as the `KairosControlPlane` resource.
+The `namespace` field is not part of this reference. The namespace defaults to the same namespace as the `KairosControlPlane`.
 
 #### RolloutStrategy
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `type` | `string` | No | `"RollingUpdate"` | Strategy type (currently only `"RollingUpdate"` supported) |
-| `rollingUpdate` | `RollingUpdate` | No | - | Rolling update configuration |
+| `type` | `string` | No | `"RollingUpdate"` | Strategy type. Currently only `"RollingUpdate"` is accepted. |
+| `rollingUpdate` | `RollingUpdate` | No | — | Rolling update configuration. |
 
 #### RollingUpdate
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `maxSurge` | `*int32` | No | Maximum number of machines that can be created above desired count |
+| `maxSurge` | `*int32` | No | Maximum number of machines that can be created above the desired count during a rollout. |
 
 ### Status Fields
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `initialized` | `bool` | Indicates the control plane has been initialized (first machine ready) |
-| `readyReplicas` | `int32` | Number of control plane machines that are ready |
-| `replicas` | `int32` | Total number of control plane machines |
-| `updatedReplicas` | `int32` | Number of machines with desired version |
-| `unavailableReplicas` | `int32` | Number of unavailable machines |
-| `conditions` | `[]Condition` | Standard CAPI conditions: `Ready`, `Available`, `Initialized` |
-| `observedGeneration` | `int64` | Most recent generation observed by the controller |
-| `failureReason` | `string` | Reason for control plane failure (if any) |
-| `failureMessage` | `string` | Human-readable failure message (if any) |
-| `selector` | `string` | Label selector for control plane machines |
+| `initialized` | `bool` | `true` when the first control plane Machine is ready and the control plane is functional. |
+| `initialization.controlPlaneInitialized` | `*bool` | v1beta2 contract field. `true` when the control plane has been initialized and can accept requests. |
+| `readyReplicas` | `int32` | Number of control plane Machines that are ready. |
+| `replicas` | `int32` | Total number of control plane Machines across all states. |
+| `updatedReplicas` | `int32` | Number of Machines running the desired version. |
+| `unavailableReplicas` | `int32` | Number of Machines that are unavailable (not ready or being deleted). |
+| `conditions` | `[]Condition` | Standard CAPI conditions: `Ready`, `Available`, `Initialized`. |
+| `observedGeneration` | `int64` | Most recent generation observed by the controller. |
+| `failureReason` | `string` | Short machine-readable failure indicator. Cleared automatically when the next reconcile succeeds — a non-empty value indicates an ongoing failure, not a terminal one. |
+| `failureMessage` | `string` | Human-readable failure description. Cleared automatically on the next successful reconcile. If non-empty, check KairosControlPlane events and owned Machine events for context. |
+| `selector` | `string` | Label selector string identifying control plane Machines. |
 
 ### Example
 
@@ -223,7 +285,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
-  version: "v1.30.0+k0s.0"
+  version: "v1.34.1+k0s.1"
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -237,24 +299,24 @@ spec:
 
 ## KairosControlPlaneTemplate
 
-**API Group:** `controlplane.cluster.x-k8s.io`  
-**API Version:** `v1beta2`  
+**API Group:** `controlplane.cluster.x-k8s.io`
+**API Version:** `v1beta2`
 **Kind:** `KairosControlPlaneTemplate`
 
-`KairosControlPlaneTemplate` is a template for creating `KairosControlPlane` resources. Used by ClusterClass (planned).
+`KairosControlPlaneTemplate` is a template for creating `KairosControlPlane` resources. Intended for use with ClusterClass (planned; not yet exercised in samples).
 
 ### Spec Fields
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `template` | `KairosControlPlaneTemplateResource` | Yes | Template for creating `KairosControlPlane` resources |
+| `template` | `KairosControlPlaneTemplateResource` | Yes | Template for creating `KairosControlPlane` resources. |
 
 #### KairosControlPlaneTemplateResource
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `metadata` | `ObjectMeta` | No | Metadata to apply to created `KairosControlPlane` resources |
-| `spec` | `KairosControlPlaneSpec` | Yes | Spec to apply to created `KairosControlPlane` resources (see [KairosControlPlane Spec](#spec-fields)) |
+| `metadata` | `ObjectMeta` | No | Metadata to apply to created `KairosControlPlane` resources. |
+| `spec` | `KairosControlPlaneSpec` | Yes | Spec applied to created `KairosControlPlane` resources. See [KairosControlPlane Spec](#spec-fields-1). |
 
 ---
 
@@ -262,25 +324,38 @@ spec:
 
 ### API Version Compatibility
 
-- **Kairos CAPI Provider APIs**: Use `v1beta2` (`bootstrap.cluster.x-k8s.io/v1beta2`, `controlplane.cluster.x-k8s.io/v1beta2`)
-- **CAPI Core Types**: Currently use `v1beta1` (`cluster.x-k8s.io/v1beta1`) as `v1beta2` is not yet available in the CAPI Go module
-- **Infrastructure Providers**: Use their respective API versions (e.g., CAPD/CAPV use `infrastructure.cluster.x-k8s.io/v1beta1`)
+- **Kairos CAPI Provider APIs**: `bootstrap.cluster.x-k8s.io/v1beta2` and `controlplane.cluster.x-k8s.io/v1beta2`.
+- **CAPI Core Types**: The wire API version for `Cluster`, `Machine`, and related resources is `v1beta2` (`cluster.x-k8s.io/v1beta2`). However, the Go module currently imports `sigs.k8s.io/cluster-api/api/v1beta1` because the go.mod pins CAPI v1.8.0 which predates the v1beta2 Go package. Bumping to CAPI v1.11 is tracked as KD-13. This is a compile-time import detail; the CRD API group and version on the wire are not affected.
+- **Infrastructure Providers**: Use their respective API versions (e.g., CAPD/CAPV use `infrastructure.cluster.x-k8s.io/v1beta1`, CAPK uses `infrastructure.cluster.x-k8s.io/v1alpha1`).
+
+### Credential Requirements
+
+At least one of the following must be set on every `KairosConfig` (enforced by the validating webhook):
+
+- `userPassword` (inline; not recommended outside lab use)
+- `userPasswordSecretRef` (recommended)
+- `sshPublicKey`
+- `githubUser`
 
 ### Worker Token Requirements
 
 For `KairosConfig` with `role: worker`:
-- **k0s**: Either `workerToken` or `workerTokenSecretRef` must be set.
-- **k3s**: Either `k3sToken` or `k3sTokenSecretRef` must be set (or `workerToken`/`workerTokenSecretRef` as fallback).
 
-The controller will fail reconciliation if no token is provided.
+- **k0s**: Set `workerToken` or `workerTokenSecretRef`. `workerTokenSecretRef` is preferred.
+- **k3s**: Set `k3sToken` or `k3sTokenSecretRef`. `k3sTokenSecretRef` is preferred.
+
+The controller fails reconciliation if no token is provided for a worker.
 
 ### Single-Node Mode
 
-When `KairosControlPlane.spec.replicas == 1`, the controller automatically sets `KairosConfig.spec.singleNode = true` for control plane machines, which configures k0s with the `--single` flag.
+When `KairosControlPlane.spec.replicas == 1`, the controller automatically sets `KairosConfig.spec.singleNode = true` on the created control-plane Machine's config. For k0s this adds the `--single` flag; for k3s it enables single-node cluster-init mode. The `singleNode` field applies to both distributions. Setting it manually on a `KairosConfigTemplate` is unnecessary when managed by `KairosControlPlane`.
+
+### Multi-Node Control Planes
+
+`KairosControlPlane.spec.replicas > 1` is currently rejected by the validating webhook. HA control planes are tracked for a future release (KD-5b / KD-25). Do not attempt to work around the webhook — setting replicas to 1 is the correct configuration for all current deployments.
 
 ### Security Considerations
 
-- **User Password**: Change the default `userPassword` for non-dev use
-- **Worker Tokens**: Prefer `workerTokenSecretRef` over inline `workerToken` for better security
-- **SSH Access**: Use `githubUser` or `sshPublicKey` instead of password-based access when possible
-
+- Provide credentials via `userPasswordSecretRef` (recommended) or `sshPublicKey` / `githubUser`. Inline `userPassword` is stored in the KairosConfig spec and readable by anyone who can `kubectl get kairosconfig`.
+- Worker tokens should use the `*SecretRef` variants. Inline tokens in specs are readable without Secret RBAC.
+- All Secrets referenced by `*SecretRef` fields must exist in the management cluster before the KairosConfig is reconciled. Missing Secrets cause a transient failure that clears automatically when the Secret is created.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,5 +1,7 @@
 # Install Guide
 
+Last verified against: CAPI v1.8.x, cert-manager v1.15+, provider v0.1.0-alpha.2.
+
 Two install paths: the released artifact (recommended for users) and a developer install from source.
 
 ## Path 1 — Released artifact (`kubectl apply`)
@@ -9,16 +11,20 @@ Use this if you want to consume a tagged release.
 ### Prerequisites
 
 1. A Kubernetes cluster acting as the management cluster (kind, EKS, GKE, AKS, etc.).
-2. **cert-manager v1.15+** installed:
+2. **cert-manager v1.15+** installed. Verify it is present before continuing:
+   ```bash
+   kubectl get crd certificates.cert-manager.io
+   ```
+   If not installed:
    ```bash
    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.15.2/cert-manager.yaml
    kubectl wait --for=condition=Available --timeout=2m -n cert-manager deploy/cert-manager-webhook
    ```
 3. **Cluster API core** installed. Easiest path:
    ```bash
-   clusterctl init --infrastructure docker   # or vsphere, kubevirt, …
+   kubectl apply -f https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.8.0/cluster-api-components.yaml
    ```
-   `clusterctl init` installs Cluster API core as a side effect of installing the infrastructure provider.
+   Or use `clusterctl init --infrastructure docker` (or vsphere, kubevirt, ...) if you already have clusterctl configured — `clusterctl init` installs Cluster API core as a side effect of installing the infrastructure provider.
 4. `kubectl` configured to use the management cluster.
 
 ### Install
@@ -49,17 +55,25 @@ Expected: one Deployment `kairos-capi-controller-manager` in `kairos-capi-system
 kubectl delete -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-alpha.1/kairos-capi-provider.yaml
 ```
 
-> **Note**: the provider's `reconcileDelete` does not yet clean up child resources (KairosConfig, owned secrets, InfraMachines) when a managed `Cluster` is deleted. Manually clean up any clusters created with this release before uninstalling the provider.
+**Re-install note**: if you are re-installing across a name-prefix change or a previous failed install, stale `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration` objects from the previous install may point at a webhook Service that no longer exists. Delete them before re-installing:
+
+```bash
+kubectl get mutatingwebhookconfigurations | grep kairos
+kubectl get validatingwebhookconfigurations | grep kairos
+# Delete any stale entries before re-applying
+kubectl delete mutatingwebhookconfiguration <stale-name>
+kubectl delete validatingwebhookconfiguration <stale-name>
+```
 
 ---
 
 ## Path 2 — Developer install (from source)
 
-Use this if you're hacking on the provider itself.
+Use this if you are hacking on the provider itself.
 
 ### Prerequisites
 
-- Go 1.26+ toolchain.
+- Go toolchain 1.26.3 (matches `go.mod` directive `go 1.26.0` / toolchain `go1.26.0`).
 - A Kubernetes cluster acting as the management cluster.
 - cert-manager and Cluster API core installed (same as Path 1).
 - `kubectl` configured to use the management cluster.
@@ -78,12 +92,14 @@ This installs CRDs, RBAC, webhooks, and the controller to the `kairos-capi-syste
 IMG=MY_REGISTRY/cluster-api-provider-kairos:dev make deploy
 ```
 
+**CRD installation note**: `make deploy` uses `kustomize build config/crd | kubectl apply -f -`, which applies kustomize-managed labels that CAPI's conversion webhook expects (`cluster.x-k8s.io/v1beta1`, `cluster.x-k8s.io/v1beta2`). If you apply raw CRD YAML via `kubectl apply -f config/crd/bases/`, those labels are absent and CAPI core may reject the CRDs. Use `make deploy` or `bin/kustomize build config/crd | kubectl apply -f -`.
+
 ### Run the controller on your host (optional)
 
 To run the controller on your host instead of deploying to the cluster:
 
 ```bash
-make install     # installs only the CRDs
+make install     # installs only the CRDs via kustomize
 make run         # runs the controller in the foreground against your kubeconfig
 ```
 

--- a/docs/QUICKSTART_CAPD.md
+++ b/docs/QUICKSTART_CAPD.md
@@ -1,15 +1,19 @@
 # Quick Start Guide - CAPD (Docker)
 
+Last verified against: Kairos v3.6.0+, CAPI v1.8.x, provider v0.1.0-alpha.2.
+
 This guide walks you through creating a single-node k0s cluster on Kairos using Cluster API with the Docker provider (CAPD).
 
-**Note:** The CAPD sample provided uses k0s. For k3s clusters, use [CAPV](QUICKSTART_CAPV.md) or [CAPK](QUICKSTART_CAPK.md).
+**Note:** The CAPD sample uses k0s. For k3s clusters, use [CAPV](QUICKSTART_CAPV.md) or [CAPK](QUICKSTART_CAPK.md).
+
+**Note:** CAPD is a development-only infrastructure provider. Docker-based Kairos clusters do not represent a production topology.
 
 ## Prerequisites
 
-1. **Management Cluster**: A Kubernetes cluster (kind, minikube, or any Kubernetes cluster)
-2. **Cluster API**: CAPI v1.11+ installed
-3. **CAPD**: Cluster API Provider Docker installed
-4. **Kairos CAPI Provider**: Installed via make (see [Install guide](INSTALL.md))
+1. **Management Cluster**: A Kubernetes cluster (kind, minikube, or any Kubernetes cluster).
+2. **Cluster API**: CAPI v1.8.x installed. v1.11.x is on the roadmap (KD-13).
+3. **CAPD**: Cluster API Provider Docker installed.
+4. **Kairos CAPI Provider**: Installed (see [Install guide](INSTALL.md)).
 
 ### Installing Prerequisites
 
@@ -19,33 +23,44 @@ Install CAPI and CAPD using your preferred method. See the [Cluster API book](ht
 
 #### 2. Install Kairos CAPI Provider
 
+**Recommended (released artifact):**
+
+```bash
+kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-alpha.1/kairos-capi-provider.yaml
+```
+
+**Developer install (from source):**
+
 ```bash
 make docker-build
 make deploy
 ```
 
-See [INSTALL.md](INSTALL.md) for full install steps.
+See [INSTALL.md](INSTALL.md) for the full developer install process, including the kustomize-CRD note for re-installs.
 
 ## Creating a Cluster
 
-### Step 1: Review the Sample Manifest
+### Step 1: Create the user-password Secret
 
-The sample manifest is located at `config/samples/capd/kairos_cluster_k0s_single_node.yaml`.
+```bash
+kubectl create secret generic kairos-user-password \
+  --from-literal=password=$(openssl rand -base64 32)
+```
+
+The sample manifest references this Secret via `userPasswordSecretRef`. Do not use `userPassword` inline for anything beyond throwaway local testing.
+
+### Step 2: Review the Sample Manifest
+
+The sample manifest is at `config/samples/capd/kairos_cluster_k0s_single_node.yaml`.
 
 Key components:
-- `Cluster` - References DockerCluster and KairosControlPlane
-- `DockerCluster` - Infrastructure cluster for Docker
-- `KairosControlPlane` - Control plane with replicas=1 (single-node)
-- `DockerMachineTemplate` - Template for Docker machines
-- `KairosConfigTemplate` - Bootstrap configuration template
 
-### Step 2: Customize the Manifest (Optional)
-
-Edit `config/samples/capd/kairos_cluster_k0s_single_node.yaml`:
-
-- Update `spec.version` in `KairosControlPlane` to your desired k0s version
-- Add `githubUser` or `sshPublicKey` in `KairosConfigTemplate` for SSH access
-- Change `userName`/`userPassword` if needed (default: kairos/kairos)
+- `Secret` — user password (referenced by `userPasswordSecretRef` in KairosConfigTemplate).
+- `Cluster` — references `DockerCluster` and `KairosControlPlane`.
+- `DockerCluster` — Docker infrastructure cluster.
+- `KairosControlPlane` — control plane with `replicas: 1` (single-node only; HA is not yet supported).
+- `DockerMachineTemplate` — template for Docker machines.
+- `KairosConfigTemplate` — bootstrap configuration with `userPasswordSecretRef`.
 
 ### Step 3: Apply the Manifest
 
@@ -53,10 +68,10 @@ Edit `config/samples/capd/kairos_cluster_k0s_single_node.yaml`:
 kubectl apply -f config/samples/capd/kairos_cluster_k0s_single_node.yaml
 ```
 
-### Step 4: Wait for Cluster to be Ready
+### Step 4: Wait for the Cluster to be Ready
 
 ```bash
-# Watch the cluster status
+# Watch cluster status
 kubectl get cluster kairos-cluster -w
 
 # Check control plane status
@@ -64,138 +79,79 @@ kubectl get kairoscontrolplane kairos-control-plane
 
 # Check machines
 kubectl get machines
-
-# Once ready, check nodes
-kubectl get nodes --kubeconfig=<path-to-kubeconfig>
 ```
 
-### Step 5: Verify k0s is Running
+### Step 5: Retrieve the Kubeconfig
 
 ```bash
-# Get kubeconfig for the cluster (from the cluster secret)
-kubectl get secret kairos-cluster-kubeconfig -o jsonpath='{.data.value}' | base64 -d > kairos-kubeconfig.yaml
-
-# Check nodes
+kubectl get secret kairos-cluster-kubeconfig \
+  -o jsonpath='{.data.value}' | base64 -d > kairos-kubeconfig.yaml
 kubectl --kubeconfig=kairos-kubeconfig.yaml get nodes
-
-# Check k0s pods (if accessible)
 kubectl --kubeconfig=kairos-kubeconfig.yaml get pods -n kube-system
 ```
-
-Notes:
-- Kubeconfig retrieval may use SSH to the control plane node depending on the infrastructure provider. Ensure SSH access is available for the Kairos user credentials in your KairosConfigTemplate.
 
 ## Troubleshooting
 
 ### Cluster Not Ready
 
 ```bash
-# Check cluster conditions
 kubectl describe cluster kairos-cluster
-
-# Check control plane conditions
 kubectl describe kairoscontrolplane kairos-control-plane
-
-# Check machine status
 kubectl describe machine <machine-name>
-
-# Check bootstrap config
 kubectl describe kairosconfig <kairosconfig-name>
-kubectl get secret <dataSecretName> -o yaml
 ```
 
 ### Bootstrap Data Not Generated
 
 ```bash
-# Check bootstrap controller logs
-kubectl logs -n kairos-capi-system deployment/kairos-capi-controller-manager | grep bootstrap
-
-# Verify KairosConfig has required fields
+kubectl logs -n kairos-capi-system deployment/kairos-capi-controller-manager
 kubectl get kairosconfig -o yaml
 ```
 
-### Worker Token Issues
+If `KairosConfig.status.failureMessage` is set, the last reconcile failed. The message clears automatically when the underlying condition is resolved (for example, if a missing Secret is created). This is a transient failure, not a terminal one.
 
-For worker nodes, ensure:
-- `WorkerToken` or `WorkerTokenSecretRef` is set in `KairosConfig`
-- Token secret exists and contains the correct key
-- Token is valid for joining the cluster
+### Missing User-Password Secret
 
-## Adding Worker Nodes
-
-Once your control plane is ready, you can add worker nodes using a `MachineDeployment`.
-
-### Step 1: Get Worker Token
-
-First, you need to obtain a worker join token from your k0s control plane:
+If `failureMessage` contains "secret not found" for `kairos-user-password`, create the Secret:
 
 ```bash
-# Get kubeconfig for the cluster (from the cluster secret)
-kubectl get secret kairos-cluster-kubeconfig -o jsonpath='{.data.value}' | base64 -d > kairos-kubeconfig.yaml
+kubectl create secret generic kairos-user-password \
+  --from-literal=password=$(openssl rand -base64 32)
+```
 
-# Option 1: If you have access to the control plane node
-# SSH into the control plane and run:
-# k0s token create --role=worker
+The controller retries automatically.
 
-# Option 2: Use kubectl to exec into k0s controller pod
+### Worker Token Issues
+
+For worker nodes, ensure `workerTokenSecretRef` references an existing Secret containing the correct key (default: `token`). Retrieve a k0s worker token from the control plane:
+
+```bash
+kubectl get secret kairos-cluster-kubeconfig \
+  -o jsonpath='{.data.value}' | base64 -d > kairos-kubeconfig.yaml
 kubectl --kubeconfig=kairos-kubeconfig.yaml exec -n kube-system \
-  $(kubectl --kubeconfig=kairos-kubeconfig.yaml get pods -n kube-system -l app=k0s-controller -o jsonpath='{.items[0].metadata.name}') \
+  $(kubectl --kubeconfig=kairos-kubeconfig.yaml get pods -n kube-system \
+    -l app=k0s-controller -o jsonpath='{.items[0].metadata.name}') \
   -- k0s token create --role=worker
 ```
 
-### Step 2: Create Worker Token Secret
+## Adding Worker Nodes
 
-Create a Secret with the worker token:
-
-```bash
-kubectl create secret generic kairos-worker-token \
-  --from-literal=token="<your-worker-token-here>" \
-  -n default
-```
-
-### Step 3: Apply Worker Sample
-
-Apply the worker sample manifest:
+Once your control plane is ready, apply the workers sample:
 
 ```bash
 kubectl apply -f config/samples/capd/kairos_cluster_k0s_with_workers.yaml
 ```
 
-This creates:
-- A `MachineDeployment` for worker nodes
-- A `KairosConfigTemplate` for worker bootstrap configuration
-- A `DockerMachineTemplate` for worker infrastructure
-
-### Step 4: Verify Worker Nodes
-
-```bash
-# Watch machines being created
-kubectl get machines -w
-
-# Once machines are ready, check nodes in the cluster
-kubectl --kubeconfig=kairos-kubeconfig.yaml get nodes
-
-# You should see worker nodes joining
-```
-
-### Worker Configuration Options
-
-The worker `KairosConfigTemplate` supports:
-
-- **Worker Token**: Use `workerTokenSecretRef` (recommended) or inline `workerToken`
-- **SSH Access**: Configure via `githubUser` or `sshPublicKey`
-- **Custom Manifests**: Add Kubernetes manifests via `spec.manifests`
+This adds a `MachineDeployment` for worker nodes referencing a separate `KairosConfigTemplate` that also uses `userPasswordSecretRef`. The `kairos-worker-token` Secret referenced in that template must be created first.
 
 ## Next Steps
 
-- Configure additional manifests via `spec.manifests` in `KairosConfig`
-- Explore multi-node control plane (set `spec.replicas > 1`)
-- Scale worker nodes by updating `MachineDeployment.spec.replicas`
+- Configure additional Kubernetes manifests via `spec.manifests` in `KairosConfigTemplate`.
+- Scale worker nodes by updating `MachineDeployment.spec.replicas`.
+- Multi-node control planes are tracked for a future release (KD-5b / KD-25).
 
 ## Cleanup
 
 ```bash
-# Delete the cluster
 kubectl delete -f config/samples/capd/kairos_cluster_k0s_single_node.yaml
 ```
-

--- a/docs/QUICKSTART_CAPK.md
+++ b/docs/QUICKSTART_CAPK.md
@@ -1,77 +1,228 @@
 # Quickstart: CAPK (KubeVirt)
 
-This guide sets up a local KubeVirt environment and provisions a single-node Kairos+k0s or Kairos+k3s cluster using CAPK.
+Last verified against: Kairos v3.6.0+, CAPI v1.8.x, KubeVirt v1.8.2, CAPK v0.1.x, provider v0.1.0-alpha.2.
 
-## Prerequisites
+This guide covers two paths:
+
+- **Lab path** (using `kubevirt-env`): an automated local setup using kind + KubeVirt. This path is lab-only; it is not suitable for production.
+- **Non-lab path**: applying sample manifests directly against an existing management cluster that already has KubeVirt and CAPI installed.
+
+Both paths use the 2-disk Kairos installer pattern, described below.
+
+---
+
+## The 2-disk Kairos installer pattern
+
+Kairos image DataVolumes (DVs) are **live-installer images**. When a KubeVirt VM boots from a Kairos image DV, the VM runs a live environment that installs Kairos OS onto a separate blank disk. The cloud-config's `install.device` field points at that blank disk.
+
+The two-disk layout the samples use:
+
+| Disk | Role | bootOrder | DataVolume |
+|------|------|-----------|------------|
+| `installeriso` (cdrom/sata) | Kairos live-installer image | 2 | `kairos-rootdisk` (your Kairos image DV) |
+| `rootdisk` (virtio) | Blank install target | 1 | `kairos-install-disk` (blank, 40Gi) |
+
+The blank install-target disk boots first (bootOrder 1) but has no OS — the firmware falls through to bootOrder 2, the Kairos installer. Kairos installs to `/dev/vda` (the blank disk), then reboots. After reboot, the blank disk now holds the installed OS and boots first.
+
+The KairosConfigTemplate must include:
+
+```yaml
+spec:
+  template:
+    spec:
+      install:
+        auto: true
+        device: "/dev/vda"
+        reboot: true
+```
+
+The `virtualMachineBootstrapCheck.checkStrategy: none` setting in `KubevirtMachineTemplate` is required because CAPK's default SSH-based readiness check fails in this configuration. The Kairos CAPI provider uses a kubeconfig-push mechanism rather than SSH, so bypassing the check is correct.
+
+---
+
+## Lab path: using `kubevirt-env`
+
+`kubevirt-env` is a local-development CLI that creates a kind cluster and installs the full KubeVirt + CAPI + Kairos stack automatically. This is the fastest way to get started in a lab environment.
+
+### Prerequisites
 
 - `docker`
 - Go toolchain (for building `kubevirt-env`)
-- Network access to `github.com` (remote `kubectl apply -k` for the Kairos operator)
+- Network access to `github.com`
 
-Pinned `kubectl`, `kind`, `clusterctl`, and `virtctl` are cached under `<RepoRoot>/.e2e-bin` on first run.
+Pinned `kubectl`, `kind`, `clusterctl`, and `virtctl` are downloaded to `<RepoRoot>/.e2e-bin` on first run.
 
-## Build the local helper
+### Build the helper
 
 ```bash
 make kubevirt-env
 ```
 
-Or manually:
+Or directly:
 
 ```bash
 go build -o bin/kubevirt-env ./cmd/kubevirt-env
 ```
 
-## Create the local KubeVirt environment
+### Create the environment
 
 ```bash
 ./bin/kubevirt-env
 ```
 
-Notes:
-- The root command creates a kind cluster (name from `--cluster-name` or `CLUSTER_NAME`), installs Calico (required first: default CNI is off), then local-path, CDI, KubeVirt, CAPI, CAPK, the [Kairos operator](https://kairos.io/docs/operator-docs/installation/) plus its nginx artifact sink, builds and uploads the Kairos cloud image, cert-manager, and the Kairos CAPI provider (release image).
-- KubeVirt emulation is enabled by default (set `KUBEVIRT_USE_EMULATION=false` to disable).
-- To pin CAPK to a specific version, set `CAPK_VERSION` (e.g., `CAPK_VERSION=v0.1.x`).
-- The control-plane API is exposed via a mandatory LoadBalancer Service named `<cluster>-control-plane-lb`. Ensure a LoadBalancer implementation is available (for example, MetalLB in kind environments).
-- The controller expects the kubeconfig secret to be created in the management cluster as `<cluster>-kubeconfig`.
+What this does:
 
-## Create a test cluster
+- Creates a kind cluster (name from `--cluster-name` or `CLUSTER_NAME` env var; default `kairos-capi`).
+- Installs Calico (required: default CNI is disabled in kind).
+- Installs local-path-provisioner, CDI, KubeVirt, CAPI core, CAPK.
+- Installs cert-manager and the Kairos CAPI provider (released image).
+- Builds and uploads your Kairos cloud image to CDI as a DataVolume.
+
+Options:
+
+- `KUBEVIRT_USE_EMULATION=false` — disable KVM emulation (requires `/dev/kvm` on the host).
+- `CAPK_VERSION=v0.1.x` — pin a specific CAPK version.
+
+The control-plane API is exposed via a LoadBalancer Service named `<cluster>-control-plane-lb`. MetalLB or equivalent must be installed in the kind cluster. `kubevirt-env` installs MetalLB as part of its setup.
+
+### Apply the install-disk DataVolume
+
+Before applying the cluster manifest, create the blank install target:
+
+```bash
+kubectl apply -f config/samples/capk/kairos-install-disk.yaml
+```
+
+Review the `storageClassName` comment in that file. The `kubevirt-env` default is `local-path`.
+
+### Create a test cluster
+
+k0s:
 
 ```bash
 kubectl apply -f config/samples/capk/kubevirt_cluster_k0s_single_node.yaml
 ```
 
-For k3s:
+k3s:
 
 ```bash
 kubectl apply -f config/samples/capk/kubevirt_cluster_k3s_single_node.yaml
 ```
 
-## Check status
-
-Optional checks (cluster name from sample is `kairos-cluster-kv`):
+### Watch cluster status
 
 ```bash
-kubectl get svc kairos-cluster-kv-control-plane-lb
-kubectl get secret kairos-cluster-kv-kubeconfig
+# Cluster name from the sample is kairos-cluster-kv
+kubectl get cluster kairos-cluster-kv -w
+kubectl get kairoscontrolplane kairos-control-plane-kv-capk -w
+kubectl get machines
 ```
 
-## Optional: Run scripted flow
+Successful provisioning sequence:
+
+1. `Machine` appears with `Provisioning` phase.
+2. `KairosConfig` transitions to `ready: true` and `dataSecretName` is set.
+3. KubeVirt VM starts; Kairos installer runs; VM reboots.
+4. `KubevirtMachine` becomes `Ready`.
+5. `KairosControlPlane` sets `initialized: true`.
+6. `<cluster>-kubeconfig` Secret appears in the management cluster.
+
+### Retrieve the kubeconfig
 
 ```bash
-make kubevirt-env
-make test-kubevirt
+kubectl get secret kairos-cluster-kv-kubeconfig \
+  -o jsonpath='{.data.value}' | base64 -d > kairos-cluster-kv.kubeconfig
+kubectl --kubeconfig=kairos-cluster-kv.kubeconfig get nodes
 ```
 
-## Cleanup
+### Run the scripted end-to-end test
 
-Delete workload resources with `kubectl` as needed, then remove the management kind cluster and work directory:
+```bash
+make kubevirt-env      # (re)build and set up the environment
+make test-kubevirt     # run the full scripted flow
+```
+
+### Cleanup
 
 ```bash
 ./bin/kubevirt-env cleanup
 ```
 
+---
+
+## Non-lab path: direct manifest apply
+
+For users with an existing management cluster that already has KubeVirt, CDI, CAPI, and CAPK installed.
+
+Do not use `clusterctl init --bootstrap kairos` — clusterctl integration is deferred to a later release (KD-38).
+
+### Prerequisites
+
+- Kubernetes management cluster with:
+  - CAPI v1.8.x installed
+  - CAPK (`infrastructure.cluster.x-k8s.io`) installed
+  - CDI (Containerized Data Importer) installed
+  - A LoadBalancer implementation (MetalLB or equivalent)
+- Kairos CAPI provider installed:
+  ```bash
+  kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-alpha.1/kairos-capi-provider.yaml
+  ```
+- A Kairos image uploaded to CDI as a DataVolume named `kairos-rootdisk` (for k0s) or `kairos-k3s-rootdisk` (for k3s) in namespace `default`. The image must be a Kairos live-installer image — not a pre-installed disk image.
+
+### Step 1: Create the user-password Secret
+
+```bash
+kubectl create secret generic kairos-user-password \
+  --from-literal=password=$(openssl rand -base64 32)
+```
+
+### Step 2: Apply the blank install-target DataVolume
+
+```bash
+kubectl apply -f config/samples/capk/kairos-install-disk.yaml
+```
+
+Edit the file to set the correct `storageClassName` for your cluster before applying.
+
+### Step 3: Customize the cluster manifest
+
+Edit `config/samples/capk/kubevirt_cluster_k0s_single_node.yaml` (or the k3s variant):
+
+- If your cluster does not have KVM on every node, uncomment `nodeSelector` and set the hostname of a KVM-capable node.
+- Adjust `cpu.cores` and `resources.requests.memory` for your workload.
+- Review `dnsServers` — the sample includes lab-specific DNS addresses.
+
+### Step 4: Apply the cluster manifest
+
+```bash
+kubectl apply -f config/samples/capk/kubevirt_cluster_k0s_single_node.yaml
+```
+
+### Step 5: Watch cluster status and retrieve kubeconfig
+
+Same commands as the lab path above.
+
+---
+
 ## Troubleshooting
-- If VMs do not start, confirm KubeVirt is `Available` and that `local-path` is the default StorageClass.
-- If you have `/dev/kvm` available and want hardware acceleration, set `KUBEVIRT_USE_EMULATION=false` before running `kubevirt-env`.
-- If you use bridged/multus networking and the management cluster stays NotReady, ensure `spec.controlPlaneEndpoint.host` is reachable from the CAPI controllers; KubevirtMachine status may not report VM IPs in this mode.
+
+**VMs do not start**: confirm KubeVirt shows `Available` and CDI is running. Check `kubectl get vmi` and `kubectl describe vmi <name>` for VM instance events.
+
+**Installer does not run**: verify the `installeriso` volume references the correct Kairos image DataVolume and that the DV is `Succeeded`. If the DV is still importing, the VM will not start.
+
+**VM boots directly to installed OS on first boot**: this is expected — the blank install-target disk boots first (bootOrder 1) and the firmware falls through to the Kairos installer (bootOrder 2) because the blank disk has no bootable partition. If the VM gets stuck before the installer image is available, check the DV import status.
+
+**`kairos-cluster-kv-kubeconfig` Secret never appears**: check `KairosControlPlane` conditions:
+```bash
+kubectl describe kairoscontrolplane kairos-control-plane-kv-capk
+```
+Also check controller logs:
+```bash
+kubectl logs -n kairos-capi-system deployment/kairos-capi-controller-manager
+```
+
+**LoadBalancer Service has no external IP**: ensure MetalLB (or equivalent) is installed and has an address pool configured. Without a LoadBalancer IP, the control-plane endpoint is not resolvable and `KairosControlPlane.status.initialized` will not become `true`.
+
+**`nodeSelector` scheduling failure**: if you have the `nodeSelector` for a specific hostname and that node does not have KVM or is not schedulable, the VM pod stays `Pending`. Either remove the selector (if all nodes have KVM) or update the hostname to match a schedulable KVM node.
+
+**KubeVirt emulation warnings**: if `/dev/kvm` is not available, `kubevirt-env` enables software emulation (`KUBEVIRT_USE_EMULATION=true`). This is substantially slower. Expect install + boot to take several minutes.

--- a/docs/QUICKSTART_CAPV.md
+++ b/docs/QUICKSTART_CAPV.md
@@ -1,22 +1,26 @@
 # Quick Start Guide - CAPV (vSphere)
 
+Last verified against: Kairos v3.6.0+, CAPI v1.8.x, CAPV v1.11.x, provider v0.1.0-alpha.2.
+
 This guide walks you through creating a single-node k0s or k3s cluster on Kairos using Cluster API with the vSphere provider (CAPV).
+
+**Note on k3s vs k0s**: the k3s flavor requires `Cluster.spec.controlPlaneEndpoint` to be set to a stable LoadBalancer IP or VIP before applying the manifest, because k3s agents join via the control-plane endpoint. The k0s flavor does not require a pre-set endpoint — the controller discovers the node IP after the VM is provisioned.
 
 ## Prerequisites
 
 1. **vSphere Environment**:
-   - vCenter Server access
-   - Datacenter, Datastore, Network configured
-   - VM Template with Kairos OS installed
-   - Resource Pool (optional)
+   - vCenter Server access (FQDN or IP, no URL prefix).
+   - Datacenter, Datastore, Network configured.
+   - A Kairos VM template uploaded to vSphere with Kairos OS.
+   - Resource Pool (optional).
 
-2. **Management Cluster**: A Kubernetes cluster with access to vSphere
+2. **Management Cluster**: A Kubernetes cluster with network access to vSphere.
 
-3. **Cluster API**: CAPI v1.11+ installed
+3. **Cluster API**: CAPI v1.8.x installed. v1.11.x is on the roadmap (KD-13).
 
-4. **CAPV**: Cluster API Provider vSphere installed and configured
+4. **CAPV**: Cluster API Provider vSphere installed and configured.
 
-5. **Kairos CAPI Provider**: Installed via make (see [Install guide](INSTALL.md))
+5. **Kairos CAPI Provider**: Installed (see [Install guide](INSTALL.md)).
 
 ### Installing Prerequisites
 
@@ -26,45 +30,9 @@ Install CAPI and CAPV using your preferred method. See the [Cluster API book](ht
 
 #### 2. Configure vSphere Credentials
 
-Create a `VSphereClusterIdentity` and Secret with vSphere credentials:
-
-**IMPORTANT**: The Secret **MUST** be created in the `capv-system` namespace (where the CAPV controller runs), not in your cluster namespace.
+The Secret **must** be in the `capv-system` namespace (where the CAPV controller runs), not in the cluster namespace.
 
 ```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: vsphere-credentials-secret
-  namespace: capv-system  # IMPORTANT: MUST be in capv-system namespace
-type: Opaque
-stringData:
-  username: administrator@vsphere.local
-  password: <your-password>
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: VSphereClusterIdentity
-metadata:
-  name: vsphere-credentials
-  # Note: VSphereClusterIdentity is cluster-scoped (no namespace)
-spec:
-  secretName: vsphere-credentials-secret  # References the Secret in capv-system namespace
-  allowedNamespaces:
-    # Use selector to control which namespaces can use this identity
-    # Option A: Allow all namespaces (use with caution)
-    selector:
-      matchLabels: {}
-    # Option B: Allow specific namespaces by label (RECOMMENDED)
-    # First label namespaces: kubectl label namespace default vsphere-identity=allowed
-    # Then use:
-    # selector:
-    #   matchLabels:
-    #     vsphere-identity: allowed
-```
-
-**Apply the credentials**:
-```bash
-# Apply the Secret and VSphereClusterIdentity
-kubectl apply -f - <<EOF
 apiVersion: v1
 kind: Secret
 metadata:
@@ -85,200 +53,144 @@ spec:
     selector:
       matchLabels:
         vsphere-identity: allowed
-EOF
+```
 
-# Label your namespace to allow using this identity
+Apply and label the target namespace:
+
+```bash
+kubectl apply -f - <<'EOF'
+# paste the YAML above
+EOF
 kubectl label namespace default vsphere-identity=allowed
 ```
 
 #### 3. Install Kairos CAPI Provider
+
+**Recommended (released artifact):**
+
+```bash
+kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-alpha.1/kairos-capi-provider.yaml
+```
+
+**Developer install (from source):**
 
 ```bash
 make docker-build
 make deploy
 ```
 
-See [INSTALL.md](INSTALL.md) for full install steps.
+See [INSTALL.md](INSTALL.md) for the full developer install process.
 
 ## Creating a Cluster
 
-### Step 1: Prepare vSphere Resources
+### Step 1: Create the user-password Secret
 
-Before applying the manifest, ensure you have:
+```bash
+kubectl create secret generic kairos-user-password \
+  --from-literal=password=$(openssl rand -base64 32)
+```
 
-1. **VM Template**: A Kairos VM template in vSphere
-   - Template name (e.g., "kairos-opensuse-leap-v3.6.0")
-   - Template should have Kairos OS installed
+The sample manifests reference this Secret via `userPasswordSecretRef`. Do not use `userPassword` inline.
 
-2. **Network**: VM Network name in vSphere
-
-3. **Datacenter**: Datacenter name
-
-4. **Datastore**: Datastore name
-
-### Step 2: Customize the Sample Manifest
-
-Edit the sample manifest you want to use:
+### Step 2: Choose a sample manifest
 
 - k0s single node: `config/samples/capv/kairos_cluster_k0s_single_node.yaml`
 - k3s single node: `config/samples/capv/kairos_cluster_k3s_single_node.yaml`
 
-#### Update Cluster
+### Step 3: Customize the manifest
 
-```yaml
-apiVersion: cluster.x-k8s.io/v1beta2
-kind: Cluster
-metadata:
-  name: kairos-cluster
-  namespace: default
-spec:
-  infrastructureRef:
-    # Note: In v1beta2, use apiGroup instead of apiVersion
-    apiGroup: infrastructure.cluster.x-k8s.io
-    kind: VSphereCluster
-    name: kairos-cluster
-  controlPlaneRef:
-    # Note: In v1beta2, use apiGroup instead of apiVersion
-    apiGroup: controlplane.cluster.x-k8s.io
-    kind: KairosControlPlane
-    name: kairos-control-plane
-```
+Open the chosen sample and fill in the following `TODO` values.
 
-#### Update VSphereCluster
+#### VSphereCluster
 
 ```yaml
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereCluster
-metadata:
-  name: kairos-cluster
-  namespace: default
 spec:
-  # IMPORTANT: Use only hostname or IP address, NOT a URL
   # Correct: "vcenter.example.com" or "172.16.56.10"
-  # Wrong: "https://vcenter.example.com" or "https://172.16.56.10/sdk"
-  server: "vcenter.example.com"  # TODO: Set your vCenter server
-  # thumbprint: "..."             # Optional: SSL thumbprint
+  # Wrong:   "https://vcenter.example.com"
+  server: "TODO-YOUR-VCENTER-HOSTNAME"
   identityRef:
     kind: VSphereClusterIdentity
     name: vsphere-credentials
-    # Note: identityRef does NOT have an apiVersion field
-  # Note: datacenter is NOT specified here - it's specified in VSphereMachineTemplate instead
 ```
 
-#### Update VSphereMachineTemplate
+#### VSphereMachineTemplate
 
 ```yaml
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereMachineTemplate
-metadata:
-  name: kairos-control-plane-template
-  namespace: default
 spec:
   template:
     spec:
-      datacenter: "Datacenter"           # TODO: Set your datacenter
-      datastore: "Datastore"             # TODO: Set your datastore
-      folder: "Folder"                   # TODO: Set folder (optional)
+      datacenter: "Datacenter"
+      datastore: "Datastore"
+      folder: "Folder"
       network:
         devices:
-          - networkName: "VM Network"     # TODO: Set your network name
-      resourcePool: "ResourcePool"       # TODO: Set resource pool (optional)
-      numCPUs: 2                         # TODO: Adjust CPU count
-      memoryMiB: 4096                    # TODO: Adjust memory
-      diskGiB: 50                        # TODO: Adjust disk size
-      template: "kairos-template"        # TODO: Set your Kairos template name
-      cloneMode: "fullClone"             # or "linkedClone"
+          - networkName: "VM Network"
+      resourcePool: "ResourcePool"
+      numCPUs: 2
+      memoryMiB: 4096
+      diskGiB: 50
+      template: "kairos-template"
+      cloneMode: "fullClone"
 ```
 
-#### Update KairosControlPlane
-
-```yaml
-apiVersion: controlplane.cluster.x-k8s.io/v1beta2
-kind: KairosControlPlane
-metadata:
-  name: kairos-control-plane
-  namespace: default
-spec:
-  replicas: 1
-  version: "v1.30.0+k0s.0"
-  machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-      kind: VSphereMachineTemplate
-      name: kairos-control-plane-template
-      namespace: default
-  kairosConfigTemplate:
-    name: kairos-config-template-control-plane
-    # Note: namespace defaults to the same namespace as KairosControlPlane
-```
-
-#### Update KairosConfigTemplate (Optional)
+#### KairosConfigTemplate
 
 ```yaml
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KairosConfigTemplate
-metadata:
-  name: kairos-config-template-control-plane
-  namespace: default
 spec:
   template:
     spec:
       role: control-plane
-      distribution: k0s
-      kubernetesVersion: "v1.30.0+k0s.0"
-      userName: kairos
-      userPassword: kairos                    # TODO: Change for non-dev usage
+      distribution: k0s       # or k3s
+      kubernetesVersion: "v1.34.1+k0s.1"
+      userPasswordSecretRef:
+        name: kairos-user-password
       userGroups:
         - admin
-      githubUser: "your-github-username"      # TODO: Add your GitHub user
-      # Or use sshPublicKey instead
-      # sshPublicKey: "ssh-rsa AAAAB3..."
+      # Optional: SSH access
+      # githubUser: "your-github-username"
+      # sshPublicKey: "ssh-rsa AAAA..."
 ```
 
-### Step 3: Apply the Manifest
+### Step 4: Apply the manifest
+
+k0s:
 
 ```bash
 kubectl apply -f config/samples/capv/kairos_cluster_k0s_single_node.yaml
-
-# Or for k3s:
-# kubectl apply -f config/samples/capv/kairos_cluster_k3s_single_node.yaml
 ```
 
-### Step 4: Monitor Cluster Creation
+k3s:
 
 ```bash
-# Watch cluster status
+kubectl apply -f config/samples/capv/kairos_cluster_k3s_single_node.yaml
+```
+
+### Step 5: Monitor Cluster Creation
+
+```bash
 kubectl get cluster kairos-cluster -w
-
-# Check control plane
 kubectl get kairoscontrolplane kairos-control-plane
-
-# Check machines
 kubectl get machines
-
-# Check VSphereMachines
 kubectl get vspheremachines
-
-# Check VSphereVMs (actual VMs in vSphere)
 kubectl get vspherevms
 ```
 
-### Step 5: Verify Cluster
+### Step 6: Retrieve the Kubeconfig
 
 ```bash
-# Get kubeconfig (from the cluster secret)
-kubectl get secret kairos-cluster-kubeconfig -o jsonpath='{.data.value}' | base64 -d > kairos-kubeconfig.yaml
-
-# Check nodes
+kubectl get secret kairos-cluster-kubeconfig \
+  -o jsonpath='{.data.value}' | base64 -d > kairos-kubeconfig.yaml
 kubectl --kubeconfig=kairos-kubeconfig.yaml get nodes
-
-# Verify k0s/k3s is running
 kubectl --kubeconfig=kairos-kubeconfig.yaml get pods -n kube-system
 ```
 
-Notes:
-- CAPV kubeconfig retrieval uses SSH to the control plane node.
-- Ensure SSH access is enabled for the Kairos user credentials you set in the template.
+**Note:** The kubeconfig retrieval currently uses SSH to reach the control plane node (KD-3b tracks removing SSH from the normal flow in a future release). Ensure the Kairos user credentials allow SSH access until that work lands (PR-7 in the alpha-2 sequence will eliminate SSH from the control plane path).
 
 ## Field Reference
 
@@ -286,94 +198,76 @@ Notes:
 
 | Field | Location | Description |
 |-------|----------|-------------|
-| `server` | VSphereCluster.spec | vCenter server FQDN/IP (hostname or IP only, NOT a URL) |
-| `datacenter` | VSphereCluster.spec, VSphereMachineTemplate.spec | Datacenter name |
-| `datastore` | VSphereMachineTemplate.spec | Datastore name |
-| `networkName` | VSphereMachineTemplate.spec.network.devices | VM Network name |
-| `template` | VSphereMachineTemplate.spec | Kairos VM template name |
+| `server` | VSphereCluster.spec | vCenter server FQDN or IP (hostname/IP only, not a URL). |
+| `datacenter` | VSphereMachineTemplate.spec | Datacenter name. |
+| `datastore` | VSphereMachineTemplate.spec | Datastore name. |
+| `networkName` | VSphereMachineTemplate.spec.network.devices | VM Network name. |
+| `template` | VSphereMachineTemplate.spec | Kairos VM template name in vSphere. |
 
 ### Optional Fields
 
 | Field | Location | Description |
 |-------|----------|-------------|
-| `thumbprint` | VSphereCluster.spec | SSL thumbprint for vCenter |
-| `identityRef` | VSphereCluster.spec | Reference to VSphereClusterIdentity |
-| `folder` | VSphereMachineTemplate.spec | VM folder path |
-| `resourcePool` | VSphereMachineTemplate.spec | Resource pool path |
-| `numCPUs` | VSphereMachineTemplate.spec | Number of CPUs |
-| `memoryMiB` | VSphereMachineTemplate.spec | Memory in MiB |
-| `diskGiB` | VSphereMachineTemplate.spec | Disk size in GiB |
-| `cloneMode` | VSphereMachineTemplate.spec | "fullClone" or "linkedClone" |
+| `thumbprint` | VSphereCluster.spec | SSL thumbprint for vCenter certificate validation. |
+| `folder` | VSphereMachineTemplate.spec | VM folder path. |
+| `resourcePool` | VSphereMachineTemplate.spec | Resource pool path. |
+| `numCPUs` | VSphereMachineTemplate.spec | CPU count. |
+| `memoryMiB` | VSphereMachineTemplate.spec | Memory in MiB. |
+| `diskGiB` | VSphereMachineTemplate.spec | Disk size in GiB. |
+| `cloneMode` | VSphereMachineTemplate.spec | `"fullClone"` or `"linkedClone"`. |
 
 ## Troubleshooting
 
 ### VSphere Connection Issues
 
 ```bash
-# Check VSphereCluster status
 kubectl describe vspherecluster kairos-cluster
-
-# Verify VSphereClusterIdentity is ready
 kubectl get vsphereclusteridentity vsphere-credentials -o yaml
-
-# Verify credentials (must be in capv-system namespace)
 kubectl get secret vsphere-credentials-secret -n capv-system -o yaml
-
-# Check CAPV controller logs
 kubectl logs -n capv-system deployment/capv-controller-manager
-
-# Common issues:
-# 1. Secret not in capv-system namespace → Move it: kubectl get secret vsphere-credentials-secret -n default -o yaml | kubectl apply -n capv-system -f -
-# 2. Server URL includes protocol/path → Use only hostname/IP: "172.16.56.10" not "https://172.16.56.10/sdk"
-# 3. Namespace not labeled → Label it: kubectl label namespace default vsphere-identity=allowed
 ```
+
+Common causes:
+
+1. Secret not in `capv-system` namespace — move it: `kubectl get secret vsphere-credentials-secret -n default -o yaml | kubectl apply -n capv-system -f -`
+2. `server` field includes protocol or path — use hostname/IP only: `"172.16.56.10"` not `"https://172.16.56.10/sdk"`.
+3. Namespace not labeled — run: `kubectl label namespace default vsphere-identity=allowed`.
 
 ### VM Creation Fails
 
 ```bash
-# Check VSphereMachine status
 kubectl describe vspheremachine <machine-name>
-
-# Check VSphereVM status
 kubectl describe vspherevm <vm-name>
-
-# Verify template exists in vSphere
-# Verify network/datastore names are correct
 ```
+
+Verify template exists in vSphere and network/datastore names match exactly.
 
 ### Bootstrap Issues
 
 ```bash
-# Check KairosConfig
 kubectl describe kairosconfig <config-name>
-
-# Check bootstrap secret
-kubectl get secret <dataSecretName> -o yaml
-
-# Check Kairos CAPI controller logs
 kubectl logs -n kairos-capi-system deployment/kairos-capi-controller-manager
 ```
 
+If `KairosConfig.status.failureMessage` is set, the issue is transient — it clears automatically when resolved. A missing `kairos-user-password` Secret is the most common first-run cause.
+
 ## Security Considerations
 
-1. **Credentials**: Use `VSphereClusterIdentity` instead of inline credentials
-2. **User Password**: Change default `userPassword` from "kairos" for non-dev use
-3. **SSH Access**: Use `githubUser` or `sshPublicKey` instead of password-based access
-4. **Worker Tokens**: Use `WorkerTokenSecretRef` instead of inline `WorkerToken`
+- **vSphere credentials**: Use `VSphereClusterIdentity` with a Secret in `capv-system`. Do not use inline credentials in `VSphereCluster.spec`.
+- **User password**: Provide via `userPasswordSecretRef`. The webhook rejects KairosConfig objects with no credential. Do not set `userPassword` inline outside of throwaway testing.
+- **SSH access**: Add `githubUser` or `sshPublicKey` if you need SSH access to nodes. Password-based SSH should not be the primary access mechanism.
+- **Worker tokens**: Use `k3sTokenSecretRef` / `workerTokenSecretRef` rather than inline tokens.
 
 ## Next Steps
 
-- Configure additional worker nodes
-- Set up HA control plane (replicas > 1)
-- Add custom Kubernetes manifests via `spec.manifests`
-- Integrate with your CI/CD pipeline
+- Configure additional worker nodes via `MachineDeployment`.
+- Add custom Kubernetes manifests via `spec.manifests` in `KairosConfigTemplate`.
+- Multi-node control planes are tracked for a future release (KD-5b / KD-25).
+- SSH will be removed from the normal control-plane flow in a future PR (KD-3b).
 
 ## Cleanup
 
 ```bash
-# Delete the cluster
 kubectl delete -f config/samples/capv/kairos_cluster_k0s_single_node.yaml
-
-# Note: This will delete VMs in vSphere
+# Note: This deletes VMs in vSphere.
 ```
-

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,29 +1,42 @@
 # Testing
 
+Last verified against: Go toolchain 1.26.3, provider v0.1.0-alpha.2.
+
 See [Install guide](INSTALL.md) for development install.
 
 ## Prerequisites
 
-- Go 1.26+ (see [Install guide](INSTALL.md))
+- Go toolchain 1.26.3 (matches `go.mod` directive `go 1.26.0`; the toolchain line pins `go1.26.0` for reproducibility). The `go.mod` line is `go 1.26.0`; both refer to the same release series.
 
 ## Unit tests
 
-Run unit tests (default, no envtest assets needed):
+Run unit tests (no envtest assets needed):
 
 ```bash
 go test ./...
 ```
 
-Coverage includes template rendering for k0s and k3s and bootstrap controller logic.
+Coverage includes template rendering for k0s and k3s, bootstrap controller logic, and webhook validation.
 
-## Envtest
+## Envtest (integration)
 
-Envtest is optional and downloads assets automatically:
+Envtest downloads assets automatically via `setup-envtest`:
 
 ```bash
 make test-envtest
 ```
 
-`make test-envtest` installs setup-envtest if needed, downloads assets, and runs envtest-tagged tests.
+`make test-envtest` installs `setup-envtest` if needed, downloads Kubernetes API server binaries, and runs the `envtest`-tagged tests. This is the local integration gate and covers the full reconcile + webhook path without a real cluster.
 
-CI tests against Go 1.26.0.
+**Note (KD-19):** The CI envtest job is permanently gated with `if: false` — it is not run in CI at present. `make test-envtest` is the integration gate for local development until KD-19 is resolved.
+
+## End-to-end (KubeVirt)
+
+The full end-to-end test spins up a kind + KubeVirt environment and provisions a real Kairos cluster:
+
+```bash
+make kubevirt-env      # build and set up the environment (downloads assets on first run)
+make test-kubevirt     # run the scripted end-to-end flow
+```
+
+This is the highest-confidence gate but requires Docker and a host with enough memory for nested VMs (16 GiB+ recommended). See [QUICKSTART_CAPK.md](QUICKSTART_CAPK.md) for details on the lab environment.


### PR DESCRIPTION
## Summary

- Foundation docs sweep aligning README, `docs/`, and `config/samples/` with the merged state of #45, #46, #47, #48, #49, #50.
- No production Go code changed. No CRD shape change. No CLI flag changed.
- Captures four operator gotchas surfaced during PR #49's 4-scenario lab validation that no doc previously documented.
- Scoped by a `staff-architect` audit pass and executed by `tech-writer`; all 6 maintainer decisions on framing/versions confirmed up-front.

## What this fixes

- **Every `kairos:kairos` / `userPassword: kairos` reference removed.** PR #49 removed the default and swept the samples, but quickstarts (`QUICKSTART_CAPV.md` line 230, `QUICKSTART_CAPD.md` line 48) and `docs/API_REFERENCE.md` still presented `kairos` as the documented default. Anyone copy-pasting hit a webhook validation error. The `userPasswordSecretRef` Secret pattern is now the documented path everywhere.
- **`replicas > 1` is now consistently described as unsupported.** PR #48 added webhook rejection; this PR removes the dangling "Set up HA control plane (replicas > 1)" next-step suggestions in three quickstarts.
- **`docs/INSTALL.md` no longer warns "manually clean up clusters before uninstalling the provider."** PR #50 fixes `reconcileDelete` in both controllers; this warning was false post-#50.
- **`docs/API_REFERENCE.md` brought current with the actual `*_types.go` source of truth.** 18 missing field rows added (`dnsServers`, `podCIDR`/`serviceCIDR`, `primaryIP`, `hostname`/`hostnamePrefix`, `install` / `InstallConfig`, `files`, `caCertHashes`/`caCertSecretRef`, `userPasswordSecretRef`, `serverAddress`, `token` / `tokenSecretRef`, `k3sTokenSecretRef`, `workerTokenSecretRef`, `KairosControlPlane.Spec.Distribution`, `initialization` sub-status, etc.); `failureReason` / `failureMessage` rewritten to "transient, cleared on success" per #50; `SingleNode` corrected from "k0s only" to "both k0s and k3s" (verified against all 4 templates); `userPassword`'s false `"kairos"` default removed.
- **`QUICKSTART_CAPK.md` documents the 2-disk Kairos installer pattern.** Lab validation revealed that the Kairos image DataVolumes are LIVE installer images, not pre-installed systems — they boot to a live shell and run an installer onto a blank install-target disk. Without this distinction, users get a confusing live-boot loop. The QS now documents: the installer-vs-pre-installed distinction; the `kairos-install-disk.yaml` blank DataVolume the user must apply before the cluster manifest; the `bootOrder: 1` rootdisk (blank target) + `bootOrder: 2` installerdisk (Kairos image) pattern; the `virtualMachineBootstrapCheck.checkStrategy: none` requirement; and a "Production / non-lab quickstart" section that walks through applying samples against the user's own management cluster.
- **`docs/INSTALL.md` documents two install-time gotchas surfaced by lab validation.** (a) The kustomize-CRD-vs-bare-CRD label mismatch — applying `config/crd/bases/*.yaml` raw skips the kustomize labels CAPI's Machine conversion webhook expects (`cluster.x-k8s.io/v1beta1`, `cluster.x-k8s.io/v1beta2`); use `bin/kustomize build config/crd | kubectl apply -f -`. (b) Stale webhook configurations from prior installs (`mutating-webhook-configuration` / `validating-webhook-configuration` without provider prefix) pointing at a non-existent `webhook-service` — delete before re-installing.
- **Sample versions selectively bumped to lab-validated.** CAPK k3s → `v1.33.5+k3s1`; CAPV k0s → `v1.34.1+k0s.1`; CAPV k3s → `v1.35.0+k3s1`. CAPK k0s was already `v1.34.1+k0s.1`. CAPD samples retain their existing versions with a doc-comment noting the field is informational (KD-24 makes this advisory).
- **Personal-environment values genericized.** `nodeSelector: { kubernetes.io/hostname: grogu }` → placeholder. `server: "vcsa.lab.k8"` → `TODO-YOUR-VCENTER-HOSTNAME`.
- **`config/samples/bootstrap/kairosconfig.yaml` and `config/samples/controlplane/kairoscontrolplane.yaml` now pass webhook validation.** Both were missing the credential field that PR #49's webhook requires.

## Out of scope

The audit surfaced three items that are tracked separately and deliberately not addressed in this PR:

- **`docs/UPGRADING.md`** does not exist yet — PR-11 (`docs/kd-35-kd-36-install-upgrade`) creates it. The UPGRADING-relevant prose from PR-2's tech-writer pass (the workaround removal for stuck Machine finalizers + latched failure status) is handed to that PR.
- **cert-manager pre-flight check in `docs/INSTALL.md`** — also PR-11 scope.
- **`clusterctl init --bootstrap kairos --control-plane kairos` is broken** (empty `sha256` in `config/clusterctl/metadata.yaml`, invalid `releaseSeries` field on `Provider`, duplicate `metadata.name`). This PR softens docs to acknowledge clusterctl is deferred to a later release; the actual fix is tracked as **KD-38** in the punch list.

The `SingleNode` / `Replicas==1` CRD redundancy surfaced during the audit is tracked as **KD-39** (deprecation candidate once HA lands, v1beta3 territory).

## Validation

```
make build                                                         PASS
make manifests                                                     PASS (no diff)
grep "kairos:kairos\|userPassword: kairos" docs/ README.md         no stale refs
grep "userPasswordSecretRef" docs/ config/samples/                 widely covered
```

Manual cross-reference: every link, file path, and KD-number mentioned in the updated docs was verified to resolve.

## Commit boundary

| # | sha | subject |
|---|---|---|
| 1 | `49cfcf8` | `docs(samples): refresh sample manifests for v0.1.0-alpha.2` |
| 2 | `8fcfc69` | `docs(api): bring API_REFERENCE.md current with post-alpha-1 surface` |
| 3 | `1702d2c` | `docs(quickstart): rewrite CAPK QUICKSTART for 2-disk installer pattern` |
| 4 | `08a3188` | `docs(quickstart): align CAPD and CAPV quickstarts with userPasswordSecretRef` |
| 5 | `c80034f` | `docs(install): refresh INSTALL.md, TESTING.md, README for post-alpha-1` |

16 files changed, +758 / −493 lines.
