### PR TITLE
fix(bootstrap): close Hostname RCE + shquote shell-context fields + dedup k0s-CAPK template (KD-22, KD-28, KD-43, KD-2 follow-up)

### DIFF
--- a/api/bootstrap/v1beta2/kairosconfig_types.go
+++ b/api/bootstrap/v1beta2/kairosconfig_types.go
@@ -256,16 +256,25 @@ type UserPasswordSecretReference struct {
 	Namespace string `json:"namespace,omitempty"`
 }
 
-// Manifest represents a Kubernetes manifest file to be deployed by k0s
-// The manifest will be placed at /var/lib/k0s/manifests/{Name}/{File} and automatically
-// applied by k0s when the cluster starts.
+// Manifest represents a Kubernetes manifest file to be deployed by the
+// workload distribution. The manifest is placed at:
+//   - k0s: /var/lib/k0s/manifests/{Name}/{File}
+//   - k3s: /var/lib/rancher/k3s/server/manifests/{Name}/{File}
+//
+// and is auto-applied by the distribution at server start. Manifests are
+// applied on control-plane nodes only.
 type Manifest struct {
-	// Name is the directory name under /var/lib/k0s/manifests/
-	// This creates a directory structure: /var/lib/k0s/manifests/{Name}/{File}
+	// Name is the directory name under the distribution's manifests directory.
+	// This creates a directory structure:
+	//   - k0s: /var/lib/k0s/manifests/{Name}/{File}
+	//   - k3s: /var/lib/rancher/k3s/server/manifests/{Name}/{File}
 	// +kubebuilder:validation:Required
 	Name string `json:"name"`
 
-	// File is the filename within the Name directory
+	// File is the filename within the Name directory. The distribution's
+	// manifest loader auto-applies it from:
+	//   - k0s: /var/lib/k0s/manifests/{Name}/{File}
+	//   - k3s: /var/lib/rancher/k3s/server/manifests/{Name}/{File}
 	// +kubebuilder:validation:Required
 	File string `json:"file"`
 

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_kairosconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_kairosconfigs.yaml
@@ -226,20 +226,30 @@ spec:
                   k3s: /var/lib/rancher/k3s/server/manifests/{Name}/{File}
                 items:
                   description: |-
-                    Manifest represents a Kubernetes manifest file to be deployed by k0s
-                    The manifest will be placed at /var/lib/k0s/manifests/{Name}/{File} and automatically
-                    applied by k0s when the cluster starts.
+                    Manifest represents a Kubernetes manifest file to be deployed by the
+                    workload distribution. The manifest is placed at:
+                      - k0s: /var/lib/k0s/manifests/{Name}/{File}
+                      - k3s: /var/lib/rancher/k3s/server/manifests/{Name}/{File}
+
+                    and is auto-applied by the distribution at server start. Manifests are
+                    applied on control-plane nodes only.
                   properties:
                     content:
                       description: Content is the manifest YAML content
                       type: string
                     file:
-                      description: File is the filename within the Name directory
+                      description: |-
+                        File is the filename within the Name directory. The distribution's
+                        manifest loader auto-applies it from:
+                          - k0s: /var/lib/k0s/manifests/{Name}/{File}
+                          - k3s: /var/lib/rancher/k3s/server/manifests/{Name}/{File}
                       type: string
                     name:
                       description: |-
-                        Name is the directory name under /var/lib/k0s/manifests/
-                        This creates a directory structure: /var/lib/k0s/manifests/{Name}/{File}
+                        Name is the directory name under the distribution's manifests directory.
+                        This creates a directory structure:
+                          - k0s: /var/lib/k0s/manifests/{Name}/{File}
+                          - k3s: /var/lib/rancher/k3s/server/manifests/{Name}/{File}
                       type: string
                   required:
                   - content

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_kairosconfigtemplates.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_kairosconfigtemplates.yaml
@@ -231,20 +231,30 @@ spec:
                           k3s: /var/lib/rancher/k3s/server/manifests/{Name}/{File}
                         items:
                           description: |-
-                            Manifest represents a Kubernetes manifest file to be deployed by k0s
-                            The manifest will be placed at /var/lib/k0s/manifests/{Name}/{File} and automatically
-                            applied by k0s when the cluster starts.
+                            Manifest represents a Kubernetes manifest file to be deployed by the
+                            workload distribution. The manifest is placed at:
+                              - k0s: /var/lib/k0s/manifests/{Name}/{File}
+                              - k3s: /var/lib/rancher/k3s/server/manifests/{Name}/{File}
+
+                            and is auto-applied by the distribution at server start. Manifests are
+                            applied on control-plane nodes only.
                           properties:
                             content:
                               description: Content is the manifest YAML content
                               type: string
                             file:
-                              description: File is the filename within the Name directory
+                              description: |-
+                                File is the filename within the Name directory. The distribution's
+                                manifest loader auto-applies it from:
+                                  - k0s: /var/lib/k0s/manifests/{Name}/{File}
+                                  - k3s: /var/lib/rancher/k3s/server/manifests/{Name}/{File}
                               type: string
                             name:
                               description: |-
-                                Name is the directory name under /var/lib/k0s/manifests/
-                                This creates a directory structure: /var/lib/k0s/manifests/{Name}/{File}
+                                Name is the directory name under the distribution's manifests directory.
+                                This creates a directory structure:
+                                  - k0s: /var/lib/k0s/manifests/{Name}/{File}
+                                  - k3s: /var/lib/rancher/k3s/server/manifests/{Name}/{File}
                               type: string
                           required:
                           - content

--- a/internal/bootstrap/funcs.go
+++ b/internal/bootstrap/funcs.go
@@ -42,6 +42,7 @@ func newFuncMap() template.FuncMap {
 	return template.FuncMap{
 		"quote":          quote,
 		"toYaml":         toYaml,
+		"shquote":        shquote,
 		"indent":         safeIndent,
 		"nindent":        nindent,
 		"trimSuffix":     trimSuffix,
@@ -80,6 +81,45 @@ func quote(v any) (string, error) {
 		return "", err
 	}
 	return strings.TrimRight(string(b), "\n"), nil
+}
+
+// shquote returns a POSIX-shell-safe single-quoted representation of s,
+// INCLUDING the surrounding single quotes. Callers therefore write
+//
+//	local var={{ .Field | shquote }}
+//
+// and NOT
+//
+//	local var='{{ .Field | shquote }}'   // wrong: double-quotes the quotes
+//
+// Use shquote for any user-influenced value that lands inside a shell
+// command in a rendered template (e.g. systemd ExecStart= lines, runcmd:
+// entries, the bash script bodies emitted under write_files: / stages:
+// initramfs.files:). The `quote` filter is YAML-aware but not shell-aware:
+// yaml.v3 emits double-quoted scalars for values that need disambiguation
+// from booleans/ints/null, and bash double-quoted strings evaluate `$()`,
+// backticks, `${VAR}`, and `\`, so handing a `quote`-rendered scalar to
+// bash through a double-quoted assignment is unsafe. shquote sidesteps the
+// problem by emitting a POSIX single-quoted literal, which bash NEVER
+// interprets (no escapes, no expansions). The only character that cannot
+// appear inside a POSIX single-quoted string is the single quote itself;
+// shquote escapes embedded ones with the standard '\” close-open-quote
+// sequence.
+//
+// Threat model: a CAPI infrastructure provider (CAPK in particular) could,
+// in principle, populate a TemplateData field with a value containing
+// shell metacharacters. The fields that pass through shquote today are
+// .ManagementAPIServer, .ManagementKubeconfigToken, .PrimaryIP,
+// .MachineName, .ClusterNS, and .ControlPlaneLBEndpoint — the
+// management-endpoint set introduced for the CAPK kubeconfig-push and
+// post-bootstrap SAN-patch flows. None of these are intended to carry
+// shell-active input today, but the renderer is the LAST line of defense
+// between user/provider input and root-privileged userdata.
+//
+// See internal/bootstrap/CLAUDE.md §2 and the cloudconfig-rendering-safety
+// skill for the broader rules.
+func shquote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 // toYaml marshals any value (typically a slice or map) and trims the trailing

--- a/internal/bootstrap/template_adversarial_test.go
+++ b/internal/bootstrap/template_adversarial_test.go
@@ -138,10 +138,10 @@ var adversarialPayloads = map[string]string{
 // list-item indentation contract or (b) shell quoting in the file-content
 // block scalars where some fields are also embedded.
 var controlCharPayloads = map[string]string{
-	"newline injection":  "foo\nshell: /bin/sh",
-	"crlf newline":       "foo\r\nbar",
-	"yaml doc separator": "---\nevil: true",
-	"NUL byte":           "foo\x00bar",
+	"newline injection":    "foo\nshell: /bin/sh",
+	"crlf newline":         "foo\r\nbar",
+	"yaml doc separator":   "---\nevil: true",
+	"NUL byte":             "foo\x00bar",
 	"bare carriage return": "foo\rbar",
 }
 
@@ -314,29 +314,29 @@ func TestPersistencyBlockDoesNotLeakUserInput(t *testing.T) {
 	// which validateTemplateData rejects) yet implausible as accidental
 	// matches against any path in expectedPersistentStatePaths.
 	const (
-		hostnameMark        = "ADV-HOSTNAME-LEAK"
-		userNameMark        = "ADV-USERNAME-LEAK"
-		userPasswordMark    = "ADV-USERPASSWORD-LEAK"
-		workerTokenMark     = "ADV-WORKERTOKEN-LEAK"
-		k3sTokenMark        = "ADV-K3STOKEN-LEAK"
-		k3sServerURLMark    = "https://ADV-K3SSERVER-LEAK:6443"
-		sshKeyMark          = "ssh-rsa ADV-SSHKEY-LEAK"
-		gitHubUserMark      = "ADV-GITHUBUSER-LEAK"
-		hostnamePrefixMark  = "ADV-HOSTPREFIX-LEAK"
-		groupMark           = "ADV-GROUP-LEAK"
-		dnsMark             = "203.0.113.7"
-		podCIDRMark         = "203.0.113.8/24"
-		serviceCIDRMark     = "203.0.113.16/28"
-		primaryIPMark       = "203.0.113.9"
-		machineNameMark     = "ADV-MACHINE-LEAK"
-		clusterNSMark       = "ADV-CLUSTERNS-LEAK"
-		lbServiceNameMark   = "ADV-LBNAME-LEAK"
-		lbServiceNSMark     = "ADV-LBNS-LEAK"
-		lbEndpointMark      = "203.0.113.10"
-		mgmtTokenMark       = "ADV-MGMTTOKEN-LEAK"
-		mgmtSecretNameMark  = "ADV-MGMTSECRET-LEAK"
-		mgmtSecretNSMark    = "ADV-MGMTNS-LEAK"
-		mgmtAPIServerMark   = "https://ADV-MGMTAPI-LEAK:6443"
+		hostnameMark       = "ADV-HOSTNAME-LEAK"
+		userNameMark       = "ADV-USERNAME-LEAK"
+		userPasswordMark   = "ADV-USERPASSWORD-LEAK"
+		workerTokenMark    = "ADV-WORKERTOKEN-LEAK"
+		k3sTokenMark       = "ADV-K3STOKEN-LEAK"
+		k3sServerURLMark   = "https://ADV-K3SSERVER-LEAK:6443"
+		sshKeyMark         = "ssh-rsa ADV-SSHKEY-LEAK"
+		gitHubUserMark     = "ADV-GITHUBUSER-LEAK"
+		hostnamePrefixMark = "ADV-HOSTPREFIX-LEAK"
+		groupMark          = "ADV-GROUP-LEAK"
+		dnsMark            = "203.0.113.7"
+		podCIDRMark        = "203.0.113.8/24"
+		serviceCIDRMark    = "203.0.113.16/28"
+		primaryIPMark      = "203.0.113.9"
+		machineNameMark    = "ADV-MACHINE-LEAK"
+		clusterNSMark      = "ADV-CLUSTERNS-LEAK"
+		lbServiceNameMark  = "ADV-LBNAME-LEAK"
+		lbServiceNSMark    = "ADV-LBNS-LEAK"
+		lbEndpointMark     = "203.0.113.10"
+		mgmtTokenMark      = "ADV-MGMTTOKEN-LEAK"
+		mgmtSecretNameMark = "ADV-MGMTSECRET-LEAK"
+		mgmtSecretNSMark   = "ADV-MGMTNS-LEAK"
+		mgmtAPIServerMark  = "https://ADV-MGMTAPI-LEAK:6443"
 	)
 
 	allMarks := []string{
@@ -551,4 +551,230 @@ func allUsers(t *testing.T, out string) []map[string]any {
 		users = append(users, m)
 	}
 	return users
+}
+
+// TestShquote_Unit asserts the POSIX single-quoting helper produces values
+// that bash cannot interpret. The contract is:
+//   - return value INCLUDES the surrounding single quotes;
+//   - embedded single quotes are escaped via the standard '\” close-open trick;
+//   - no other character receives special treatment — `$`, backticks, `;`,
+//     `&&`, `|`, `(` `)`, etc. are emitted verbatim and rely on the
+//     single-quoting to keep bash from interpreting them.
+func TestShquote_Unit(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", `''`},
+		{"plain", "hello", `'hello'`},
+		{"single_quote", "a'b", `'a'\''b'`},
+		{"double_quote", `a"b`, `'a"b'`},
+		{"dollar_subshell", "a$(rm -rf /)b", `'a$(rm -rf /)b'`},
+		{"backtick", "a`rm`b", "'a`rm`b'"},
+		{"semicolon", "a; rm -rf /", `'a; rm -rf /'`},
+		{"pipe_and", "a && evil", `'a && evil'`},
+		{"shell_redirect", "a > /tmp/x", `'a > /tmp/x'`},
+		{"glob", "a*b", `'a*b'`},
+		{"injection_close_then_evil", `'; rm -rf /; echo '`, `''\''; rm -rf /; echo '\'''`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shquote(tc.in)
+			if got != tc.want {
+				t.Errorf("shquote(%q) = %q; want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// shquoteCAPKAdversarialFields enumerates the 6 TemplateData fields that
+// land in shell-context positions in the CAPK templates (k0s + k3s). For
+// each, we render the two CAPK template variants with an adversarial
+// payload that injects shell metacharacters, then assert:
+//
+//  1. The rendered output is still parseable as YAML.
+//  2. The adversarial payload appears wrapped in POSIX single quotes
+//     (i.e. the shquote envelope).
+//  3. The dangerous fragments inside the payload (`; rm -rf /`, `$(rm)`)
+//     never appear UNQUOTED in the rendered output. They only ever appear
+//     inside a `'...'` envelope.
+//
+// Inputs without control characters (no `\n`, `\r`, NUL) bypass
+// validateTemplateData's reject-list and reach the template, so this test
+// exercises the renderer's escaping rather than the validator's.
+func TestShquoteFieldsAreShellSafe(t *testing.T) {
+	urlInjection := `https://api:6443'; rm -rf /; echo '`
+	tokenInjection := `evil-token'; rm -rf /; echo '`
+	ipInjection := `1.2.3.4'; rm -rf /; #`
+	nameInjection := `evil$(rm -rf /)`
+
+	type fieldCase struct {
+		name       string
+		payload    string
+		applyToK0s func(d *TemplateData)
+		applyToK3s func(d *TemplateData)
+	}
+
+	cases := []fieldCase{
+		{
+			name:       "ManagementAPIServer",
+			payload:    urlInjection,
+			applyToK0s: func(d *TemplateData) { d.ManagementAPIServer = urlInjection },
+			applyToK3s: func(d *TemplateData) { d.ManagementAPIServer = urlInjection },
+		},
+		{
+			name:       "ManagementKubeconfigToken",
+			payload:    tokenInjection,
+			applyToK0s: func(d *TemplateData) { d.ManagementKubeconfigToken = tokenInjection },
+			applyToK3s: func(d *TemplateData) { d.ManagementKubeconfigToken = tokenInjection },
+		},
+		{
+			name:       "PrimaryIP",
+			payload:    ipInjection,
+			applyToK0s: func(d *TemplateData) { d.PrimaryIP = ipInjection },
+			applyToK3s: func(d *TemplateData) { d.PrimaryIP = ipInjection },
+		},
+		{
+			name:       "MachineName",
+			payload:    nameInjection,
+			applyToK0s: func(d *TemplateData) { d.MachineName = nameInjection },
+			applyToK3s: func(d *TemplateData) { d.MachineName = nameInjection },
+		},
+		{
+			name:       "ClusterNS",
+			payload:    nameInjection,
+			applyToK0s: func(d *TemplateData) { d.ClusterNS = nameInjection },
+			applyToK3s: func(d *TemplateData) { d.ClusterNS = nameInjection },
+		},
+		{
+			name:       "ControlPlaneLBEndpoint",
+			payload:    urlInjection,
+			applyToK0s: func(d *TemplateData) { d.ControlPlaneLBEndpoint = urlInjection },
+			applyToK3s: func(d *TemplateData) { d.ControlPlaneLBEndpoint = urlInjection },
+		},
+	}
+
+	baseK0s := func() TemplateData {
+		return TemplateData{
+			Role:                                "control-plane",
+			SingleNode:                          true,
+			UserName:                            "kairos",
+			UserPassword:                        "kairos",
+			UserGroups:                          []string{"admin"},
+			IsKubeVirt:                          true,
+			ManagementKubeconfigToken:           "test-token", // required to render the push block
+			ManagementKubeconfigSecretName:      "cluster-kubeconfig",
+			ManagementKubeconfigSecretNamespace: "default",
+			ManagementAPIServer:                 "https://1.2.3.4:6443",
+		}
+	}
+	baseK3s := func() TemplateData {
+		return TemplateData{
+			Role:                                "control-plane",
+			SingleNode:                          true,
+			UserName:                            "kairos",
+			UserPassword:                        "kairos",
+			UserGroups:                          []string{"admin"},
+			IsKubeVirt:                          true,
+			ManagementKubeconfigToken:           "test-token",
+			ManagementKubeconfigSecretName:      "cluster-kubeconfig",
+			ManagementKubeconfigSecretNamespace: "default",
+			ManagementAPIServer:                 "https://1.2.3.4:6443",
+		}
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, dist := range []struct {
+				name   string
+				render func() (string, error)
+			}{
+				{
+					name: "k0s",
+					render: func() (string, error) {
+						d := baseK0s()
+						tc.applyToK0s(&d)
+						return RenderK0sCloudConfig(d)
+					},
+				},
+				{
+					name: "k3s",
+					render: func() (string, error) {
+						d := baseK3s()
+						tc.applyToK3s(&d)
+						return RenderK3sCloudConfig(d)
+					},
+				},
+			} {
+				t.Run(dist.name, func(t *testing.T) {
+					out, err := dist.render()
+					if err != nil {
+						t.Fatalf("render: %v", err)
+					}
+
+					// (1) YAML must still parse.
+					var doc map[string]any
+					if err := yaml.Unmarshal([]byte(out), &doc); err != nil {
+						t.Fatalf("rendered YAML did not parse: %v\n---OUTPUT---\n%s", err, out)
+					}
+
+					// (2) Some templates DO embed the field, but only CAPK uses
+					// these fields in shell context. If the value is referenced
+					// at all, it must be inside POSIX single quotes — i.e. the
+					// shquote envelope appears in the output. The shquote of any
+					// of our adversarial payloads is non-empty and contains an
+					// embedded escape sequence; assert the envelope is present.
+					envelope := shquote(tc.payload)
+					if !strings.Contains(out, envelope) {
+						// It's acceptable for some fields to be unused on a
+						// given template variant (e.g. PrimaryIP isn't
+						// referenced by the k3s template). Skip the rest of the
+						// assertions in that case.
+						if !strings.Contains(out, tc.payload) {
+							t.Logf("field not referenced in this template variant; skipping")
+							return
+						}
+						t.Fatalf("payload appears in output WITHOUT shquote envelope:\nenvelope=%q\n---OUTPUT---\n%s", envelope, out)
+					}
+
+					// (3) Dangerous fragments must never appear UNQUOTED outside
+					// the shquote envelope. Walk every occurrence of each
+					// fragment and verify it sits inside a single-quoted region.
+					for _, dangerous := range []string{
+						"; rm -rf /",
+						"$(rm -rf /)",
+					} {
+						if !strings.Contains(tc.payload, dangerous) {
+							continue
+						}
+						// Find each occurrence and confirm it's bracketed by
+						// single quotes via the surrounding envelope.
+						idx := 0
+						for {
+							pos := strings.Index(out[idx:], dangerous)
+							if pos < 0 {
+								break
+							}
+							absPos := idx + pos
+							// Walk backwards: the most recent unescaped single
+							// quote before this position must be unmatched
+							// (i.e., we're inside `'...'`).
+							before := out[:absPos]
+							lastOpen := strings.LastIndex(before, "'")
+							if lastOpen < 0 {
+								t.Fatalf("dangerous fragment %q at offset %d has no preceding `'` — not inside shquote envelope\n---OUTPUT---\n%s", dangerous, absPos, out)
+							}
+							after := out[absPos+len(dangerous):]
+							nextClose := strings.Index(after, "'")
+							if nextClose < 0 {
+								t.Fatalf("dangerous fragment %q at offset %d has no closing `'` after it — not inside shquote envelope\n---OUTPUT---\n%s", dangerous, absPos, out)
+							}
+							idx = absPos + len(dangerous)
+						}
+					}
+				})
+			}
+		})
+	}
 }

--- a/internal/bootstrap/template_adversarial_test.go
+++ b/internal/bootstrap/template_adversarial_test.go
@@ -439,6 +439,132 @@ func TestPersistencyBlockDoesNotLeakUserInput(t *testing.T) {
 	}
 }
 
+// TestHostnameShellInjection_K3sCAPK_ProviderID is the regression guard for
+// KD-43. The k3s CAPK template's VM self-discovery script interpolates the
+// user-controlled .Hostname into a PROVIDER_ID shell assignment. Before the
+// fix, the line was:
+//
+//	PROVIDER_ID="kubevirt://{{ .Hostname }}"
+//
+// which is a double-quoted shell-string-literal context. An attacker who can
+// create or update a KairosConfig could set Hostname to (e.g.)
+//
+//	foo"; rm -rf /; echo "
+//
+// and obtain RCE as root at first boot — validateTemplateData only rejects
+// `\n\r\x00`, not shell metacharacters. The fix concatenates a static
+// double-quoted prefix with the shquote'd Hostname so any embedded `"` or
+// shell metas are literally quoted by POSIX single quotes.
+//
+// This test renders the k3s CAPK template with adversarial Hostname payloads
+// that DO inject shell metas (but do NOT contain `\n`/`\r`/NUL, which
+// validateTemplateData rejects before render) and asserts:
+//
+//  1. The rendered YAML still parses.
+//  2. The PROVIDER_ID line in /usr/local/bin/kairos-k3s-discover-provider-id.sh
+//     contains the payload bracketed by `'...'` (the shquote envelope),
+//     never unescaped.
+//  3. Dangerous fragments inside the payload never appear unquoted.
+//
+// The k3s CAPV, k0s CAPV, and k0s CAPK templates do NOT embed Hostname in a
+// shell context (the only other appearances are YAML block-scalar file
+// contents written to /usr/local/etc/hostname, which is `cat`'d at runtime —
+// the validator's `\n`/`\r`/NUL reject keeps that contract intact), so this
+// test is intentionally scoped to k3s CAPK.
+func TestHostnameShellInjection_K3sCAPK_ProviderID(t *testing.T) {
+	payloads := map[string]string{
+		"double_quote_break": `foo"; rm -rf /; echo "`,
+		"command_subst":      `host$(rm -rf /)`,
+		"backtick":           "host`rm -rf /`",
+		"semicolon_and_and":  `host'; rm -rf /; && echo '`,
+		"single_quote_break": `host'; rm -rf /; echo '`,
+	}
+
+	for name, payload := range payloads {
+		t.Run(name, func(t *testing.T) {
+			data := TemplateData{
+				Role:       "control-plane",
+				SingleNode: true,
+				Hostname:   payload,
+				UserName:   "kairos",
+				IsKubeVirt: true,
+				// Leave ProviderID empty so the self-discovery script
+				// (which is where the Hostname interpolation lives) renders.
+			}
+			out, err := RenderK3sCloudConfig(data)
+			if err != nil {
+				t.Fatalf("render: %v", err)
+			}
+
+			// (1) YAML must still parse.
+			var doc map[string]any
+			if err := yaml.Unmarshal([]byte(stripCloudConfigHeader(out)), &doc); err != nil {
+				t.Fatalf("rendered YAML did not parse: %v\n---OUTPUT---\n%s", err, out)
+			}
+
+			// (2) The PROVIDER_ID assignment line must appear, and the
+			// payload must appear wrapped in the shquote envelope. The
+			// expected line shape is:
+			//   PROVIDER_ID="kubevirt://"'<shquoted-payload>'
+			envelope := shquote(payload)
+			wantLine := `PROVIDER_ID="kubevirt://"` + envelope
+			if !strings.Contains(out, wantLine) {
+				t.Fatalf("PROVIDER_ID assignment not found in expected shquoted form\nwant substring: %q\n---OUTPUT---\n%s", wantLine, out)
+			}
+
+			// (3) On the PROVIDER_ID line specifically, dangerous fragments
+			// must only appear within the shquote envelope. We restrict to
+			// the line because the payload also appears (safely) in the YAML
+			// hostname scalar at the top of the document, where the
+			// surrounding context is YAML-double-quoted rather than
+			// shell-single-quoted; that's a different escape contract and
+			// is not the regression site KD-43 covers.
+			//
+			// Locate the line beginning `PROVIDER_ID="kubevirt://"` and
+			// extract just that line to perform the walk on.
+			marker := `PROVIDER_ID="kubevirt://"`
+			lineStart := strings.Index(out, marker)
+			if lineStart < 0 {
+				t.Fatalf("PROVIDER_ID assignment line not found in output\n---OUTPUT---\n%s", out)
+			}
+			lineEnd := strings.Index(out[lineStart:], "\n")
+			if lineEnd < 0 {
+				lineEnd = len(out) - lineStart
+			}
+			providerIDLine := out[lineStart : lineStart+lineEnd]
+
+			for _, dangerous := range []string{
+				"; rm -rf /",
+				"$(rm -rf /)",
+				"`rm -rf /`",
+			} {
+				if !strings.Contains(payload, dangerous) {
+					continue
+				}
+				idx := 0
+				for {
+					pos := strings.Index(providerIDLine[idx:], dangerous)
+					if pos < 0 {
+						break
+					}
+					absPos := idx + pos
+					before := providerIDLine[:absPos]
+					lastOpen := strings.LastIndex(before, "'")
+					if lastOpen < 0 {
+						t.Fatalf("dangerous fragment %q at PROVIDER_ID-line offset %d has no preceding `'` — not inside shquote envelope\nLINE: %s", dangerous, absPos, providerIDLine)
+					}
+					after := providerIDLine[absPos+len(dangerous):]
+					nextClose := strings.Index(after, "'")
+					if nextClose < 0 {
+						t.Fatalf("dangerous fragment %q at PROVIDER_ID-line offset %d has no closing `'` after it — not inside shquote envelope\nLINE: %s", dangerous, absPos, providerIDLine)
+					}
+					idx = absPos + len(dangerous)
+				}
+			}
+		})
+	}
+}
+
 // TestSafeIndent_CRLF asserts the indent function strips \r so Windows-authored
 // Manifest.Content doesn't leak \r into the YAML block scalar (which would
 // then propagate into files written on the node).

--- a/internal/bootstrap/template_test.go
+++ b/internal/bootstrap/template_test.go
@@ -398,8 +398,16 @@ func TestRenderK3sCloudConfig_CapkKubeconfigPush(t *testing.T) {
 	if !strings.Contains(result, "/etc/rancher/k3s/k3s.yaml") {
 		t.Error("Missing k3s kubeconfig path in push block")
 	}
-	if !strings.Contains(result, "https://10.0.0.1:6443") {
-		t.Error("Missing ControlPlaneLBEndpoint in kubeconfig server URL replacement")
+	// ControlPlaneLBEndpoint is routed through a shquote'd shell variable
+	// (`local lb_endpoint='10.0.0.1'`) and then referenced as
+	// `https://${lb_endpoint}:6443` in the sed substitution, so the literal
+	// "https://10.0.0.1:6443" no longer appears verbatim in the rendered
+	// output. Assert on the safe-routing observable shape instead.
+	if !strings.Contains(result, "local lb_endpoint='10.0.0.1'") {
+		t.Error("Missing shquote'd lb_endpoint local var for ControlPlaneLBEndpoint")
+	}
+	if !strings.Contains(result, "https://${lb_endpoint}:6443") {
+		t.Error("Missing ${lb_endpoint} reference in sed URL substitution")
 	}
 	if !strings.Contains(result, "systemctl enable kairos-k3s-post-bootstrap.service") {
 		t.Error("Missing systemctl enable for k3s post-bootstrap service in runcmd")

--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capk.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capk.yaml.tmpl
@@ -166,7 +166,7 @@ write_files:
       set -e
 
       {{- if .ControlPlaneLBEndpoint }}
-      KAIROS_LB_ENDPOINT="{{ .ControlPlaneLBEndpoint }}"
+      KAIROS_LB_ENDPOINT={{ .ControlPlaneLBEndpoint | shquote }}
       {{- end }}
 
       if [ -z "${KAIROS_LB_ENDPOINT}" ]; then
@@ -324,17 +324,17 @@ stages:
             # KubeVirt: ensure the API server cert includes the node IP (pod or bridged)
             # This prevents TLS SAN mismatch when CAPI connects to the workload cluster.
             {{- if .PrimaryIP }}
-            KAIROS_PRIMARY_IP="{{ .PrimaryIP }}"
+            KAIROS_PRIMARY_IP={{ .PrimaryIP | shquote }}
             {{- end }}
             {{- if .MachineName }}
-            KAIROS_VMI_NAME="{{ .MachineName }}"
+            KAIROS_VMI_NAME={{ .MachineName | shquote }}
             {{- end }}
             {{- if .ClusterNS }}
-            KAIROS_VMI_NAMESPACE="{{ .ClusterNS }}"
+            KAIROS_VMI_NAMESPACE={{ .ClusterNS | shquote }}
             {{- end }}
             {{- if .ManagementKubeconfigToken }}
-            KAIROS_MGMT_API="{{ .ManagementAPIServer }}"
-            KAIROS_MGMT_TOKEN="{{ .ManagementKubeconfigToken }}"
+            KAIROS_MGMT_API={{ .ManagementAPIServer | shquote }}
+            KAIROS_MGMT_TOKEN={{ .ManagementKubeconfigToken | shquote }}
             {{- end }}
             fetch_vmi_ip_from_management() {
               if [ -z "${KAIROS_MGMT_API}" ] || [ -z "${KAIROS_MGMT_TOKEN}" ] || [ -z "${KAIROS_VMI_NAME}" ] || [ -z "${KAIROS_VMI_NAMESPACE}" ]; then
@@ -535,10 +535,10 @@ MANIFEST_EOF
               fi
               local kubeconfig_b64
               kubeconfig_b64=$(base64 -w 0 "${kubeconfig_file}" 2>/dev/null || base64 "${kubeconfig_file}" | tr -d '\n')
-              local api="{{ .ManagementAPIServer }}"
+              local api={{ .ManagementAPIServer | shquote }}
               local ns="{{ .ManagementKubeconfigSecretNamespace }}"
               local name="{{ .ManagementKubeconfigSecretName }}"
-              local token="{{ .ManagementKubeconfigToken }}"
+              local token={{ .ManagementKubeconfigToken | shquote }}
               local payload
               payload="{\"apiVersion\":\"v1\",\"kind\":\"Secret\",\"metadata\":{\"name\":\"${name}\",\"namespace\":\"${ns}\"},\"type\":\"cluster.x-k8s.io/secret\",\"data\":{\"value\":\"${kubeconfig_b64}\"}}"
               local url="${api}/api/v1/namespaces/${ns}/secrets/${name}"

--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capk.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capk.yaml.tmpl
@@ -121,321 +121,7 @@ write_files:
     content: |
       {{ .WorkerToken }}
   {{- end }}
-  {{- if .IsKubeVirt }}
-  - path: /etc/systemd/system/kairos-k0s-post-bootstrap.service
-    permissions: "0644"
-    owner: 0
-    group: 0
-    content: |
-      [Unit]
-      Description=Kairos k0s post-bootstrap tasks
-      {{- if eq .Role "control-plane" }}
-      After=k0s.service
-      Wants=k0s.service
-      {{- else }}
-      After=k0s-worker.service
-      Wants=k0s-worker.service
-      {{- end }}
-      
-      [Service]
-      Type=oneshot
-      RemainAfterExit=yes
-      ExecStart=/usr/local/bin/kairos-k0s-post-bootstrap.sh
-      
-      [Install]
-      WantedBy=multi-user.target
-  - path: /usr/local/bin/kairos-k0s-post-bootstrap.sh
-    permissions: "0755"
-    owner: 0
-    group: 0
-    content: |
-      #!/bin/bash
-      set -e
-      
-      # CAPK: always mark bootstrap success on script exit
-      mark_bootstrap_success() {
-        mkdir -p /run/cluster-api
-        echo "success" > /run/cluster-api/bootstrap-success.complete
-        chmod 0644 /run/cluster-api/bootstrap-success.complete
-      }
-      trap mark_bootstrap_success EXIT
-      
-      {{- if .HostnamePrefix }}
-      # Enforce hostname from cloud-config on immutable rootfs
-      if [ -f /usr/local/etc/hostname ]; then
-        /usr/bin/hostnamectl set-hostname "$(cat /usr/local/etc/hostname)"
-        if ! grep -qE "127\.0\.1\.1[[:space:]]+$(cat /usr/local/etc/hostname)" /etc/hosts; then
-          echo "127.0.1.1 $(cat /usr/local/etc/hostname)" >> /etc/hosts
-        fi
-      fi
-      {{- end }}
-
-      {{- if and .IsKubeVirt (eq .Role "control-plane") }}
-      # KubeVirt: ensure the API server cert includes the node IP (pod or bridged)
-      # This prevents TLS SAN mismatch when CAPI connects to the workload cluster.
-      {{- if .PrimaryIP }}
-      KAIROS_PRIMARY_IP="{{ .PrimaryIP }}"
-      {{- end }}
-      {{- if .MachineName }}
-      KAIROS_VMI_NAME="{{ .MachineName }}"
-      {{- end }}
-      {{- if .ClusterNS }}
-      KAIROS_VMI_NAMESPACE="{{ .ClusterNS }}"
-      {{- end }}
-      {{- if .ManagementKubeconfigToken }}
-      KAIROS_MGMT_API="{{ .ManagementAPIServer }}"
-      KAIROS_MGMT_TOKEN="{{ .ManagementKubeconfigToken }}"
-      {{- end }}
-      fetch_vmi_ip_from_management() {
-        if [ -z "${KAIROS_MGMT_API}" ] || [ -z "${KAIROS_MGMT_TOKEN}" ] || [ -z "${KAIROS_VMI_NAME}" ] || [ -z "${KAIROS_VMI_NAMESPACE}" ]; then
-          return 1
-        fi
-        if ! command -v curl >/dev/null 2>&1; then
-          return 1
-        fi
-        local url="${KAIROS_MGMT_API}/apis/kubevirt.io/v1/namespaces/${KAIROS_VMI_NAMESPACE}/virtualmachineinstances/${KAIROS_VMI_NAME}"
-        local json
-        json=$(curl -k -sS -H "Authorization: Bearer ${KAIROS_MGMT_TOKEN}" "${url}" 2>/dev/null || true)
-        if [ -z "${json}" ]; then
-          return 1
-        fi
-        local ip
-        ip=$(echo "${json}" | sed -n 's/.*"ipAddress":"\\([^"]*\\)".*/\\1/p' | head -n1)
-        if [ -n "${ip}" ]; then
-          echo "${ip}"
-          return 0
-        fi
-        return 1
-      }
-      detect_primary_ip_once() {
-        if [ -n "${KAIROS_PRIMARY_IP}" ]; then
-          echo "Using primary IP override: ${KAIROS_PRIMARY_IP}"
-          echo "${KAIROS_PRIMARY_IP}"
-          return 0
-        fi
-        local mgmt_ip=""
-        mgmt_ip=$(fetch_vmi_ip_from_management || true)
-        if [ -n "${mgmt_ip}" ]; then
-          echo "Using VMI IP from management API: ${mgmt_ip}"
-          echo "${mgmt_ip}"
-          return 0
-        fi
-        local dev=""
-        local ip=""
-        dev=$(ip -4 route show default 2>/dev/null | awk '{print $5; exit}')
-        if [ -n "${dev}" ]; then
-          ip=$(ip -4 -o addr show dev "${dev}" scope global 2>/dev/null | awk '{print $4}' | cut -d/ -f1 | head -n1)
-        fi
-        if [ -z "${ip}" ]; then
-          ip=$(ip -4 -o addr show scope global 2>/dev/null | awk '{print $4}' | cut -d/ -f1 | head -n1)
-        fi
-        if [ -n "${ip}" ]; then
-          echo "Using detected guest IP: ${ip}"
-        fi
-        echo "${ip}"
-      }
-      detect_primary_ip() {
-        local ip=""
-        for i in {1..30}; do
-          ip="$(detect_primary_ip_once)"
-          if [ -n "${ip}" ]; then
-            echo "${ip}"
-            return 0
-          fi
-          echo "Waiting for primary IP... (${i}/30)"
-          sleep 5
-        done
-        return 1
-      }
-
-      KAIROS_SANS_CHANGED=0
-      ensure_k0s_api_sans() {
-        local api_ip="$1"
-        if [ -z "${api_ip}" ]; then
-          echo "WARN: unable to detect node IP for k0s api.sans"
-          return 1
-        fi
-
-        local cfg="/etc/k0s/k0s.yaml"
-        if [ ! -f "${cfg}" ]; then
-          printf '%s\n' \
-            "apiVersion: k0s.k0sproject.io/v1beta1" \
-            "kind: ClusterConfig" \
-            "metadata:" \
-            "  name: k0s" \
-            "spec:" \
-            "  api:" \
-            "    sans:" \
-            "    - ${api_ip}" > "${cfg}"
-          KAIROS_SANS_CHANGED=1
-          return 0
-        fi
-
-        if grep -qE '^[[:space:]]*api:' "${cfg}"; then
-          if grep -qE '^[[:space:]]*sans:' "${cfg}"; then
-            if ! grep -qE '^[[:space:]]*-[[:space:]]*'"${api_ip}"'([[:space:]]|$)' "${cfg}"; then
-              sed -i "/^[[:space:]]*sans:/a\\    - ${api_ip}" "${cfg}"
-              KAIROS_SANS_CHANGED=1
-            fi
-            return 0
-          fi
-          sed -i "/^[[:space:]]*api:/a\\    sans:\\\n    - ${api_ip}" "${cfg}"
-          KAIROS_SANS_CHANGED=1
-          return 0
-        fi
-
-        if grep -qE '^[[:space:]]*spec:' "${cfg}"; then
-          sed -i "/^[[:space:]]*spec:/a\\  api:\\\n    sans:\\\n    - ${api_ip}" "${cfg}"
-          KAIROS_SANS_CHANGED=1
-          return 0
-        fi
-
-        printf '%s\n' \
-          "spec:" \
-          "  api:" \
-          "    sans:" \
-          "    - ${api_ip}" >> "${cfg}"
-        KAIROS_SANS_CHANGED=1
-        return 0
-      }
-
-      API_IP="$(detect_primary_ip || true)"
-      ensure_k0s_api_sans "${API_IP}" || true
-
-      if [ "${KAIROS_SANS_CHANGED}" = "1" ]; then
-        echo "Updated k0s api.sans entries"
-        KAIROS_REPUSH_KUBECONFIG=true
-        # Force apiserver cert regeneration with updated SANs
-        rm -f /var/lib/k0s/pki/apiserver.crt /var/lib/k0s/pki/apiserver.key || true
-        if systemctl is-active --quiet k0scontroller; then
-          systemctl restart k0scontroller || true
-        else
-          systemctl restart k0s || true
-        fi
-      fi
-      {{- end }}
-      
-      {{- if .Manifests }}
-      # Write k0s manifests
-      echo "Writing k0s manifests..."
-      mkdir -p /var/lib/k0s/manifests
-      {{- range .Manifests }}
-      mkdir -p /var/lib/k0s/manifests/{{ .Name }}
-      cat > /var/lib/k0s/manifests/{{ .Name }}/{{ .File }} << 'MANIFEST_EOF'
-{{ .Content }}
-MANIFEST_EOF
-      chmod 0644 /var/lib/k0s/manifests/{{ .Name }}/{{ .File }}
-      echo "Written manifest: /var/lib/k0s/manifests/{{ .Name }}/{{ .File }}"
-      {{- end }}
-      {{- end }}
-      
-      {{- if .ProviderID }}
-      # Wait for k0s to be ready and Node to be registered
-      echo "Waiting for k0s node to be registered..."
-      export KUBECONFIG=/var/lib/k0s/pki/admin.conf
-      MAX_WAIT=300
-      ELAPSED=0
-      while ! kubectl get node $(hostname) &>/dev/null; do
-        if [ $ELAPSED -ge $MAX_WAIT ]; then
-          echo "ERROR: Timeout waiting for node to be registered"
-          exit 1
-        fi
-        echo "Waiting for node to be registered... (${ELAPSED}s/${MAX_WAIT}s)"
-        sleep 5
-        ELAPSED=$((ELAPSED + 5))
-      done
-      
-      # Set providerID on the Node
-      # Retry in case of temporary API server unavailability
-      echo "Setting providerID={{ .ProviderID }} on node $(hostname)..."
-      PROVIDER_ID_SET=false
-      for i in {1..30}; do
-        if kubectl patch node $(hostname) --type=merge -p '{"spec":{"providerID":"{{ .ProviderID }}"}}' &>/dev/null; then
-          echo "Successfully set providerID={{ .ProviderID }} on node $(hostname)"
-          PROVIDER_ID_SET=true
-          break
-        fi
-        echo "Attempt $i/30: Failed to set providerID, retrying in 5 seconds..."
-        sleep 5
-      done
-      
-      if [ "$PROVIDER_ID_SET" != "true" ]; then
-        echo "ERROR: Failed to set providerID after 30 attempts"
-        exit 1
-      fi
-      {{- else }}
-      echo "No providerID to set"
-      {{- end }}
-      
-      {{- if .ManagementKubeconfigToken }}
-      # Push kubeconfig to management cluster without SSH (KubeVirt)
-      push_kubeconfig() {
-        local kubeconfig_file="/var/lib/k0s/pki/admin.conf"
-        if [ ! -f "${kubeconfig_file}" ]; then
-          echo "WARN: kubeconfig file not found at ${kubeconfig_file}"
-          return 1
-        fi
-        if ! command -v curl >/dev/null 2>&1; then
-          echo "WARN: curl not available; cannot push kubeconfig"
-          return 1
-        fi
-        if ! command -v base64 >/dev/null 2>&1; then
-          echo "WARN: base64 not available; cannot push kubeconfig"
-          return 1
-        fi
-        local kubeconfig_b64
-        kubeconfig_b64=$(base64 -w 0 "${kubeconfig_file}" 2>/dev/null || base64 "${kubeconfig_file}" | tr -d '\n')
-        local api="{{ .ManagementAPIServer }}"
-        local ns="{{ .ManagementKubeconfigSecretNamespace }}"
-        local name="{{ .ManagementKubeconfigSecretName }}"
-        local token="{{ .ManagementKubeconfigToken }}"
-        local payload
-        payload="{\"apiVersion\":\"v1\",\"kind\":\"Secret\",\"metadata\":{\"name\":\"${name}\",\"namespace\":\"${ns}\"},\"type\":\"cluster.x-k8s.io/secret\",\"data\":{\"value\":\"${kubeconfig_b64}\"}}"
-        local url="${api}/api/v1/namespaces/${ns}/secrets/${name}"
-        local status
-        status=$(curl -k -sS -o /tmp/kairos-kubeconfig-push.log -w "%{http_code}" \
-          -H "Authorization: Bearer ${token}" \
-          -H "Content-Type: application/json" \
-          -X PUT \
-          --data "${payload}" \
-          "${url}" || true)
-        if [ "${status}" = "404" ]; then
-          status=$(curl -k -sS -o /tmp/kairos-kubeconfig-push.log -w "%{http_code}" \
-            -H "Authorization: Bearer ${token}" \
-            -H "Content-Type: application/json" \
-            -X POST \
-            --data "${payload}" \
-            "${api}/api/v1/namespaces/${ns}/secrets" || true)
-        fi
-        if [ "${status}" -ge 200 ] && [ "${status}" -lt 300 ]; then
-          echo "Pushed kubeconfig to management secret ${ns}/${name}"
-          return 0
-        fi
-        echo "WARN: failed to push kubeconfig to management cluster (status ${status})"
-        return 1
-      }
-      if [ "${KAIROS_REPUSH_KUBECONFIG}" = "true" ]; then
-        for i in {1..12}; do
-          if push_kubeconfig; then
-            break
-          fi
-          echo "Retrying kubeconfig push after cert update ($i/12)..."
-          sleep 5
-        done
-      fi
-      if ! push_kubeconfig; then
-        echo "WARN: kubeconfig push failed; proceeding without blocking bootstrap"
-      fi
-      {{- end }}
-      
-      # Mark bootstrap success for CAPI/CAPK consumers
-      # This file is used by Cluster API to determine bootstrap completion
-      mkdir -p /run/cluster-api
-      echo "success" > /run/cluster-api/bootstrap-success.complete
-      chmod 0644 /run/cluster-api/bootstrap-success.complete
-      
-      echo "k0s post-bootstrap tasks completed successfully"
-  {{- if eq .Role "control-plane" }}
+  {{- if and .IsKubeVirt (eq .Role "control-plane") }}
   - path: /etc/systemd/system/kairos-k0s-lb-sans.service
     permissions: "0644"
     owner: 0
@@ -535,7 +221,6 @@ MANIFEST_EOF
       fi
       exit 1
   {{- end }}
-  {{- end }}
 
 {{- /* DNS overrides and post-bootstrap service */}}
 stages:
@@ -631,6 +316,151 @@ stages:
               /usr/bin/hostnamectl set-hostname "$(cat /usr/local/etc/hostname)"
               if ! grep -qE "127\.0\.1\.1[[:space:]]+$(cat /usr/local/etc/hostname)" /etc/hosts; then
                 echo "127.0.1.1 $(cat /usr/local/etc/hostname)" >> /etc/hosts
+              fi
+            fi
+            {{- end }}
+
+            {{- if and .IsKubeVirt (eq .Role "control-plane") }}
+            # KubeVirt: ensure the API server cert includes the node IP (pod or bridged)
+            # This prevents TLS SAN mismatch when CAPI connects to the workload cluster.
+            {{- if .PrimaryIP }}
+            KAIROS_PRIMARY_IP="{{ .PrimaryIP }}"
+            {{- end }}
+            {{- if .MachineName }}
+            KAIROS_VMI_NAME="{{ .MachineName }}"
+            {{- end }}
+            {{- if .ClusterNS }}
+            KAIROS_VMI_NAMESPACE="{{ .ClusterNS }}"
+            {{- end }}
+            {{- if .ManagementKubeconfigToken }}
+            KAIROS_MGMT_API="{{ .ManagementAPIServer }}"
+            KAIROS_MGMT_TOKEN="{{ .ManagementKubeconfigToken }}"
+            {{- end }}
+            fetch_vmi_ip_from_management() {
+              if [ -z "${KAIROS_MGMT_API}" ] || [ -z "${KAIROS_MGMT_TOKEN}" ] || [ -z "${KAIROS_VMI_NAME}" ] || [ -z "${KAIROS_VMI_NAMESPACE}" ]; then
+                return 1
+              fi
+              if ! command -v curl >/dev/null 2>&1; then
+                return 1
+              fi
+              local url="${KAIROS_MGMT_API}/apis/kubevirt.io/v1/namespaces/${KAIROS_VMI_NAMESPACE}/virtualmachineinstances/${KAIROS_VMI_NAME}"
+              local json
+              json=$(curl -k -sS -H "Authorization: Bearer ${KAIROS_MGMT_TOKEN}" "${url}" 2>/dev/null || true)
+              if [ -z "${json}" ]; then
+                return 1
+              fi
+              local ip
+              ip=$(echo "${json}" | sed -n 's/.*"ipAddress":"\\([^"]*\\)".*/\\1/p' | head -n1)
+              if [ -n "${ip}" ]; then
+                echo "${ip}"
+                return 0
+              fi
+              return 1
+            }
+            detect_primary_ip_once() {
+              if [ -n "${KAIROS_PRIMARY_IP}" ]; then
+                echo "Using primary IP override: ${KAIROS_PRIMARY_IP}"
+                echo "${KAIROS_PRIMARY_IP}"
+                return 0
+              fi
+              local mgmt_ip=""
+              mgmt_ip=$(fetch_vmi_ip_from_management || true)
+              if [ -n "${mgmt_ip}" ]; then
+                echo "Using VMI IP from management API: ${mgmt_ip}"
+                echo "${mgmt_ip}"
+                return 0
+              fi
+              local dev=""
+              local ip=""
+              dev=$(ip -4 route show default 2>/dev/null | awk '{print $5; exit}')
+              if [ -n "${dev}" ]; then
+                ip=$(ip -4 -o addr show dev "${dev}" scope global 2>/dev/null | awk '{print $4}' | cut -d/ -f1 | head -n1)
+              fi
+              if [ -z "${ip}" ]; then
+                ip=$(ip -4 -o addr show scope global 2>/dev/null | awk '{print $4}' | cut -d/ -f1 | head -n1)
+              fi
+              if [ -n "${ip}" ]; then
+                echo "Using detected guest IP: ${ip}"
+              fi
+              echo "${ip}"
+            }
+            detect_primary_ip() {
+              local ip=""
+              for i in {1..30}; do
+                ip="$(detect_primary_ip_once)"
+                if [ -n "${ip}" ]; then
+                  echo "${ip}"
+                  return 0
+                fi
+                echo "Waiting for primary IP... (${i}/30)"
+                sleep 5
+              done
+              return 1
+            }
+
+            KAIROS_SANS_CHANGED=0
+            ensure_k0s_api_sans() {
+              local api_ip="$1"
+              if [ -z "${api_ip}" ]; then
+                echo "WARN: unable to detect node IP for k0s api.sans"
+                return 1
+              fi
+
+              local cfg="/etc/k0s/k0s.yaml"
+              if [ ! -f "${cfg}" ]; then
+                printf '%s\n' \
+                  "apiVersion: k0s.k0sproject.io/v1beta1" \
+                  "kind: ClusterConfig" \
+                  "metadata:" \
+                  "  name: k0s" \
+                  "spec:" \
+                  "  api:" \
+                  "    sans:" \
+                  "    - ${api_ip}" > "${cfg}"
+                KAIROS_SANS_CHANGED=1
+                return 0
+              fi
+
+              if grep -qE '^[[:space:]]*api:' "${cfg}"; then
+                if grep -qE '^[[:space:]]*sans:' "${cfg}"; then
+                  if ! grep -qE '^[[:space:]]*-[[:space:]]*'"${api_ip}"'([[:space:]]|$)' "${cfg}"; then
+                    sed -i "/^[[:space:]]*sans:/a\\    - ${api_ip}" "${cfg}"
+                    KAIROS_SANS_CHANGED=1
+                  fi
+                  return 0
+                fi
+                sed -i "/^[[:space:]]*api:/a\\    sans:\\\n    - ${api_ip}" "${cfg}"
+                KAIROS_SANS_CHANGED=1
+                return 0
+              fi
+
+              if grep -qE '^[[:space:]]*spec:' "${cfg}"; then
+                sed -i "/^[[:space:]]*spec:/a\\  api:\\\n    sans:\\\n    - ${api_ip}" "${cfg}"
+                KAIROS_SANS_CHANGED=1
+                return 0
+              fi
+
+              printf '%s\n' \
+                "spec:" \
+                "  api:" \
+                "    sans:" \
+                "    - ${api_ip}" >> "${cfg}"
+              KAIROS_SANS_CHANGED=1
+              return 0
+            }
+
+            API_IP="$(detect_primary_ip || true)"
+            ensure_k0s_api_sans "${API_IP}" || true
+
+            if [ "${KAIROS_SANS_CHANGED}" = "1" ]; then
+              echo "Updated k0s api.sans entries"
+              KAIROS_REPUSH_KUBECONFIG=true
+              # Force apiserver cert regeneration with updated SANs
+              rm -f /var/lib/k0s/pki/apiserver.crt /var/lib/k0s/pki/apiserver.key || true
+              if systemctl is-active --quiet k0scontroller; then
+                systemctl restart k0scontroller || true
+              else
+                systemctl restart k0s || true
               fi
             fi
             {{- end }}
@@ -760,13 +590,21 @@ MANIFEST_EOF
         - mkdir -p /etc/systemd/system/multi-user.target.wants
         - ln -sf /etc/systemd/system/kairos-k0s-post-bootstrap-enable.service /etc/systemd/system/multi-user.target.wants/kairos-k0s-post-bootstrap-enable.service || true
 
+{{- /*
+  Post-bootstrap service enablement: kairos-k0s-post-bootstrap.service is
+  enabled by kairos-k0s-post-bootstrap-enable.service, which is itself
+  symlinked into multi-user.target.wants by the stages.initramfs commands
+  above. No explicit `systemctl enable kairos-k0s-post-bootstrap.service`
+  is needed in runcmd — keeping one here was a duplicate of the enabler.
+
+  The kairos-k0s-lb-sans.path watcher does still need to be enabled
+  explicitly on control-plane nodes; there is no equivalent enabler
+  service for it, so we enable + start it here once after initramfs has
+  written the unit file.
+*/ -}}
+{{- if and .IsKubeVirt (eq .Role "control-plane") }}
 runcmd:
-{{- if .IsKubeVirt }}
   - /bin/systemctl daemon-reload || true
-  - /bin/systemctl enable kairos-k0s-post-bootstrap.service || true
-  - /bin/systemctl start kairos-k0s-post-bootstrap.service || true
-  {{- if eq .Role "control-plane" }}
   - /bin/systemctl enable kairos-k0s-lb-sans.path || true
   - /bin/systemctl start kairos-k0s-lb-sans.path || true
-  {{- end }}
 {{- end }}

--- a/internal/bootstrap/templates/k3s_kairos_cloud_config_capk.yaml.tmpl
+++ b/internal/bootstrap/templates/k3s_kairos_cloud_config_capk.yaml.tmpl
@@ -172,8 +172,12 @@ write_files:
       set -e
       PROVIDER_ID=""
       # Prefer hostname: CAPK uses kubevirt://<vm-name> and hostname matches KubevirtMachine/VM name
+      # Hostname is shquote'd into POSIX single quotes to prevent shell injection
+      # (KD-43): the static "kubevirt://" prefix is in double quotes (safe — no
+      # template expansion), and the user-controlled .Hostname is concatenated as
+      # a single-quoted literal that bash cannot reinterpret.
       {{- if .Hostname }}
-      PROVIDER_ID="kubevirt://{{ .Hostname }}"
+      PROVIDER_ID="kubevirt://"{{ .Hostname | shquote }}
       echo "Discovered providerID: $PROVIDER_ID (hostname)"
       {{- end }}
       # Fallback: DMI product_uuid (KubeVirt VMs may expose UUID; only if hostname not available)

--- a/internal/bootstrap/templates/k3s_kairos_cloud_config_capk.yaml.tmpl
+++ b/internal/bootstrap/templates/k3s_kairos_cloud_config_capk.yaml.tmpl
@@ -71,7 +71,7 @@ k3s:
     - --kubelet-arg=provider-id={{ .ProviderID }}
   {{- end }}
   {{- if .ControlPlaneLBEndpoint }}
-    - --tls-san={{ .ControlPlaneLBEndpoint }}
+    - {{ printf "--tls-san=%s" .ControlPlaneLBEndpoint | quote }}
   {{- end }}
   {{- end }}
 
@@ -291,16 +291,17 @@ MANIFEST_EOF
         {{- if .ControlPlaneLBEndpoint }}
         local tmp_kubeconfig
         tmp_kubeconfig=$(mktemp)
-        sed "s|https://[^[:space:]]*:6443|https://{{ .ControlPlaneLBEndpoint }}:6443|g" "${kubeconfig_file}" > "${tmp_kubeconfig}"
+        local lb_endpoint={{ .ControlPlaneLBEndpoint | shquote }}
+        sed "s|https://[^[:space:]]*:6443|https://${lb_endpoint}:6443|g" "${kubeconfig_file}" > "${tmp_kubeconfig}"
         kubeconfig_b64=$(base64 -w 0 "${tmp_kubeconfig}" 2>/dev/null || base64 "${tmp_kubeconfig}" | tr -d '\n')
         rm -f "${tmp_kubeconfig}"
         {{- else }}
         kubeconfig_b64=$(base64 -w 0 "${kubeconfig_file}" 2>/dev/null || base64 "${kubeconfig_file}" | tr -d '\n')
         {{- end }}
-        local api="{{ .ManagementAPIServer }}"
+        local api={{ .ManagementAPIServer | shquote }}
         local ns="{{ .ManagementKubeconfigSecretNamespace }}"
         local name="{{ .ManagementKubeconfigSecretName }}"
-        local token="{{ .ManagementKubeconfigToken }}"
+        local token={{ .ManagementKubeconfigToken | shquote }}
         local payload
         payload="{\"apiVersion\":\"v1\",\"kind\":\"Secret\",\"metadata\":{\"name\":\"${name}\",\"namespace\":\"${ns}\"},\"type\":\"cluster.x-k8s.io/secret\",\"data\":{\"value\":\"${kubeconfig_b64}\"}}"
         local url="${api}/api/v1/namespaces/${ns}/secrets/${name}"


### PR DESCRIPTION
## Summary

- Correct the `Manifest` struct godoc to document both k0s and k3s manifest paths (KD-28); CRDs regenerated.
- Collapse duplicate `kairos-k0s-post-bootstrap.service` definition in the k0s CAPK template (KD-22): −162 LOC, single canonical unit in `stages.initramfs`.
- Add `shquote` FuncMap entry and apply it to all six management-endpoint fields that land in shell-variable assignments in the CAPK templates (KD-2 follow-up).
- Fix RCE: shquote `.Hostname` in the `PROVIDER_ID` shell context in the k3s CAPK template (KD-43).

## What this fixes

**KD-28 — `Manifest` godoc claimed k0s only.** The `Manifest` struct and its `Name`/`File` field doc-comments described only `/var/lib/k0s/manifests/{Name}/{File}`. The templates have always written to `/var/lib/rancher/k3s/server/manifests/{Name}/{File}` for k3s. Updated the struct and field godocs to enumerate both paths. CRDs regenerated via `make manifests`. `docs/API_REFERENCE.md` already had the correct prose from PR #51; this commit makes the godoc match.

**KD-22 — Duplicate post-bootstrap unit in k0s CAPK template.** `k0s_kairos_cloud_config_capk.yaml.tmpl` carried two parallel definitions of `kairos-k0s-post-bootstrap.service` and its shell script — one in `write_files:`, one in `stages.initramfs[0].files:`. Both wrote the same file via different yip code paths. `runcmd:` then re-enabled and re-started the unit, which was already enabled by the `stages.initramfs` symlink. Collapsed to a single definition in `stages.initramfs.files` (consistent with the persistence story from KD-23). The IP-detection / SANs-patching / `k0scontroller`-restart block that previously existed only in the `write_files:` copy was moved into the surviving copy, guarded by `{{- if and .IsKubeVirt (eq .Role "control-plane") }}`. Net change: −162 LOC. All existing template tests pass unchanged. No user-visible behavior change.

> **Scope correction**: KD-22 in the punch list originally described "replace hand-rolled units with upstream `provider-kairos.bootstrap.after.{controller,worker}` hooks." Investigation by `staff-architect` found that hook only fires in the P2P role-runner (`provider-kairos/internal/role/p2p/{master,worker}.go`); our cloud-configs are not P2P-configured, so they route to `oneTimeBootstrap` which fires no `provider-kairos.bootstrap.after.*` stage. The closer alternative `.k3s-ready` requires users to bake `{k0s,k3s}-ready.service` into a custom Kairos image at build time — contradicts the project's operator model. Real upstream-hook adoption is tracked as **KD-40** in the punch list, paired with HA (KD-5b / KD-25). What KD-22 safely delivers in alpha-2 is the dedup of the k0s-CAPK template.

**KD-2 follow-up — `shquote` management-endpoint shell-context fields.** The existing `quote` template filter uses `gopkg.in/yaml.v3` to emit double-quoted YAML scalars. Bash double-quoted strings evaluate `$()`, backticks, `${VAR}`, and `\` — so a `quote`-rendered value placed in a bash variable assignment is NOT shell-safe. Added `shquote` (POSIX single-quoted literal; bash never interprets single-quoted content) and applied it to the six fields in the CAPK templates that land in shell-variable assignments:

- `.ManagementAPIServer` — CAPK k0s + k3s kubeconfig-push block
- `.ManagementKubeconfigToken` — same
- `.PrimaryIP` — CAPK k0s SAN-detection block
- `.MachineName` — CAPK k0s SAN-detection block
- `.ClusterNS` — CAPK k0s SAN-detection block
- `.ControlPlaneLBEndpoint` — CAPK k0s + k3s kubeconfig-rewrite block

Adversarial render-round-trip tests added (12 `shquote` unit cases + the 6-field × 2-template matrix); all assert rendered YAML still parses and dangerous fragments only appear inside `'...'` envelopes.

**KD-43 — RCE: `.Hostname` interpolated into double-quoted shell assignment.** The k3s CAPK template's VM self-discovery script contained:

```
PROVIDER_ID="kubevirt://{{ .Hostname }}"
```

`validateTemplateData` rejects `\n`, `\r`, NUL — not shell metacharacters. An actor with RBAC permission to create or update a `KairosConfig` with `spec.hostname` set to `foo"; rm -rf /; echo "` would obtain RCE as root at first boot on every CAPK control-plane node bootstrapped while that config is in effect. This is a pre-existing defect (since `cde9144`); NOT introduced by this PR, but bundled here for security velocity.

Fix: concatenate the static double-quoted prefix (no template expansion) with `.Hostname` routed through `shquote`:

```
PROVIDER_ID="kubevirt://"{{ .Hostname | shquote }}
```

The adversarial payload now renders as a POSIX single-quoted literal that bash cannot reinterpret. Five adversarial payloads tested in `TestHostnameShellInjection_K3sCAPK_ProviderID`. A shell-metacharacter rejection validator for `Hostname` is deferred to a small follow-up PR (KD-43-followup); `shquote` in the template is the primary control.

## Security implications

KD-43 closes an authenticated RCE. Attack path: actor with RBAC on `KairosConfig` write sets `spec.hostname` to a shell-injection payload → renderer embeds the raw value into a double-quoted bash assignment in the VM's cloud-config userdata → VM executes the payload as root at first boot.

Scope: **k3s + CAPK (KubevirtMachineTemplate) configurations only.** CAPV and CAPD templates do not contain this `PROVIDER_ID="kubevirt://..."` shell assignment; k0s CAPK does not interpolate `.Hostname` into a shell context for this field.

The KD-2 follow-up commit closes a weaker variant of the same class of defect for the six management-endpoint fields: those carry URLs and tokens that originate from controller-controlled values rather than user-controlled hostnames, so exploitability is lower, but the escape model was incorrect.

## Implementation notes

Four commits, bisectable:

1. `8b71ee0` — docs-only: godoc + CRD description text for `Manifest` (KD-28)
2. `09bf5bf` — refactor-only: template dedup, no behavior change (KD-22)
3. `2cac6fa` — defense-in-depth: `shquote` the 6 management-endpoint fields + add `shquote` FuncMap entry + adversarial tests (KD-2 follow-up)
4. `10970d5` — security fix: `shquote` `.Hostname` in `PROVIDER_ID` + regression tests (KD-43)

## Validation

```
go vet ./...                            PASS
go build ./...                          PASS
go test ./internal/bootstrap/... -v     PASS (all existing + 12 shquote unit + 12 shquote-field + 5 KD-43 sub-cases)
make manifests                          PASS (description-only CRD diff for KD-28)
make build                              PASS
```

`security-architect` pre-merge review: **APPROVE** all 4 commits. Two pre-existing, separate concerns surfaced and filed as separate punch-list items (KD-43 was bundled here; KD-44 sed-replacement-metacharacter and KD-42 `Manifests[].Name/.File` validator remain deferred to follow-up PRs).

## Out of scope

- Validator for shell-metacharacter rejection in `Hostname` — defense-in-depth secondary layer, deferred to a small KD-43-followup PR.
- `Manifests[].Name` / `.File` validator (KD-42) — pre-existing shell-context exposure unrelated to PR-5's scope.
- HA control planes (KD-5b / KD-25) — no change here.
- CAPV or CAPD template changes — those templates do not use the affected fields.
- Real upstream-hook adoption (KD-40) — blocked on HA / P2P decision.
