### PR TITLE
fix(bootstrap): inject persistent-state-paths config via cloud-config (KD-23)

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -342,7 +342,7 @@ The provider declares the following paths as persistent across reboots and A/B u
 
 **Second-boot-onward semantic.** The first install boot consumes the cloud-config directly (the bootstrap Secret is rendered into userdata and applied by `kairos-agent`). From the second reboot onward, the on-disk `/system/oem/12_kairos-capi-persistency.yaml` is what immucore reads at every boot to assemble the persistent overlay.
 
-**Adding your own persistent paths.** Users who need application-specific persistent paths can layer their own cloud-config snippet by writing a file via `Spec.Files` to `/oem/91_custom.yaml` (or any `/oem/9*` prefix). Lower numeric prefixes (`5x`–`8x`) are not recommended: future provider files may use those slots and silently shadow your override.
+**Adding your own persistent paths.** Users who need application-specific persistent paths can layer their own cloud-config snippet by writing a file via `Spec.Files` to `/system/oem/91_custom.yaml` (or any `/system/oem/9*` prefix). Lower numeric prefixes (`5x`–`8x`) are not recommended: future provider files may use those slots and silently shadow your override.
 
 Tracked as KD-23 (persistence injection) and KD-34 (in-place upgrade persistence guarantees) in the punch list.
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -10,6 +10,7 @@ This document provides a reference for all Custom Resource Definitions (CRDs) pr
 - [KairosConfigTemplate](#kairosconfigtemplate)
 - [KairosControlPlane](#kairoscontrolplane)
 - [KairosControlPlaneTemplate](#kairoscontrolplanetemplate)
+- [Persistence behavior](#persistence-behavior)
 - [Notes](#notes)
 
 ---
@@ -317,6 +318,33 @@ spec:
 |-------|------|----------|-------------|
 | `metadata` | `ObjectMeta` | No | Metadata to apply to created `KairosControlPlane` resources. |
 | `spec` | `KairosControlPlaneSpec` | Yes | Spec applied to created `KairosControlPlane` resources. See [KairosControlPlane Spec](#spec-fields-1). |
+
+---
+
+## Persistence behavior
+
+The provider injects `/system/oem/12_kairos-capi-persistency.yaml` into every node's cloud-config via `write_files`. The file uses immucore's `extra-layout.env` mechanism (not `cos-layout.env`), so its `PERSISTENT_STATE_PATHS` value is **unioned** with the stock image's persistent paths — never overwriting them. A custom or stock Kairos image is unaffected; the provider's persistent paths are added on top of whatever the image already persists.
+
+The provider declares the following paths as persistent across reboots and A/B upgrades:
+
+- `/etc/cni`
+- `/etc/k0s`
+- `/etc/kubernetes`
+- `/etc/rancher`
+- `/etc/ssh`
+- `/etc/systemd`
+- `/var/lib/cni`
+- `/var/lib/containerd`
+- `/var/lib/k0s`
+- `/var/lib/kubelet`
+- `/var/lib/rancher`
+- `/var/log`
+
+**Second-boot-onward semantic.** The first install boot consumes the cloud-config directly (the bootstrap Secret is rendered into userdata and applied by `kairos-agent`). From the second reboot onward, the on-disk `/system/oem/12_kairos-capi-persistency.yaml` is what immucore reads at every boot to assemble the persistent overlay.
+
+**Adding your own persistent paths.** Users who need application-specific persistent paths can layer their own cloud-config snippet by writing a file via `Spec.Files` to `/oem/91_custom.yaml` (or any `/oem/9*` prefix). Lower numeric prefixes (`5x`–`8x`) are not recommended: future provider files may use those slots and silently shadow your override.
+
+Tracked as KD-23 (persistence injection) and KD-34 (in-place upgrade persistence guarantees) in the punch list.
 
 ---
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -40,3 +40,7 @@ make test-kubevirt     # run the scripted end-to-end flow
 ```
 
 This is the highest-confidence gate but requires Docker and a host with enough memory for nested VMs (16 GiB+ recommended). See [QUICKSTART_CAPK.md](QUICKSTART_CAPK.md) for details on the lab environment.
+
+## Reboot survival test
+
+After the cluster is `Available=true`, drain a node via `kubectl drain <node> --ignore-daemonsets --delete-emptydir-data`, restart the underlying VM (`virtctl restart <vm>` for CAPK; vSphere "Restart Guest OS" for CAPV), uncordon, and verify `kubectl get nodes` shows `Ready` within 5 minutes. This validates KD-23's persistence injection — k0s/k3s state, SSH host keys, and CNI config must survive the reboot.

--- a/internal/bootstrap/funcs.go
+++ b/internal/bootstrap/funcs.go
@@ -40,11 +40,12 @@ import (
 //   - quotes scalars containing YAML metacharacters (`:`, `#`, `---`, etc.).
 func newFuncMap() template.FuncMap {
 	return template.FuncMap{
-		"quote":      quote,
-		"toYaml":     toYaml,
-		"indent":     safeIndent,
-		"nindent":    nindent,
-		"trimSuffix": trimSuffix,
+		"quote":          quote,
+		"toYaml":         toYaml,
+		"indent":         safeIndent,
+		"nindent":        nindent,
+		"trimSuffix":     trimSuffix,
+		"persistencyOEM": persistencyOEM,
 	}
 }
 

--- a/internal/bootstrap/persistency.go
+++ b/internal/bootstrap/persistency.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2024 The Kairos CAPI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package bootstrap
+
+// SECURITY:
+//
+//  1. Why is this a compile-time constant?
+//     The cloud-config we render runs as root at first boot on every node, and
+//     the persistent-state-paths it declares decide which directories survive a
+//     reboot on Kairos's immutable rootfs. If a user-controlled string could
+//     reach this content, an attacker who controlled a KairosConfig field
+//     could either (a) add `/` to PERSISTENT_STATE_PATHS and turn the whole
+//     filesystem into mutable state, or (b) inject a yip stage that runs
+//     before our bootstrap script. We deliberately keep this content static,
+//     package-private, and zero-arg from the template engine so no field on
+//     TemplateData can influence it. The cloudconfig-rendering-safety skill
+//     calls this out explicitly.
+//
+//  2. Why /run/cos/extra-layout.env and not /run/cos/cos-layout.env?
+//     immucore reads BOTH files when it computes the runtime persistence
+//     overlay:
+//       - /run/cos/cos-layout.env       (primary, written by Kairos's own
+//                                        00_rootfs.yaml in the base image)
+//       - /run/cos/extra-layout.env     (additive, intended for downstream
+//                                        consumers like us)
+//     immucore's loader UNIONs PERSISTENT_STATE_PATHS across both files (see
+//     immucore steps_shared.go — keys are split on whitespace and deduped).
+//     The yip "Environment" plugin under the hood is godotenv, which on a
+//     single-file write OVERWRITES values on key collision. If we wrote to
+//     cos-layout.env we would either (a) clobber the base-image paths (losing
+//     /etc, /var/lib, etc.) or (b) require us to read+merge the existing file
+//     ourselves, which is brittle. Writing to extra-layout.env is the
+//     contract immucore exposes for downstream additions.
+//
+//  3. Why these twelve paths and only these twelve?
+//     They are exactly the directories the CAPI provider's own cloud-config
+//     (in this package's templates) writes to OR depends on after first boot:
+//       /etc/cni            — CNI plugin configs (workloads)
+//       /etc/k0s            — k0s config + token file (worker join)
+//       /etc/kubernetes     — kubeconfigs, manifests staging
+//       /etc/rancher        — k3s config + token file (worker join)
+//       /etc/ssh            — host keys (avoids MITM on reboot)
+//       /etc/systemd        — drop-in units we install (post-bootstrap, lb-sans)
+//       /var/lib/cni        — CNI runtime state
+//       /var/lib/containerd — container image cache + state
+//       /var/lib/k0s        — k0s data dir (etcd-like state, PKI)
+//       /var/lib/kubelet    — kubelet state (volumes, pods)
+//       /var/lib/rancher    — k3s data dir (etcd-like state, PKI, manifests)
+//       /var/log            — journal/log retention across reboot
+//     The list is intentionally conservative: only directories this provider
+//     touches. We do not add /opt, /home, /root, or application paths — those
+//     are user responsibilities, addressable via Spec.Files writing
+//     /system/oem/91_*.yaml on a per-cluster basis.
+//
+//     Adding paths here expands the persistent surface on every cluster. Any
+//     edit needs a clear justification.
+//
+// The const is exported to no one. It is referenced only by the
+// `persistencyOEM` template func registered in funcs.go.
+const persistencyOEMContent = `name: "Kairos CAPI persistent state paths"
+stages:
+  rootfs:
+    - environment_file: /run/cos/extra-layout.env
+      environment:
+        PERSISTENT_STATE_PATHS: "/etc/cni /etc/k0s /etc/kubernetes /etc/rancher /etc/ssh /etc/systemd /var/lib/cni /var/lib/containerd /var/lib/k0s /var/lib/kubelet /var/lib/rancher /var/log"
+`
+
+// persistencyOEM returns the static OEM cloud-config content that declares the
+// persistent-state paths this provider depends on. It takes no arguments — the
+// content is intentionally not parameterizable; see the SECURITY notes above.
+//
+// The returned string is intended to be piped through `indent N` in templates
+// so it embeds cleanly under a `content: |` block-scalar.
+func persistencyOEM() string {
+	return persistencyOEMContent
+}

--- a/internal/bootstrap/persistency_test.go
+++ b/internal/bootstrap/persistency_test.go
@@ -1,0 +1,307 @@
+/*
+Copyright 2024 The Kairos CAPI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	yaml "gopkg.in/yaml.v3"
+)
+
+// expectedPersistentStatePaths is the locked, alphabetically-sorted list of
+// directories the provider declares persistent. Any change to this set MUST be
+// accompanied by an explicit decision — see the SECURITY block in
+// persistency.go for the rationale.
+//
+// The test that consumes this list (TestPersistencyOEMContentPathsAreConservative)
+// is intentionally strict: it fails on ANY drift (additions OR removals), so a
+// drive-by edit cannot quietly expand the persistent surface across every
+// cluster the provider boots.
+var expectedPersistentStatePaths = []string{
+	"/etc/cni",
+	"/etc/k0s",
+	"/etc/kubernetes",
+	"/etc/rancher",
+	"/etc/ssh",
+	"/etc/systemd",
+	"/var/lib/cni",
+	"/var/lib/containerd",
+	"/var/lib/k0s",
+	"/var/lib/kubelet",
+	"/var/lib/rancher",
+	"/var/log",
+}
+
+// TestPersistencyOEMContentValidYAML asserts the const itself is well-formed
+// YAML in the shape yip expects: a top-level `name` string and a `stages.rootfs`
+// list whose first entry declares an environment_file plus an environment
+// map containing PERSISTENT_STATE_PATHS.
+func TestPersistencyOEMContentValidYAML(t *testing.T) {
+	var doc map[string]any
+	if err := yaml.Unmarshal([]byte(persistencyOEMContent), &doc); err != nil {
+		t.Fatalf("persistencyOEMContent did not parse as YAML: %v", err)
+	}
+
+	name, ok := doc["name"].(string)
+	if !ok {
+		t.Fatalf("top-level `name` missing or not a string: %T %#v", doc["name"], doc["name"])
+	}
+	if name == "" {
+		t.Errorf("top-level `name` is empty")
+	}
+
+	stages, ok := doc["stages"].(map[string]any)
+	if !ok {
+		t.Fatalf("top-level `stages` missing or not a map: %T %#v", doc["stages"], doc["stages"])
+	}
+
+	rootfsRaw, ok := stages["rootfs"].([]any)
+	if !ok {
+		t.Fatalf("stages.rootfs missing or not a list: %T %#v", stages["rootfs"], stages["rootfs"])
+	}
+	if len(rootfsRaw) == 0 {
+		t.Fatalf("stages.rootfs is empty")
+	}
+
+	entry, ok := rootfsRaw[0].(map[string]any)
+	if !ok {
+		t.Fatalf("stages.rootfs[0] is not a map: %T %#v", rootfsRaw[0], rootfsRaw[0])
+	}
+
+	envFile, ok := entry["environment_file"].(string)
+	if !ok {
+		t.Fatalf("stages.rootfs[0].environment_file missing or not a string: %T %#v", entry["environment_file"], entry["environment_file"])
+	}
+	if envFile != "/run/cos/extra-layout.env" {
+		// The choice of extra-layout.env (not cos-layout.env) is documented in
+		// persistency.go's SECURITY block as the contract immucore exposes for
+		// downstream persistent-path additions. A drift here would silently
+		// either clobber the base-image paths or fail to register ours.
+		t.Errorf("environment_file mismatch:\n  got: %q\n want: %q", envFile, "/run/cos/extra-layout.env")
+	}
+
+	env, ok := entry["environment"].(map[string]any)
+	if !ok {
+		t.Fatalf("stages.rootfs[0].environment missing or not a map: %T %#v", entry["environment"], entry["environment"])
+	}
+	pathsRaw, ok := env["PERSISTENT_STATE_PATHS"].(string)
+	if !ok {
+		t.Fatalf("stages.rootfs[0].environment.PERSISTENT_STATE_PATHS missing or not a string: %T %#v",
+			env["PERSISTENT_STATE_PATHS"], env["PERSISTENT_STATE_PATHS"])
+	}
+	if pathsRaw == "" {
+		t.Errorf("PERSISTENT_STATE_PATHS is empty")
+	}
+}
+
+// TestPersistencyOEMContentPathsAreConservative asserts the set of paths is
+// EXACTLY the documented list. The check is order-independent (immucore
+// whitespace-splits and unions) but content-strict (additions OR removals
+// both fail). This is the gate that prevents accidental expansion of the
+// persistent surface on every cluster the provider boots — adding a path here
+// makes it persistent for every user of every CAPI provider release, so an
+// explicit edit + review of expectedPersistentStatePaths is required.
+func TestPersistencyOEMContentPathsAreConservative(t *testing.T) {
+	var doc map[string]any
+	if err := yaml.Unmarshal([]byte(persistencyOEMContent), &doc); err != nil {
+		t.Fatalf("persistencyOEMContent did not parse: %v", err)
+	}
+	stages := doc["stages"].(map[string]any)
+	rootfs := stages["rootfs"].([]any)
+	entry := rootfs[0].(map[string]any)
+	env := entry["environment"].(map[string]any)
+	pathsRaw := env["PERSISTENT_STATE_PATHS"].(string)
+
+	gotPaths := strings.Fields(pathsRaw)
+	sort.Strings(gotPaths)
+
+	want := make([]string, len(expectedPersistentStatePaths))
+	copy(want, expectedPersistentStatePaths)
+	sort.Strings(want)
+
+	if len(gotPaths) != len(want) {
+		t.Fatalf("PERSISTENT_STATE_PATHS path count mismatch:\n  got %d: %v\n want %d: %v",
+			len(gotPaths), gotPaths, len(want), want)
+	}
+	for i, p := range want {
+		if gotPaths[i] != p {
+			t.Errorf("PERSISTENT_STATE_PATHS[%d] mismatch:\n  got: %q\n want: %q\n full got:  %v\n full want: %v",
+				i, gotPaths[i], p, gotPaths, want)
+		}
+	}
+}
+
+// renderCaseForPersistency is the matrix entry used by the per-template
+// inclusion tests below. Each case isolates the rendered template under test
+// to a minimal valid TemplateData so the assertion below operates on real
+// renderer output, not just the const.
+type renderCaseForPersistency struct {
+	name   string
+	data   TemplateData
+	render func(TemplateData) (string, error)
+}
+
+func persistencyRenderCases() []renderCaseForPersistency {
+	// CAPK = IsKubeVirt true; CAPV = IsKubeVirt false. Minimal valid input for
+	// each is a control-plane single-node with a hostname; the templates
+	// branch on Role + IsKubeVirt + ProviderID but the persistency block
+	// itself must appear regardless.
+	return []renderCaseForPersistency{
+		{
+			name: "K0sCAPK",
+			data: TemplateData{
+				Role:       "control-plane",
+				SingleNode: true,
+				Hostname:   "cp-0",
+				UserName:   "kairos",
+				IsKubeVirt: true,
+			},
+			render: RenderK0sCloudConfig,
+		},
+		{
+			name: "K0sCAPV",
+			data: TemplateData{
+				Role:       "control-plane",
+				SingleNode: true,
+				Hostname:   "cp-0",
+				UserName:   "kairos",
+				IsKubeVirt: false,
+				// Trigger write_files: previously the k0s CAPV write_files
+				// block was entirely conditional. After KD-23 it is
+				// unconditional; this test guards that promotion.
+			},
+			render: RenderK0sCloudConfig,
+		},
+		{
+			name: "K3sCAPK",
+			data: TemplateData{
+				Role:       "control-plane",
+				SingleNode: true,
+				Hostname:   "cp-0",
+				UserName:   "kairos",
+				IsKubeVirt: true,
+			},
+			render: RenderK3sCloudConfig,
+		},
+		{
+			name: "K3sCAPV",
+			data: TemplateData{
+				Role:       "control-plane",
+				SingleNode: true,
+				Hostname:   "cp-0",
+				UserName:   "kairos",
+				IsKubeVirt: false,
+			},
+			render: RenderK3sCloudConfig,
+		},
+	}
+}
+
+// TestRender_IncludesPersistencyFile asserts every renderer (k0s/k3s × CAPK/CAPV)
+// emits the persistency write_files entry at the documented path and that the
+// inner content parses as YAML with the documented structure.
+//
+// The assertion walks the rendered cloud-config from the outside in:
+//  1. The outer YAML parses.
+//  2. write_files is a non-empty list.
+//  3. The persistency entry is present (filename match).
+//  4. The entry's `content` string parses as YAML.
+//  5. The inner doc has the expected name + stages.rootfs.PERSISTENT_STATE_PATHS.
+//
+// This is the round-trip test the architect plan calls for: substring
+// assertions alone are insufficient because they can't catch broken
+// indentation that survives `grep` but breaks YAML parsing on the node.
+func TestRender_IncludesPersistencyFile(t *testing.T) {
+	for _, tc := range persistencyRenderCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := tc.render(tc.data)
+			if err != nil {
+				t.Fatalf("render failed: %v", err)
+			}
+
+			// (1) Outer YAML must parse.
+			doc := parseRendered(t, out)
+
+			// (2) write_files must exist.
+			rawWF, ok := doc["write_files"].([]any)
+			if !ok {
+				t.Fatalf("write_files missing or not a list: %T %#v", doc["write_files"], doc["write_files"])
+			}
+			if len(rawWF) == 0 {
+				t.Fatalf("write_files is empty")
+			}
+
+			// (3) Find the persistency entry by path.
+			const wantPath = "/system/oem/12_kairos-capi-persistency.yaml"
+			var entry map[string]any
+			for _, raw := range rawWF {
+				e, ok := raw.(map[string]any)
+				if !ok {
+					continue
+				}
+				if p, _ := e["path"].(string); p == wantPath {
+					entry = e
+					break
+				}
+			}
+			if entry == nil {
+				t.Fatalf("write_files entry with path=%q not found", wantPath)
+			}
+
+			// File metadata must match what the template hard-codes.
+			if perms, _ := entry["permissions"].(string); perms != "0644" {
+				t.Errorf("persistency entry permissions = %q, want %q", perms, "0644")
+			}
+
+			// (4) Inner content must parse as YAML.
+			content, ok := entry["content"].(string)
+			if !ok {
+				t.Fatalf("persistency entry content missing or not a string: %T %#v", entry["content"], entry["content"])
+			}
+			var inner map[string]any
+			if err := yaml.Unmarshal([]byte(content), &inner); err != nil {
+				t.Fatalf("persistency content did not parse as YAML: %v\n---\n%s", err, content)
+			}
+
+			// (5) Inner doc shape.
+			if name, _ := inner["name"].(string); name == "" {
+				t.Errorf("persistency inner doc: top-level `name` missing")
+			}
+			stages, ok := inner["stages"].(map[string]any)
+			if !ok {
+				t.Fatalf("persistency inner doc: stages missing or wrong type: %T", inner["stages"])
+			}
+			rootfs, ok := stages["rootfs"].([]any)
+			if !ok || len(rootfs) == 0 {
+				t.Fatalf("persistency inner doc: stages.rootfs missing/empty: %T %#v", stages["rootfs"], stages["rootfs"])
+			}
+			rootEntry, ok := rootfs[0].(map[string]any)
+			if !ok {
+				t.Fatalf("persistency inner doc: stages.rootfs[0] not a map: %T", rootfs[0])
+			}
+			env, ok := rootEntry["environment"].(map[string]any)
+			if !ok {
+				t.Fatalf("persistency inner doc: stages.rootfs[0].environment missing or wrong type: %T", rootEntry["environment"])
+			}
+			if _, ok := env["PERSISTENT_STATE_PATHS"].(string); !ok {
+				t.Errorf("persistency inner doc: PERSISTENT_STATE_PATHS missing or not a string: %T", env["PERSISTENT_STATE_PATHS"])
+			}
+		})
+	}
+}

--- a/internal/bootstrap/template_adversarial_test.go
+++ b/internal/bootstrap/template_adversarial_test.go
@@ -296,6 +296,149 @@ func TestRender_RejectsControlChars(t *testing.T) {
 	}
 }
 
+// TestPersistencyBlockDoesNotLeakUserInput asserts the persistency
+// write_files entry (KD-23) is content-static — no user-controlled string
+// from TemplateData can appear inside the persistency subtree of the
+// rendered cloud-config.
+//
+// The block is supposed to be a compile-time constant (see persistency.go's
+// SECURITY notes) and its template-func is zero-arg, but the safety story
+// breaks if a future template edit accidentally interpolates a user field
+// into the wrong YAML scope and yip then expands PERSISTENT_STATE_PATHS to
+// include a user-controlled directory. This test renders with adversarial
+// markers in every user-controlled string field and then asserts none of
+// those markers appear anywhere inside the persistency entry's `content`.
+func TestPersistencyBlockDoesNotLeakUserInput(t *testing.T) {
+	// Distinct sentinel strings so a leak names the exact field that bled
+	// through. The values are chosen to be plain ASCII (no `\n`/`\r`/NUL
+	// which validateTemplateData rejects) yet implausible as accidental
+	// matches against any path in expectedPersistentStatePaths.
+	const (
+		hostnameMark        = "ADV-HOSTNAME-LEAK"
+		userNameMark        = "ADV-USERNAME-LEAK"
+		userPasswordMark    = "ADV-USERPASSWORD-LEAK"
+		workerTokenMark     = "ADV-WORKERTOKEN-LEAK"
+		k3sTokenMark        = "ADV-K3STOKEN-LEAK"
+		k3sServerURLMark    = "https://ADV-K3SSERVER-LEAK:6443"
+		sshKeyMark          = "ssh-rsa ADV-SSHKEY-LEAK"
+		gitHubUserMark      = "ADV-GITHUBUSER-LEAK"
+		hostnamePrefixMark  = "ADV-HOSTPREFIX-LEAK"
+		groupMark           = "ADV-GROUP-LEAK"
+		dnsMark             = "203.0.113.7"
+		podCIDRMark         = "203.0.113.8/24"
+		serviceCIDRMark     = "203.0.113.16/28"
+		primaryIPMark       = "203.0.113.9"
+		machineNameMark     = "ADV-MACHINE-LEAK"
+		clusterNSMark       = "ADV-CLUSTERNS-LEAK"
+		lbServiceNameMark   = "ADV-LBNAME-LEAK"
+		lbServiceNSMark     = "ADV-LBNS-LEAK"
+		lbEndpointMark      = "203.0.113.10"
+		mgmtTokenMark       = "ADV-MGMTTOKEN-LEAK"
+		mgmtSecretNameMark  = "ADV-MGMTSECRET-LEAK"
+		mgmtSecretNSMark    = "ADV-MGMTNS-LEAK"
+		mgmtAPIServerMark   = "https://ADV-MGMTAPI-LEAK:6443"
+	)
+
+	allMarks := []string{
+		hostnameMark, userNameMark, userPasswordMark, workerTokenMark,
+		k3sTokenMark, k3sServerURLMark, sshKeyMark, gitHubUserMark,
+		hostnamePrefixMark, groupMark, dnsMark, podCIDRMark, serviceCIDRMark,
+		primaryIPMark, machineNameMark, clusterNSMark, lbServiceNameMark,
+		lbServiceNSMark, lbEndpointMark, mgmtTokenMark, mgmtSecretNameMark,
+		mgmtSecretNSMark, mgmtAPIServerMark,
+	}
+
+	mkData := func(isKV bool, dist string) TemplateData {
+		d := TemplateData{
+			Role:                                "control-plane",
+			SingleNode:                          true,
+			Hostname:                            hostnameMark,
+			UserName:                            userNameMark,
+			UserPassword:                        userPasswordMark,
+			UserGroups:                          []string{groupMark},
+			GitHubUser:                          gitHubUserMark,
+			SSHPublicKey:                        sshKeyMark,
+			HostnamePrefix:                      hostnamePrefixMark,
+			DNSServers:                          []string{dnsMark},
+			PodCIDR:                             podCIDRMark,
+			ServiceCIDR:                         serviceCIDRMark,
+			PrimaryIP:                           primaryIPMark,
+			MachineName:                         machineNameMark,
+			ClusterNS:                           clusterNSMark,
+			IsKubeVirt:                          isKV,
+			ControlPlaneLBServiceName:           lbServiceNameMark,
+			ControlPlaneLBServiceNamespace:      lbServiceNSMark,
+			ControlPlaneLBEndpoint:              lbEndpointMark,
+			ManagementKubeconfigToken:           mgmtTokenMark,
+			ManagementKubeconfigSecretName:      mgmtSecretNameMark,
+			ManagementKubeconfigSecretNamespace: mgmtSecretNSMark,
+			ManagementAPIServer:                 mgmtAPIServerMark,
+		}
+		if dist == "k3s" {
+			// k3s control-plane templates don't read WorkerToken (workers
+			// only); set K3sToken so the field is still exercised on the
+			// worker-template-share path. Use a control-plane role here so
+			// the persistency block renders; set K3sToken anyway as a
+			// belt-and-braces check that even an unused-in-this-role field
+			// doesn't leak.
+			d.K3sToken = k3sTokenMark
+			d.K3sServerURL = k3sServerURLMark
+		} else {
+			d.WorkerToken = workerTokenMark
+		}
+		return d
+	}
+
+	for _, dist := range []string{"k0s", "k3s"} {
+		for _, isKV := range []bool{false, true} {
+			tag := dist
+			if isKV {
+				tag += "/capk"
+			} else {
+				tag += "/capv"
+			}
+			t.Run(tag, func(t *testing.T) {
+				out, err := renderForDist(dist, mkData(isKV, dist))
+				if err != nil {
+					t.Fatalf("render failed: %v", err)
+				}
+
+				// Walk the rendered YAML to the persistency entry's inner content.
+				doc := parseRendered(t, out)
+				rawWF, ok := doc["write_files"].([]any)
+				if !ok {
+					t.Fatalf("write_files missing or not a list")
+				}
+				const wantPath = "/system/oem/12_kairos-capi-persistency.yaml"
+				var content string
+				for _, raw := range rawWF {
+					e, ok := raw.(map[string]any)
+					if !ok {
+						continue
+					}
+					if p, _ := e["path"].(string); p == wantPath {
+						content, _ = e["content"].(string)
+						break
+					}
+				}
+				if content == "" {
+					t.Fatalf("persistency entry with path=%q not found or content empty", wantPath)
+				}
+
+				// None of the adversarial markers may appear inside the
+				// persistency content. (We assert on the raw content string
+				// rather than the parsed inner doc to catch leaks even into
+				// YAML comments or structurally-broken regions.)
+				for _, mark := range allMarks {
+					if strings.Contains(content, mark) {
+						t.Errorf("user-controlled value %q leaked into persistency block content", mark)
+					}
+				}
+			})
+		}
+	}
+}
+
 // TestSafeIndent_CRLF asserts the indent function strips \r so Windows-authored
 // Manifest.Content doesn't leak \r into the YAML block scalar (which would
 // then propagate into files written on the node).

--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capk.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capk.yaml.tmpl
@@ -80,8 +80,13 @@ k0s-worker:
 
 {{- end }}
 
-{{- if or .IsKubeVirt (and (eq .Role "control-plane") (or .PodCIDR .ServiceCIDR)) (and (ne .Role "control-plane") .WorkerToken) }}
 write_files:
+  - path: /system/oem/12_kairos-capi-persistency.yaml
+    permissions: "0644"
+    owner: 0
+    group: 0
+    content: |
+{{ persistencyOEM | indent 6 }}
   {{- if and (eq .Role "control-plane") (or .PodCIDR .ServiceCIDR .IsKubeVirt) }}
   - path: /etc/k0s/k0s.yaml
     permissions: "0644"
@@ -531,7 +536,6 @@ MANIFEST_EOF
       exit 1
   {{- end }}
   {{- end }}
-{{- end }}
 
 {{- /* DNS overrides and post-bootstrap service */}}
 stages:

--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
@@ -80,8 +80,13 @@ k0s-worker:
 
 {{- end }}
 
-{{- if or (and (eq .Role "control-plane") (or .PodCIDR .ServiceCIDR)) (and (ne .Role "control-plane") .WorkerToken) }}
 write_files:
+  - path: /system/oem/12_kairos-capi-persistency.yaml
+    permissions: "0644"
+    owner: 0
+    group: 0
+    content: |
+{{ persistencyOEM | indent 6 }}
   {{- if and (eq .Role "control-plane") (or .PodCIDR .ServiceCIDR) }}
   - path: /etc/k0s/k0s.yaml
     permissions: "0644"
@@ -109,7 +114,6 @@ write_files:
     content: |
       {{ .WorkerToken }}
   {{- end }}
-{{- end }}
 
 {{- /* DNS overrides and post-bootstrap service */}}
 stages:

--- a/internal/bootstrap/templates/k3s_kairos_cloud_config_capk.yaml.tmpl
+++ b/internal/bootstrap/templates/k3s_kairos_cloud_config_capk.yaml.tmpl
@@ -88,6 +88,12 @@ k3s-agent:
 
 {{- /* write_files: worker token + post-bootstrap service/script (like k0s CAPK) */}}
 write_files:
+  - path: /system/oem/12_kairos-capi-persistency.yaml
+    permissions: "0644"
+    owner: 0
+    group: 0
+    content: |
+{{ persistencyOEM | indent 6 }}
   {{- if and (eq .Role "control-plane") .ProviderID }}
   - path: /etc/rancher/k3s/config.yaml.d/90-provider-id.yaml
     permissions: "0644"

--- a/internal/bootstrap/templates/k3s_kairos_cloud_config_capv.yaml.tmpl
+++ b/internal/bootstrap/templates/k3s_kairos_cloud_config_capv.yaml.tmpl
@@ -82,6 +82,12 @@ k3s-agent:
 
 {{- /* write_files: worker token + post-bootstrap service/script (like k0s CAPK) */}}
 write_files:
+  - path: /system/oem/12_kairos-capi-persistency.yaml
+    permissions: "0644"
+    owner: 0
+    group: 0
+    content: |
+{{ persistencyOEM | indent 6 }}
   {{- if and (eq .Role "control-plane") .ProviderID }}
   - path: /etc/rancher/k3s/config.yaml.d/90-provider-id.yaml
     permissions: "0644"


### PR DESCRIPTION
## Summary

- Injects `/system/oem/12_kairos-capi-persistency.yaml` into every rendered cloud-config via `write_files`, making the provider's persistence dependency on Kairos's immutable overlay explicit and self-contained (KD-23).
- Documents the new behavior in `docs/API_REFERENCE.md` ("Persistence behavior" section) and adds a reboot survival test recipe to `docs/TESTING.md`.

## What this fixes

KD-23: On a custom Kairos image that does not ship the stock `kairos-init/pkg/bundled/cloudconfigs/00_rootfs.yaml` OEM config, every CAPI-provisioned file under `/etc` and `/var/lib` is lost on the first reboot because immucore's default `RW_PATHS` maps those directories to ephemeral tmpfs overlays. The provider now unconditionally writes its own additive persistence manifest, so the twelve directories it depends on (k0s/k3s state, CNI config, SSH host keys, systemd units, container runtime state) survive reboots and A/B upgrades regardless of the base image's OEM layer.

The twelve persisted paths: `/etc/cni`, `/etc/k0s`, `/etc/kubernetes`, `/etc/rancher`, `/etc/ssh`, `/etc/systemd`, `/var/lib/cni`, `/var/lib/containerd`, `/var/lib/k0s`, `/var/lib/kubelet`, `/var/lib/rancher`, `/var/log`.

## Implementation notes

**Three-commit structure:**

- `e7be036` — Production change. New `internal/bootstrap/persistency.go` (static OEM content + zero-arg template func), `funcs.go` registration, four template edits, `persistency_test.go` (307 lines covering path-list conservation, per-template render assertions, and an adversarial test confirming no user-controlled string can reach the persistency block).
- `f011947` — Docs. `API_REFERENCE.md` "Persistence behavior" section + ToC update; `TESTING.md` "Reboot survival test" paragraph.
- `758f9be` — Tech-writer pass correction: `/oem/9*` → `/system/oem/9*` in the user-path guidance. The earlier draft referenced the wrong Kairos OEM directory and would have silently misled users.

**`extra-layout.env` vs `cos-layout.env`** — The provider writes to `/run/cos/extra-layout.env`, not the primary `cos-layout.env`. immucore unions `PERSISTENT_STATE_PATHS` across both files. Writing to the primary file would clobber base-image paths because godotenv overwrites on key collision; the `extra-layout.env` channel is the contract immucore exposes for downstream additions. Cross-references: `mudler/yip/pkg/plugins/environment.go` for the overwrite semantic, `kairos-io/immucore/pkg/state/steps_shared.go:171-187` for the union/dedupe semantic.

**Content is a compile-time constant.** `persistencyOEMContent` in `persistency.go` is not parameterizable. No field on `TemplateData` can influence what becomes persistent. This is intentional — an attacker controlling a KairosConfig field could otherwise inject arbitrary paths into `PERSISTENT_STATE_PATHS`. The adversarial test (`TestPersistencyBlockDoesNotLeakUserInput` in `template_adversarial_test.go`) asserts this property across 23 sentinels and all four dist × infra combinations.

**Second-boot-onward semantic.** Documented in `docs/API_REFERENCE.md`. The first install boot consumes the cloud-config directly; reboots from the second onward use the on-disk `/system/oem/12_kairos-capi-persistency.yaml` file picked up by immucore at the `rootfs` stage. This matches how Kairos handles every OEM cloud-config file.

## Validation

```
go vet ./...                            PASS
go build ./...                          PASS
go test ./internal/bootstrap/...        PASS (6 new tests + 50+ existing)
make build                              PASS
make manifests                          PASS (no CRD diff — pure rendering change)
```

`security-architect` pre-merge review: **APPROVE** with no required changes (all 10 architect-supplied checklist items pass; const has zero template variables; FuncMap is zero-arg; round-trip and no-leak tests cover the rendering paths).

## Out of scope

- **KD-34** (in-place upgrade persistence guarantees via `kairos-agent upgrade` or kairos-operator NodeOpUpgrade) — tracked separately. KD-23 is its prerequisite; KD-34 will exercise the persistence in the upgrade path itself.
- **CAPD reboot survival test** — Docker container restart does not exercise the Kairos boot path; excluded by design.
- **HA control planes** — still rejected by webhook (KD-5b / KD-25 tracking, not in alpha-2).
- **Opt-out via CRD field** — explicitly NOT added. The persisted paths are properties of what the CAPI provider writes, not user preference. A future `Spec.PersistencePaths.Disabled` can be added later if real usage demands; the reverse (adding a field once shipped) is irreversible v1beta2 surface.
