### PR TITLE
refactor(bootstrap/controllers): introduce ManagementEndpoint type and resolver interface (KD-33)

### DIFF
--- a/internal/bootstrap/funcs.go
+++ b/internal/bootstrap/funcs.go
@@ -109,10 +109,11 @@ func quote(v any) (string, error) {
 // Threat model: a CAPI infrastructure provider (CAPK in particular) could,
 // in principle, populate a TemplateData field with a value containing
 // shell metacharacters. The fields that pass through shquote today are
-// .ManagementAPIServer, .ManagementKubeconfigToken, .PrimaryIP,
-// .MachineName, .ClusterNS, and .ControlPlaneLBEndpoint — the
-// management-endpoint set introduced for the CAPK kubeconfig-push and
-// post-bootstrap SAN-patch flows. None of these are intended to carry
+// .ManagementEndpoint.APIServer, .ManagementEndpoint.Token,
+// .ManagementEndpoint.KubeconfigSecretName,
+// .ManagementEndpoint.KubeconfigSecretNamespace (all four rendered only
+// when ManagementEndpoint is non-nil), .PrimaryIP, .MachineName, .ClusterNS,
+// and .ControlPlaneLBEndpoint. None of these are intended to carry
 // shell-active input today, but the renderer is the LAST line of defense
 // between user/provider input and root-privileged userdata.
 //

--- a/internal/bootstrap/template.go
+++ b/internal/bootstrap/template.go
@@ -60,11 +60,26 @@ type TemplateData struct {
 	ControlPlaneLBServiceName      string
 	ControlPlaneLBServiceNamespace string
 	ControlPlaneLBEndpoint         string
-	// Management cluster push config for KubeVirt (non-SSH kubeconfig retrieval)
-	ManagementKubeconfigToken           string
-	ManagementKubeconfigSecretName      string
-	ManagementKubeconfigSecretNamespace string
-	ManagementAPIServer                 string
+	// ManagementEndpoint, if non-nil, enables the in-node kubeconfig-push path
+	// (CAPK today; other infra providers under KD-3b). The renderer treats the
+	// pointer as the single gate for emitting the push block — when nil, no
+	// management-cluster contact is rendered. Resolved by the controller from a
+	// ManagementEndpointResolver; see internal/controllers/bootstrap/CLAUDE.md.
+	ManagementEndpoint *ManagementEndpoint
+}
+
+// ManagementEndpoint bundles the four values the rendered cloud-config needs
+// to push the workload kubeconfig back to the management cluster without SSH:
+// the management API URL, an authenticated bearer token, and the
+// (namespace, name) of the kubeconfig Secret to write. All four fields are
+// rendered into shell command positions via the shquote template func — any
+// new field added here that lands in a shell context MUST be routed through
+// shquote per the rules in internal/bootstrap/CLAUDE.md § "Shell contexts".
+type ManagementEndpoint struct {
+	APIServer                 string
+	Token                     string
+	KubeconfigSecretName      string
+	KubeconfigSecretNamespace string
 }
 
 // InstallConfig holds installation configuration for the template

--- a/internal/bootstrap/template_adversarial_test.go
+++ b/internal/bootstrap/template_adversarial_test.go
@@ -350,29 +350,31 @@ func TestPersistencyBlockDoesNotLeakUserInput(t *testing.T) {
 
 	mkData := func(isKV bool, dist string) TemplateData {
 		d := TemplateData{
-			Role:                                "control-plane",
-			SingleNode:                          true,
-			Hostname:                            hostnameMark,
-			UserName:                            userNameMark,
-			UserPassword:                        userPasswordMark,
-			UserGroups:                          []string{groupMark},
-			GitHubUser:                          gitHubUserMark,
-			SSHPublicKey:                        sshKeyMark,
-			HostnamePrefix:                      hostnamePrefixMark,
-			DNSServers:                          []string{dnsMark},
-			PodCIDR:                             podCIDRMark,
-			ServiceCIDR:                         serviceCIDRMark,
-			PrimaryIP:                           primaryIPMark,
-			MachineName:                         machineNameMark,
-			ClusterNS:                           clusterNSMark,
-			IsKubeVirt:                          isKV,
-			ControlPlaneLBServiceName:           lbServiceNameMark,
-			ControlPlaneLBServiceNamespace:      lbServiceNSMark,
-			ControlPlaneLBEndpoint:              lbEndpointMark,
-			ManagementKubeconfigToken:           mgmtTokenMark,
-			ManagementKubeconfigSecretName:      mgmtSecretNameMark,
-			ManagementKubeconfigSecretNamespace: mgmtSecretNSMark,
-			ManagementAPIServer:                 mgmtAPIServerMark,
+			Role:                           "control-plane",
+			SingleNode:                     true,
+			Hostname:                       hostnameMark,
+			UserName:                       userNameMark,
+			UserPassword:                   userPasswordMark,
+			UserGroups:                     []string{groupMark},
+			GitHubUser:                     gitHubUserMark,
+			SSHPublicKey:                   sshKeyMark,
+			HostnamePrefix:                 hostnamePrefixMark,
+			DNSServers:                     []string{dnsMark},
+			PodCIDR:                        podCIDRMark,
+			ServiceCIDR:                    serviceCIDRMark,
+			PrimaryIP:                      primaryIPMark,
+			MachineName:                    machineNameMark,
+			ClusterNS:                      clusterNSMark,
+			IsKubeVirt:                     isKV,
+			ControlPlaneLBServiceName:      lbServiceNameMark,
+			ControlPlaneLBServiceNamespace: lbServiceNSMark,
+			ControlPlaneLBEndpoint:         lbEndpointMark,
+			ManagementEndpoint: &ManagementEndpoint{
+				Token:                     mgmtTokenMark,
+				KubeconfigSecretName:      mgmtSecretNameMark,
+				KubeconfigSecretNamespace: mgmtSecretNSMark,
+				APIServer:                 mgmtAPIServerMark,
+			},
 		}
 		if dist == "k3s" {
 			// k3s control-plane templates don't read WorkerToken (workers
@@ -746,14 +748,14 @@ func TestShquoteFieldsAreShellSafe(t *testing.T) {
 		{
 			name:       "ManagementAPIServer",
 			payload:    urlInjection,
-			applyToK0s: func(d *TemplateData) { d.ManagementAPIServer = urlInjection },
-			applyToK3s: func(d *TemplateData) { d.ManagementAPIServer = urlInjection },
+			applyToK0s: func(d *TemplateData) { d.ManagementEndpoint.APIServer = urlInjection },
+			applyToK3s: func(d *TemplateData) { d.ManagementEndpoint.APIServer = urlInjection },
 		},
 		{
 			name:       "ManagementKubeconfigToken",
 			payload:    tokenInjection,
-			applyToK0s: func(d *TemplateData) { d.ManagementKubeconfigToken = tokenInjection },
-			applyToK3s: func(d *TemplateData) { d.ManagementKubeconfigToken = tokenInjection },
+			applyToK0s: func(d *TemplateData) { d.ManagementEndpoint.Token = tokenInjection },
+			applyToK3s: func(d *TemplateData) { d.ManagementEndpoint.Token = tokenInjection },
 		},
 		{
 			name:       "PrimaryIP",
@@ -783,30 +785,34 @@ func TestShquoteFieldsAreShellSafe(t *testing.T) {
 
 	baseK0s := func() TemplateData {
 		return TemplateData{
-			Role:                                "control-plane",
-			SingleNode:                          true,
-			UserName:                            "kairos",
-			UserPassword:                        "kairos",
-			UserGroups:                          []string{"admin"},
-			IsKubeVirt:                          true,
-			ManagementKubeconfigToken:           "test-token", // required to render the push block
-			ManagementKubeconfigSecretName:      "cluster-kubeconfig",
-			ManagementKubeconfigSecretNamespace: "default",
-			ManagementAPIServer:                 "https://1.2.3.4:6443",
+			Role:         "control-plane",
+			SingleNode:   true,
+			UserName:     "kairos",
+			UserPassword: "kairos",
+			UserGroups:   []string{"admin"},
+			IsKubeVirt:   true,
+			ManagementEndpoint: &ManagementEndpoint{ // non-nil → push block renders
+				Token:                     "test-token",
+				KubeconfigSecretName:      "cluster-kubeconfig",
+				KubeconfigSecretNamespace: "default",
+				APIServer:                 "https://1.2.3.4:6443",
+			},
 		}
 	}
 	baseK3s := func() TemplateData {
 		return TemplateData{
-			Role:                                "control-plane",
-			SingleNode:                          true,
-			UserName:                            "kairos",
-			UserPassword:                        "kairos",
-			UserGroups:                          []string{"admin"},
-			IsKubeVirt:                          true,
-			ManagementKubeconfigToken:           "test-token",
-			ManagementKubeconfigSecretName:      "cluster-kubeconfig",
-			ManagementKubeconfigSecretNamespace: "default",
-			ManagementAPIServer:                 "https://1.2.3.4:6443",
+			Role:         "control-plane",
+			SingleNode:   true,
+			UserName:     "kairos",
+			UserPassword: "kairos",
+			UserGroups:   []string{"admin"},
+			IsKubeVirt:   true,
+			ManagementEndpoint: &ManagementEndpoint{
+				Token:                     "test-token",
+				KubeconfigSecretName:      "cluster-kubeconfig",
+				KubeconfigSecretNamespace: "default",
+				APIServer:                 "https://1.2.3.4:6443",
+			},
 		}
 	}
 

--- a/internal/bootstrap/template_adversarial_test.go
+++ b/internal/bootstrap/template_adversarial_test.go
@@ -910,3 +910,146 @@ func TestShquoteFieldsAreShellSafe(t *testing.T) {
 		})
 	}
 }
+
+// TestRender_ManagementEndpoint_AdversarialFields is the per-field adversarial
+// coverage matrix for the four ManagementEndpoint nested fields × the two
+// CAPK templates (k0s and k3s) = 8 subcases.
+//
+// Why this and not the existing TestShquoteFieldsAreShellSafe:
+//   - TestShquoteFieldsAreShellSafe predates KD-33's struct refactor and
+//     covers the two endpoint fields that already had shquote treatment
+//     (APIServer + Token). It does NOT cover the two namespace/name fields,
+//     which got shquote'd as the residual KD-2 follow-up in commit (a).
+//   - The naming and structure of THIS test enumerate
+//     ManagementEndpoint.{APIServer,Token,KubeconfigSecretName,
+//     KubeconfigSecretNamespace} explicitly so a future field added to
+//     ManagementEndpoint without the corresponding adversarial case fails
+//     code review at the subtest-count check.
+//
+// Per field, the test asserts:
+//
+//  1. Rendered YAML still parses (`yaml.Unmarshal`).
+//  2. The payload appears inside `'...'` (POSIX single-quoted) — the
+//     shquote envelope.
+//  3. Known shell metacharacters in the payload (`;`, `$()`, backticks,
+//     `&&`) appear only inside the single-quoted envelope, never as a
+//     bare token in the rendered output.
+func TestRender_ManagementEndpoint_AdversarialFields(t *testing.T) {
+	// Payloads chosen to surface the most dangerous metacharacter classes
+	// per field type. None contain `\n`/`\r`/NUL so they bypass
+	// validateTemplateData and reach the template — exercising the
+	// shquote envelope, not the validator.
+	const (
+		apiServerInj         = `https://api:6443'; rm -rf /; echo '`
+		tokenInj             = `evil-token'; rm -rf /; echo '`
+		secretNameInj        = `evil$(rm -rf /)`
+		secretNamespaceInj   = `evil$(rm -rf /)`
+		dangerousSemi        = "; rm -rf /"
+		dangerousDollarSubsh = "$(rm -rf /)"
+	)
+
+	type fieldCase struct {
+		name    string
+		payload string
+		// apply mutates the ManagementEndpoint inside a base TemplateData.
+		apply func(ep *ManagementEndpoint)
+	}
+
+	cases := []fieldCase{
+		{
+			name:    "APIServer",
+			payload: apiServerInj,
+			apply:   func(ep *ManagementEndpoint) { ep.APIServer = apiServerInj },
+		},
+		{
+			name:    "Token",
+			payload: tokenInj,
+			apply:   func(ep *ManagementEndpoint) { ep.Token = tokenInj },
+		},
+		{
+			name:    "KubeconfigSecretName",
+			payload: secretNameInj,
+			apply:   func(ep *ManagementEndpoint) { ep.KubeconfigSecretName = secretNameInj },
+		},
+		{
+			name:    "KubeconfigSecretNamespace",
+			payload: secretNamespaceInj,
+			apply:   func(ep *ManagementEndpoint) { ep.KubeconfigSecretNamespace = secretNamespaceInj },
+		},
+	}
+
+	baseEndpoint := func() *ManagementEndpoint {
+		return &ManagementEndpoint{
+			APIServer:                 "https://1.2.3.4:6443",
+			Token:                     "good-token",
+			KubeconfigSecretName:      "cluster-kubeconfig",
+			KubeconfigSecretNamespace: "default",
+		}
+	}
+
+	baseData := func(ep *ManagementEndpoint) TemplateData {
+		return TemplateData{
+			Role:               "control-plane",
+			SingleNode:         true,
+			UserName:           "kairos",
+			UserPassword:       "kairos",
+			UserGroups:         []string{"admin"},
+			IsKubeVirt:         true,
+			ManagementEndpoint: ep,
+		}
+	}
+
+	for _, tc := range cases {
+		for _, dist := range []string{"k0s", "k3s"} {
+			t.Run(tc.name+"/"+dist, func(t *testing.T) {
+				ep := baseEndpoint()
+				tc.apply(ep)
+				data := baseData(ep)
+
+				out, err := renderForDist(dist, data)
+				if err != nil {
+					t.Fatalf("render: %v", err)
+				}
+
+				// (1) YAML must still parse.
+				var doc map[string]any
+				if err := yaml.Unmarshal([]byte(stripCloudConfigHeader(out)), &doc); err != nil {
+					t.Fatalf("rendered YAML did not parse: %v\n---OUTPUT---\n%s", err, out)
+				}
+
+				// (2) The payload must appear wrapped in the shquote envelope.
+				envelope := shquote(tc.payload)
+				if !strings.Contains(out, envelope) {
+					t.Fatalf("payload appears in output WITHOUT shquote envelope:\nenvelope=%q\n---OUTPUT---\n%s", envelope, out)
+				}
+
+				// (3) Dangerous fragments inside the payload must only appear
+				// inside the shquote envelope — never as bare shell tokens.
+				for _, dangerous := range []string{dangerousSemi, dangerousDollarSubsh} {
+					if !strings.Contains(tc.payload, dangerous) {
+						continue
+					}
+					idx := 0
+					for {
+						pos := strings.Index(out[idx:], dangerous)
+						if pos < 0 {
+							break
+						}
+						absPos := idx + pos
+						before := out[:absPos]
+						lastOpen := strings.LastIndex(before, "'")
+						if lastOpen < 0 {
+							t.Fatalf("dangerous fragment %q at offset %d has no preceding `'` — not inside shquote envelope\n---OUTPUT---\n%s", dangerous, absPos, out)
+						}
+						after := out[absPos+len(dangerous):]
+						nextClose := strings.Index(after, "'")
+						if nextClose < 0 {
+							t.Fatalf("dangerous fragment %q at offset %d has no closing `'` after it — not inside shquote envelope\n---OUTPUT---\n%s", dangerous, absPos, out)
+						}
+						idx = absPos + len(dangerous)
+					}
+				}
+			})
+		}
+	}
+}

--- a/internal/bootstrap/template_test.go
+++ b/internal/bootstrap/template_test.go
@@ -376,15 +376,17 @@ func TestRenderK3sCloudConfig_CapkBootstrapTrap(t *testing.T) {
 
 func TestRenderK3sCloudConfig_CapkKubeconfigPush(t *testing.T) {
 	data := TemplateData{
-		Role:                                "control-plane",
-		SingleNode:                          true,
-		UserName:                            "kairos",
-		IsKubeVirt:                          true,
-		ManagementKubeconfigToken:           "test-token",
-		ManagementKubeconfigSecretName:      "cluster-kubeconfig",
-		ManagementKubeconfigSecretNamespace: "default",
-		ManagementAPIServer:                 "https://1.2.3.4:6443",
-		ControlPlaneLBEndpoint:              "10.0.0.1",
+		Role:       "control-plane",
+		SingleNode: true,
+		UserName:   "kairos",
+		IsKubeVirt: true,
+		ManagementEndpoint: &ManagementEndpoint{
+			Token:                     "test-token",
+			KubeconfigSecretName:      "cluster-kubeconfig",
+			KubeconfigSecretNamespace: "default",
+			APIServer:                 "https://1.2.3.4:6443",
+		},
+		ControlPlaneLBEndpoint: "10.0.0.1",
 	}
 
 	result, err := RenderK3sCloudConfig(data)
@@ -576,6 +578,66 @@ func TestRenderK0sCloudConfig_WithDNSServers(t *testing.T) {
 	if !strings.Contains(result, "dns:\n        nameservers:\n          - 1.1.1.1\n          - 8.8.8.8") {
 		t.Error("Missing DNS servers initramfs block")
 	}
+}
+
+// TestRenderK0sCloudConfig_CapkNoManagementEndpoint asserts that when
+// ManagementEndpoint is nil on the CAPK k0s control-plane template, the
+// in-node kubeconfig-push block is omitted entirely. The pointer-nil check on
+// .ManagementEndpoint is the single gate the renderer uses; this guards
+// against accidentally re-introducing a flat-field-only check that would
+// silently render an unauthenticated push attempt.
+//
+// Two gate sites in the k0s CAPK template close on ManagementEndpoint:
+//
+//  1. The KAIROS_MGMT_API / KAIROS_MGMT_TOKEN assignment lines in the
+//     fetch_vmi_ip_from_management() helper (the rest of the helper body
+//     always renders, so we assert on the ASSIGNMENT lines, not on the
+//     identifier itself which is referenced in `[ -z "${KAIROS_MGMT_API}" ]`).
+//  2. The push_kubeconfig() function and its call sites.
+func TestRenderK0sCloudConfig_CapkNoManagementEndpoint(t *testing.T) {
+	data := TemplateData{
+		Role:               "control-plane",
+		SingleNode:         true,
+		UserName:           "kairos",
+		IsKubeVirt:         true,
+		ManagementEndpoint: nil,
+	}
+	result, err := RenderK0sCloudConfig(data)
+	if err != nil {
+		t.Fatalf("Failed to render template: %v", err)
+	}
+	// Assignment lines must be omitted (they only render under .ManagementEndpoint).
+	if strings.Contains(result, "KAIROS_MGMT_API=") {
+		t.Errorf("KAIROS_MGMT_API assignment must not appear when ManagementEndpoint is nil")
+	}
+	if strings.Contains(result, "KAIROS_MGMT_TOKEN=") {
+		t.Errorf("KAIROS_MGMT_TOKEN assignment must not appear when ManagementEndpoint is nil")
+	}
+	// Entire push block must be omitted.
+	if strings.Contains(result, "push_kubeconfig") {
+		t.Errorf("push_kubeconfig must not appear when ManagementEndpoint is nil")
+	}
+}
+
+// TestRenderK3sCloudConfig_CapkNoManagementEndpoint is the k3s twin of
+// TestRenderK0sCloudConfig_CapkNoManagementEndpoint.
+func TestRenderK3sCloudConfig_CapkNoManagementEndpoint(t *testing.T) {
+	data := TemplateData{
+		Role:               "control-plane",
+		SingleNode:         true,
+		UserName:           "kairos",
+		IsKubeVirt:         true,
+		ManagementEndpoint: nil,
+	}
+	result, err := RenderK3sCloudConfig(data)
+	if err != nil {
+		t.Fatalf("Failed to render template: %v", err)
+	}
+	if strings.Contains(result, "push_kubeconfig") {
+		t.Errorf("push_kubeconfig must not appear when ManagementEndpoint is nil")
+	}
+	// k3s template doesn't have the KAIROS_MGMT_API SAN-detection block (only
+	// the push block), so the push_kubeconfig check above is sufficient.
 }
 
 func TestRenderK0sCloudConfig_WithoutInstallConfig(t *testing.T) {

--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capk.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capk.yaml.tmpl
@@ -332,9 +332,9 @@ stages:
             {{- if .ClusterNS }}
             KAIROS_VMI_NAMESPACE={{ .ClusterNS | shquote }}
             {{- end }}
-            {{- if .ManagementKubeconfigToken }}
-            KAIROS_MGMT_API={{ .ManagementAPIServer | shquote }}
-            KAIROS_MGMT_TOKEN={{ .ManagementKubeconfigToken | shquote }}
+            {{- if .ManagementEndpoint }}
+            KAIROS_MGMT_API={{ .ManagementEndpoint.APIServer | shquote }}
+            KAIROS_MGMT_TOKEN={{ .ManagementEndpoint.Token | shquote }}
             {{- end }}
             fetch_vmi_ip_from_management() {
               if [ -z "${KAIROS_MGMT_API}" ] || [ -z "${KAIROS_MGMT_TOKEN}" ] || [ -z "${KAIROS_VMI_NAME}" ] || [ -z "${KAIROS_VMI_NAMESPACE}" ]; then
@@ -517,7 +517,7 @@ MANIFEST_EOF
             echo "No providerID to set"
             {{- end }}
             
-            {{- if .ManagementKubeconfigToken }}
+            {{- if .ManagementEndpoint }}
             # Push kubeconfig to management cluster without SSH (KubeVirt)
             push_kubeconfig() {
               local kubeconfig_file="/var/lib/k0s/pki/admin.conf"
@@ -535,10 +535,10 @@ MANIFEST_EOF
               fi
               local kubeconfig_b64
               kubeconfig_b64=$(base64 -w 0 "${kubeconfig_file}" 2>/dev/null || base64 "${kubeconfig_file}" | tr -d '\n')
-              local api={{ .ManagementAPIServer | shquote }}
-              local ns="{{ .ManagementKubeconfigSecretNamespace }}"
-              local name="{{ .ManagementKubeconfigSecretName }}"
-              local token={{ .ManagementKubeconfigToken | shquote }}
+              local api={{ .ManagementEndpoint.APIServer | shquote }}
+              local ns={{ .ManagementEndpoint.KubeconfigSecretNamespace | shquote }}
+              local name={{ .ManagementEndpoint.KubeconfigSecretName | shquote }}
+              local token={{ .ManagementEndpoint.Token | shquote }}
               local payload
               payload="{\"apiVersion\":\"v1\",\"kind\":\"Secret\",\"metadata\":{\"name\":\"${name}\",\"namespace\":\"${ns}\"},\"type\":\"cluster.x-k8s.io/secret\",\"data\":{\"value\":\"${kubeconfig_b64}\"}}"
               local url="${api}/api/v1/namespaces/${ns}/secrets/${name}"

--- a/internal/bootstrap/templates/k3s_kairos_cloud_config_capk.yaml.tmpl
+++ b/internal/bootstrap/templates/k3s_kairos_cloud_config_capk.yaml.tmpl
@@ -274,7 +274,7 @@ MANIFEST_EOF
       fi
       {{- end }}
       
-      {{- if .ManagementKubeconfigToken }}
+      {{- if .ManagementEndpoint }}
       # Push kubeconfig to management cluster without SSH (KubeVirt/CAPK)
       # Update server URL to LB endpoint so management cluster can connect
       push_kubeconfig() {
@@ -302,10 +302,10 @@ MANIFEST_EOF
         {{- else }}
         kubeconfig_b64=$(base64 -w 0 "${kubeconfig_file}" 2>/dev/null || base64 "${kubeconfig_file}" | tr -d '\n')
         {{- end }}
-        local api={{ .ManagementAPIServer | shquote }}
-        local ns="{{ .ManagementKubeconfigSecretNamespace }}"
-        local name="{{ .ManagementKubeconfigSecretName }}"
-        local token={{ .ManagementKubeconfigToken | shquote }}
+        local api={{ .ManagementEndpoint.APIServer | shquote }}
+        local ns={{ .ManagementEndpoint.KubeconfigSecretNamespace | shquote }}
+        local name={{ .ManagementEndpoint.KubeconfigSecretName | shquote }}
+        local token={{ .ManagementEndpoint.Token | shquote }}
         local payload
         payload="{\"apiVersion\":\"v1\",\"kind\":\"Secret\",\"metadata\":{\"name\":\"${name}\",\"namespace\":\"${ns}\"},\"type\":\"cluster.x-k8s.io/secret\",\"data\":{\"value\":\"${kubeconfig_b64}\"}}"
         local url="${api}/api/v1/namespaces/${ns}/secrets/${name}"

--- a/internal/bootstrap/validate.go
+++ b/internal/bootstrap/validate.go
@@ -95,14 +95,27 @@ func validateTemplateData(d *TemplateData) error {
 		{"controlPlaneLBServiceName", d.ControlPlaneLBServiceName},
 		{"controlPlaneLBServiceNamespace", d.ControlPlaneLBServiceNamespace},
 		{"controlPlaneLBEndpoint", d.ControlPlaneLBEndpoint},
-		{"managementKubeconfigToken", d.ManagementKubeconfigToken},
-		{"managementKubeconfigSecretName", d.ManagementKubeconfigSecretName},
-		{"managementKubeconfigSecretNamespace", d.ManagementKubeconfigSecretNamespace},
-		{"managementAPIServer", d.ManagementAPIServer},
 	}
 	for _, f := range stringFields {
 		if err := rejectControlChars(f.name, f.value); err != nil {
 			errs = append(errs, err)
+		}
+	}
+	// ManagementEndpoint is an optional nested struct; only when set do we
+	// check its fields. The nested-field names below mirror the JSON-style
+	// dotted form so the error message points the user back to the resolver
+	// output that produced it.
+	if d.ManagementEndpoint != nil {
+		nested := []struct{ name, value string }{
+			{"managementEndpoint.apiServer", d.ManagementEndpoint.APIServer},
+			{"managementEndpoint.token", d.ManagementEndpoint.Token},
+			{"managementEndpoint.kubeconfigSecretName", d.ManagementEndpoint.KubeconfigSecretName},
+			{"managementEndpoint.kubeconfigSecretNamespace", d.ManagementEndpoint.KubeconfigSecretNamespace},
+		}
+		for _, f := range nested {
+			if err := rejectControlChars(f.name, f.value); err != nil {
+				errs = append(errs, err)
+			}
 		}
 	}
 	for i, g := range d.UserGroups {

--- a/internal/bootstrap/validate_test.go
+++ b/internal/bootstrap/validate_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2024 The Kairos CAPI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidate_ManagementEndpointControlChars asserts that a control character
+// in any of the four ManagementEndpoint nested fields is rejected at render
+// time with an error message that names the offending nested field. These are
+// the gate-controlled fields the CAPK push block injects into shell scripts;
+// a stray `\n`/`\r`/NUL would break the YAML block scalar or escape the
+// shell-string-literal context inside `local foo='...'`.
+//
+// The renderer's reject is the secondary control — the primary control is the
+// shquote envelope on each field at the template site (see CLAUDE.md
+// § "Shell contexts"). This test only verifies the secondary control.
+func TestValidate_ManagementEndpointControlChars(t *testing.T) {
+	const payload = "evil\nshell"
+
+	cases := []struct {
+		name        string
+		ep          *ManagementEndpoint
+		wantInError string
+	}{
+		{
+			name: "APIServer",
+			ep: &ManagementEndpoint{
+				APIServer:                 "https://1.2.3.4:6443" + payload,
+				Token:                     "ok",
+				KubeconfigSecretName:      "ok",
+				KubeconfigSecretNamespace: "ok",
+			},
+			wantInError: "managementEndpoint.apiServer",
+		},
+		{
+			name: "Token",
+			ep: &ManagementEndpoint{
+				APIServer:                 "https://1.2.3.4:6443",
+				Token:                     "tok" + payload,
+				KubeconfigSecretName:      "ok",
+				KubeconfigSecretNamespace: "ok",
+			},
+			wantInError: "managementEndpoint.token",
+		},
+		{
+			name: "KubeconfigSecretName",
+			ep: &ManagementEndpoint{
+				APIServer:                 "https://1.2.3.4:6443",
+				Token:                     "ok",
+				KubeconfigSecretName:      "sec" + payload,
+				KubeconfigSecretNamespace: "ok",
+			},
+			wantInError: "managementEndpoint.kubeconfigSecretName",
+		},
+		{
+			name: "KubeconfigSecretNamespace",
+			ep: &ManagementEndpoint{
+				APIServer:                 "https://1.2.3.4:6443",
+				Token:                     "ok",
+				KubeconfigSecretName:      "ok",
+				KubeconfigSecretNamespace: "ns" + payload,
+			},
+			wantInError: "managementEndpoint.kubeconfigSecretNamespace",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data := TemplateData{
+				Role:               "control-plane",
+				SingleNode:         true,
+				UserName:           "kairos",
+				IsKubeVirt:         true,
+				ManagementEndpoint: tc.ep,
+			}
+			_, err := RenderK0sCloudConfig(data)
+			if err == nil {
+				t.Fatalf("expected render error for control char in %s, got nil", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantInError) {
+				t.Errorf("error %q does not mention expected field name %q", err.Error(), tc.wantInError)
+			}
+		})
+	}
+}
+
+// TestValidate_NilManagementEndpointSkipsNestedCheck asserts that a nil
+// ManagementEndpoint pointer does NOT trigger the nested-field control-char
+// check. The CAPV path and worker path never populate ManagementEndpoint;
+// asserting that the nested-field walk is gated by the nil check guards
+// against an accidental dereference (which would surface as a panic, not a
+// validation error).
+func TestValidate_NilManagementEndpointSkipsNestedCheck(t *testing.T) {
+	data := TemplateData{
+		Role:               "control-plane",
+		SingleNode:         true,
+		UserName:           "kairos",
+		IsKubeVirt:         false,
+		ManagementEndpoint: nil,
+	}
+	if _, err := RenderK0sCloudConfig(data); err != nil {
+		t.Fatalf("render with nil ManagementEndpoint should not error: %v", err)
+	}
+}

--- a/internal/controllers/bootstrap/kairosconfig_controller.go
+++ b/internal/controllers/bootstrap/kairosconfig_controller.go
@@ -937,39 +937,37 @@ func (r *KairosConfigReconciler) generateK0sCloudConfig(ctx context.Context, log
 
 	// Build template data
 	templateData := bootstrap.TemplateData{
-		Role:                                role,
-		SingleNode:                          singleNode,
-		Hostname:                            hostname,
-		UserName:                            userName,
-		UserPassword:                        userPassword,
-		UserGroups:                          userGroups,
-		GitHubUser:                          kairosConfig.Spec.GitHubUser,
-		SSHPublicKey:                        kairosConfig.Spec.SSHPublicKey,
-		WorkerToken:                         workerToken,
-		Manifests:                           kairosConfig.Spec.Manifests,
-		HostnamePrefix:                      hostnamePrefix,
-		DNSServers:                          kairosConfig.Spec.DNSServers,
-		PodCIDR:                             kairosConfig.Spec.PodCIDR,
-		ServiceCIDR:                         kairosConfig.Spec.ServiceCIDR,
-		PrimaryIP:                           kairosConfig.Spec.PrimaryIP,
-		MachineName:                         "",
-		ClusterNS:                           "",
-		IsKubeVirt:                          isKubevirtMachine(machine),
-		Install:                             installConfig,
-		ProviderID:                          providerID,
-		ControlPlaneLBServiceName:           "",
-		ControlPlaneLBServiceNamespace:      "",
-		ControlPlaneLBEndpoint:              "",
-		ManagementKubeconfigToken:           "",
-		ManagementKubeconfigSecretName:      "",
-		ManagementKubeconfigSecretNamespace: "",
-		ManagementAPIServer:                 "",
+		Role:                           role,
+		SingleNode:                     singleNode,
+		Hostname:                       hostname,
+		UserName:                       userName,
+		UserPassword:                   userPassword,
+		UserGroups:                     userGroups,
+		GitHubUser:                     kairosConfig.Spec.GitHubUser,
+		SSHPublicKey:                   kairosConfig.Spec.SSHPublicKey,
+		WorkerToken:                    workerToken,
+		Manifests:                      kairosConfig.Spec.Manifests,
+		HostnamePrefix:                 hostnamePrefix,
+		DNSServers:                     kairosConfig.Spec.DNSServers,
+		PodCIDR:                        kairosConfig.Spec.PodCIDR,
+		ServiceCIDR:                    kairosConfig.Spec.ServiceCIDR,
+		PrimaryIP:                      kairosConfig.Spec.PrimaryIP,
+		MachineName:                    "",
+		ClusterNS:                      "",
+		IsKubeVirt:                     isKubevirtMachine(machine),
+		Install:                        installConfig,
+		ProviderID:                     providerID,
+		ControlPlaneLBServiceName:      "",
+		ControlPlaneLBServiceNamespace: "",
+		ControlPlaneLBEndpoint:         "",
 	}
 	if kubeconfigPush != nil {
-		templateData.ManagementKubeconfigToken = kubeconfigPush.Token
-		templateData.ManagementKubeconfigSecretName = kubeconfigPush.SecretName
-		templateData.ManagementKubeconfigSecretNamespace = kubeconfigPush.SecretNamespace
-		templateData.ManagementAPIServer = kubeconfigPush.APIServer
+		templateData.ManagementEndpoint = &bootstrap.ManagementEndpoint{
+			APIServer:                 kubeconfigPush.APIServer,
+			Token:                     kubeconfigPush.Token,
+			KubeconfigSecretName:      kubeconfigPush.SecretName,
+			KubeconfigSecretNamespace: kubeconfigPush.SecretNamespace,
+		}
 	}
 	if machine != nil {
 		templateData.MachineName = machine.Name
@@ -1163,38 +1161,36 @@ func (r *KairosConfigReconciler) generateK3sCloudConfig(ctx context.Context, log
 
 	// Build template data
 	templateData := bootstrap.TemplateData{
-		Role:                                role,
-		SingleNode:                          singleNode,
-		Hostname:                            hostname,
-		UserName:                            userName,
-		UserPassword:                        userPassword,
-		UserGroups:                          userGroups,
-		GitHubUser:                          kairosConfig.Spec.GitHubUser,
-		SSHPublicKey:                        kairosConfig.Spec.SSHPublicKey,
-		Manifests:                           kairosConfig.Spec.Manifests,
-		HostnamePrefix:                      hostnamePrefix,
-		DNSServers:                          kairosConfig.Spec.DNSServers,
-		PrimaryIP:                           kairosConfig.Spec.PrimaryIP,
-		MachineName:                         "",
-		ClusterNS:                           "",
-		IsKubeVirt:                          isKubevirtMachine(machine),
-		Install:                             installConfig,
-		ProviderID:                          providerID,
-		K3sServerURL:                        serverAddress,
-		K3sToken:                            k3sToken,
-		ControlPlaneLBServiceName:           "",
-		ControlPlaneLBServiceNamespace:      "",
-		ControlPlaneLBEndpoint:              "",
-		ManagementKubeconfigToken:           "",
-		ManagementKubeconfigSecretName:      "",
-		ManagementKubeconfigSecretNamespace: "",
-		ManagementAPIServer:                 "",
+		Role:                           role,
+		SingleNode:                     singleNode,
+		Hostname:                       hostname,
+		UserName:                       userName,
+		UserPassword:                   userPassword,
+		UserGroups:                     userGroups,
+		GitHubUser:                     kairosConfig.Spec.GitHubUser,
+		SSHPublicKey:                   kairosConfig.Spec.SSHPublicKey,
+		Manifests:                      kairosConfig.Spec.Manifests,
+		HostnamePrefix:                 hostnamePrefix,
+		DNSServers:                     kairosConfig.Spec.DNSServers,
+		PrimaryIP:                      kairosConfig.Spec.PrimaryIP,
+		MachineName:                    "",
+		ClusterNS:                      "",
+		IsKubeVirt:                     isKubevirtMachine(machine),
+		Install:                        installConfig,
+		ProviderID:                     providerID,
+		K3sServerURL:                   serverAddress,
+		K3sToken:                       k3sToken,
+		ControlPlaneLBServiceName:      "",
+		ControlPlaneLBServiceNamespace: "",
+		ControlPlaneLBEndpoint:         "",
 	}
 	if kubeconfigPush != nil {
-		templateData.ManagementKubeconfigToken = kubeconfigPush.Token
-		templateData.ManagementKubeconfigSecretName = kubeconfigPush.SecretName
-		templateData.ManagementKubeconfigSecretNamespace = kubeconfigPush.SecretNamespace
-		templateData.ManagementAPIServer = kubeconfigPush.APIServer
+		templateData.ManagementEndpoint = &bootstrap.ManagementEndpoint{
+			APIServer:                 kubeconfigPush.APIServer,
+			Token:                     kubeconfigPush.Token,
+			KubeconfigSecretName:      kubeconfigPush.SecretName,
+			KubeconfigSecretNamespace: kubeconfigPush.SecretNamespace,
+		}
 	}
 	if machine != nil {
 		templateData.MachineName = machine.Name

--- a/internal/controllers/bootstrap/kairosconfig_controller.go
+++ b/internal/controllers/bootstrap/kairosconfig_controller.go
@@ -27,16 +27,13 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/rest"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -56,11 +53,21 @@ const controlPlaneLBServiceSuffix = "control-plane-lb"
 var errLBEndpointNotReady = errors.New("control plane load balancer endpoint not ready")
 var errK3sTokenNotReady = errors.New("k3s token secret not ready")
 
-// KairosConfigReconciler reconciles a KairosConfig object
+// KairosConfigReconciler reconciles a KairosConfig object.
+//
+// MgmtEndpointResolver is the seam introduced by KD-33: the reconciler holds
+// an adapter that turns a (KairosConfig, Cluster) tuple into the four-field
+// management-endpoint bundle the renderer needs to emit the in-node
+// kubeconfig-push block on CAPK control-plane Machines. In production
+// (main.go) this is a kubeVirtTokenResolver wired off mgr.GetConfig().Host.
+// In tests it can be a fake. The reconciler MUST tolerate the resolver
+// returning (nil, nil) — that is the documented "disabled" signal, used by
+// envtest setups and the out-of-cluster `go run` flow where the manager has
+// no usable REST config to point nodes back at.
 type KairosConfigReconciler struct {
 	client.Client
-	Scheme     *runtime.Scheme
-	RESTConfig *rest.Config
+	Scheme               *runtime.Scheme
+	MgmtEndpointResolver ManagementEndpointResolver
 }
 
 //+kubebuilder:rbac:groups=bootstrap.cluster.x-k8s.io,resources=kairosconfigs,verbs=get;list;watch;create;update;patch;delete
@@ -926,10 +933,17 @@ func (r *KairosConfigReconciler) generateK0sCloudConfig(ctx context.Context, log
 	// This is needed to set the Node's providerID so the Machine controller can match Nodes to Machines
 	providerID := r.getProviderID(ctx, log, machine)
 
-	var kubeconfigPush *kubeconfigPushConfig
-	if isKubevirtMachine(machine) && role == "control-plane" {
+	// CAPK control-plane: ask the resolver for the management-endpoint bundle
+	// the node needs to push its kubeconfig back without SSH. The gating
+	// (CAPK + control-plane only) stays here in the reconciler — it's
+	// routing, not a resolver concern. The resolver itself is allowed to
+	// return (nil, nil) as a "disabled" signal (e.g. envtest without a
+	// management REST config); we treat that the same as "no push block",
+	// per the contract in management_endpoint.go.
+	var mgmtEndpoint *ManagementEndpoint
+	if isKubevirtMachine(machine) && role == "control-plane" && r.MgmtEndpointResolver != nil {
 		var err error
-		kubeconfigPush, err = r.ensureKubeconfigPushConfig(ctx, log, kairosConfig, cluster)
+		mgmtEndpoint, err = r.MgmtEndpointResolver.Resolve(ctx, kairosConfig, cluster)
 		if err != nil {
 			return "", err
 		}
@@ -961,12 +975,15 @@ func (r *KairosConfigReconciler) generateK0sCloudConfig(ctx context.Context, log
 		ControlPlaneLBServiceNamespace: "",
 		ControlPlaneLBEndpoint:         "",
 	}
-	if kubeconfigPush != nil {
+	if mgmtEndpoint != nil {
+		// One-line conversion preserves the rule that internal/bootstrap is
+		// API-server-unaware: the renderer's ManagementEndpoint is a flat
+		// data struct, identical in shape but distinct in type.
 		templateData.ManagementEndpoint = &bootstrap.ManagementEndpoint{
-			APIServer:                 kubeconfigPush.APIServer,
-			Token:                     kubeconfigPush.Token,
-			KubeconfigSecretName:      kubeconfigPush.SecretName,
-			KubeconfigSecretNamespace: kubeconfigPush.SecretNamespace,
+			APIServer:                 mgmtEndpoint.APIServer,
+			Token:                     mgmtEndpoint.Token,
+			KubeconfigSecretName:      mgmtEndpoint.KubeconfigSecretName,
+			KubeconfigSecretNamespace: mgmtEndpoint.KubeconfigSecretNamespace,
 		}
 	}
 	if machine != nil {
@@ -1149,11 +1166,11 @@ func (r *KairosConfigReconciler) generateK3sCloudConfig(ctx context.Context, log
 	// Get providerID from Machine's infrastructure reference
 	providerID := r.getProviderID(ctx, log, machine)
 
-	// CAPK: ensure kubeconfig push config and LB endpoint for KubeVirt control-plane (same as k0s)
-	var kubeconfigPush *kubeconfigPushConfig
-	if isKubevirtMachine(machine) && role == "control-plane" {
+	// CAPK control-plane: same routing as the k0s path above.
+	var mgmtEndpoint *ManagementEndpoint
+	if isKubevirtMachine(machine) && role == "control-plane" && r.MgmtEndpointResolver != nil {
 		var err error
-		kubeconfigPush, err = r.ensureKubeconfigPushConfig(ctx, log, kairosConfig, cluster)
+		mgmtEndpoint, err = r.MgmtEndpointResolver.Resolve(ctx, kairosConfig, cluster)
 		if err != nil {
 			return "", err
 		}
@@ -1184,12 +1201,12 @@ func (r *KairosConfigReconciler) generateK3sCloudConfig(ctx context.Context, log
 		ControlPlaneLBServiceNamespace: "",
 		ControlPlaneLBEndpoint:         "",
 	}
-	if kubeconfigPush != nil {
+	if mgmtEndpoint != nil {
 		templateData.ManagementEndpoint = &bootstrap.ManagementEndpoint{
-			APIServer:                 kubeconfigPush.APIServer,
-			Token:                     kubeconfigPush.Token,
-			KubeconfigSecretName:      kubeconfigPush.SecretName,
-			KubeconfigSecretNamespace: kubeconfigPush.SecretNamespace,
+			APIServer:                 mgmtEndpoint.APIServer,
+			Token:                     mgmtEndpoint.Token,
+			KubeconfigSecretName:      mgmtEndpoint.KubeconfigSecretName,
+			KubeconfigSecretNamespace: mgmtEndpoint.KubeconfigSecretNamespace,
 		}
 	}
 	if machine != nil {
@@ -1302,124 +1319,11 @@ func randomString(length int) (string, error) {
 	return string(b), nil
 }
 
-type kubeconfigPushConfig struct {
-	Token           string
-	APIServer       string
-	SecretName      string
-	SecretNamespace string
-}
-
-func (r *KairosConfigReconciler) ensureKubeconfigPushConfig(ctx context.Context, log logr.Logger, kairosConfig *bootstrapv1beta2.KairosConfig, cluster *clusterv1.Cluster) (*kubeconfigPushConfig, error) {
-	if r.RESTConfig == nil || r.RESTConfig.Host == "" {
-		log.Info("Skipping kubeconfig push config; REST config not available")
-		return nil, nil
-	}
-
-	secretName := fmt.Sprintf("%s-kubeconfig", cluster.Name)
-	saName := kubeconfigWriterName(cluster.Name)
-
-	serviceAccount := &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      saName,
-			Namespace: cluster.Namespace,
-		},
-	}
-	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, serviceAccount, func() error {
-		if serviceAccount.Labels == nil {
-			serviceAccount.Labels = map[string]string{}
-		}
-		serviceAccount.Labels[clusterv1.ClusterNameLabel] = cluster.Name
-		return controllerutil.SetControllerReference(kairosConfig, serviceAccount, r.Scheme)
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to ensure kubeconfig writer serviceaccount: %w", err)
-	}
-
-	role := &rbacv1.Role{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      saName,
-			Namespace: cluster.Namespace,
-		},
-	}
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, role, func() error {
-		role.Rules = []rbacv1.PolicyRule{
-			{
-				APIGroups:     []string{""},
-				Resources:     []string{"secrets"},
-				ResourceNames: []string{secretName},
-				Verbs:         []string{"get", "create", "update", "patch"},
-			},
-			{
-				APIGroups: []string{"kubevirt.io"},
-				Resources: []string{"virtualmachineinstances"},
-				Verbs:     []string{"get"},
-			},
-			{
-				APIGroups: []string{""},
-				Resources: []string{"services"},
-				Verbs:     []string{"get"},
-			},
-		}
-		if role.Labels == nil {
-			role.Labels = map[string]string{}
-		}
-		role.Labels[clusterv1.ClusterNameLabel] = cluster.Name
-		return controllerutil.SetControllerReference(kairosConfig, role, r.Scheme)
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to ensure kubeconfig writer role: %w", err)
-	}
-
-	roleBinding := &rbacv1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      saName,
-			Namespace: cluster.Namespace,
-		},
-	}
-	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, roleBinding, func() error {
-		roleBinding.RoleRef = rbacv1.RoleRef{
-			APIGroup: rbacv1.GroupName,
-			Kind:     "Role",
-			Name:     role.Name,
-		}
-		roleBinding.Subjects = []rbacv1.Subject{
-			{
-				Kind:      "ServiceAccount",
-				Name:      serviceAccount.Name,
-				Namespace: serviceAccount.Namespace,
-			},
-		}
-		if roleBinding.Labels == nil {
-			roleBinding.Labels = map[string]string{}
-		}
-		roleBinding.Labels[clusterv1.ClusterNameLabel] = cluster.Name
-		return controllerutil.SetControllerReference(kairosConfig, roleBinding, r.Scheme)
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to ensure kubeconfig writer rolebinding: %w", err)
-	}
-
-	expirationSeconds := int64(24 * 60 * 60)
-	tokenRequest := &authenticationv1.TokenRequest{
-		Spec: authenticationv1.TokenRequestSpec{
-			Audiences:         []string{"https://kubernetes.default.svc"},
-			ExpirationSeconds: &expirationSeconds,
-		},
-	}
-	if err := r.SubResource("token").Create(ctx, serviceAccount, tokenRequest); err != nil {
-		return nil, fmt.Errorf("failed to create serviceaccount token: %w", err)
-	}
-	if tokenRequest.Status.Token == "" {
-		return nil, fmt.Errorf("serviceaccount token request returned empty token")
-	}
-
-	return &kubeconfigPushConfig{
-		Token:           tokenRequest.Status.Token,
-		APIServer:       r.RESTConfig.Host,
-		SecretName:      secretName,
-		SecretNamespace: cluster.Namespace,
-	}, nil
-}
+// kubeconfigPushConfig + ensureKubeconfigPushConfig were moved out to
+// management_endpoint_resolver.go's kubeVirtTokenResolver implementation as
+// part of KD-33. The reconciler now holds an interface-typed
+// MgmtEndpointResolver field and routes through it; main.go wires the
+// production kubeVirtTokenResolver, tests wire fakes.
 
 func kubeconfigWriterName(clusterName string) string {
 	base := "kairos-kubeconfig-writer"

--- a/internal/controllers/bootstrap/kairosconfig_controller_test.go
+++ b/internal/controllers/bootstrap/kairosconfig_controller_test.go
@@ -929,7 +929,9 @@ func TestGenerateK3sCloudConfig_ControlPlaneKubeVirtCapk(t *testing.T) {
 	reconciler := &KairosConfigReconciler{
 		Client: client,
 		Scheme: scheme,
-		// RESTConfig nil: ensureKubeconfigPushConfig returns nil, but LB + CAPK template still used
+		// MgmtEndpointResolver nil: the CAPK gate in generate*CloudConfig
+		// short-circuits to "no push block" but the LB endpoint + CAPK
+		// template selection still apply.
 	}
 
 	kairosConfig := &bootstrapv1beta2.KairosConfig{

--- a/internal/controllers/bootstrap/management_endpoint.go
+++ b/internal/controllers/bootstrap/management_endpoint.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2024 The Kairos CAPI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"context"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+	bootstrapv1beta2 "github.com/kairos-io/cluster-api-provider-kairos/api/bootstrap/v1beta2"
+)
+
+// ManagementEndpoint carries the four values a node needs to push its
+// kubeconfig back to the management cluster without SSH. It is the
+// controller-package twin of internal/bootstrap.ManagementEndpoint — the two
+// structs are kept separate so the renderer stays free of any controller /
+// Kubernetes-API concerns (cloudconfig-rendering-safety rule: the renderer
+// does not talk to the API server). The call site in generate*CloudConfig
+// performs a one-line struct-literal conversion.
+type ManagementEndpoint struct {
+	APIServer                 string
+	Token                     string
+	KubeconfigSecretName      string
+	KubeconfigSecretNamespace string
+}
+
+// ManagementEndpointResolver materialises the management-cluster contact info
+// the node needs at boot. Implementations are responsible for:
+//
+//   - Mint or look up an authenticated token whose RBAC reach is the bare
+//     minimum required to push the kubeconfig Secret (and read VMI status,
+//     under CAPK, for the SAN-detection script).
+//   - Compute the management API URL the node should call back to.
+//   - Pick the (namespace, name) of the kubeconfig Secret to write.
+//
+// Returning (nil, nil) is the documented "disabled" signal — used by the
+// production resolver when the manager's REST config is unavailable (envtest,
+// out-of-cluster `go run` flows). Callers MUST treat (nil, nil) as
+// "render without push block", not as an error.
+//
+// The interface is the seam PR-6 introduces so PR-7 (KD-3b) can drop in
+// non-CAPK resolvers (CAPV, CAPM3) without touching the bootstrap controller.
+type ManagementEndpointResolver interface {
+	Resolve(ctx context.Context, kc *bootstrapv1beta2.KairosConfig, cluster *clusterv1.Cluster) (*ManagementEndpoint, error)
+}

--- a/internal/controllers/bootstrap/management_endpoint_resolver.go
+++ b/internal/controllers/bootstrap/management_endpoint_resolver.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2024 The Kairos CAPI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+	bootstrapv1beta2 "github.com/kairos-io/cluster-api-provider-kairos/api/bootstrap/v1beta2"
+)
+
+// kubeVirtTokenResolver implements ManagementEndpointResolver against the CAPK
+// kubeconfig-push pattern: a per-cluster ServiceAccount whose Role can write
+// the cluster's kubeconfig Secret and read the controlling VMI for
+// SAN-detection. The resolver mints a fresh 24h TokenRequest on every call —
+// see TODO(KD-33b) on Resolve below.
+//
+// Behavior must remain byte-identical to the pre-refactor
+// KairosConfigReconciler.ensureKubeconfigPushConfig method this struct
+// replaces. PR-6 is a pure move; the SA/Role/RoleBinding shape, the
+// 24h-token-on-every-render policy, the cluster.x-k8s.io/cluster-name labels,
+// and the (nil,nil) "disabled" signal when ManagementAPIServer is empty are
+// all preserved.
+type kubeVirtTokenResolver struct {
+	// Client is the controller-runtime client used to upsert the
+	// ServiceAccount, Role and RoleBinding. Must be the management-cluster
+	// client (not a workload-cluster client).
+	Client client.Client
+
+	// SubResource returns a SubResourceClient for the named subresource
+	// ("token"). The indirection lets tests inject a fake that returns a
+	// canned TokenRequest without spinning up envtest; production passes
+	// (client.Client).SubResource directly.
+	SubResource func(string) client.SubResourceClient
+
+	// Scheme is needed by controllerutil.SetControllerReference on the SA /
+	// Role / RoleBinding. Must include core/v1 and rbac/v1.
+	Scheme *runtime.Scheme
+
+	// ManagementAPIServer is the URL nodes will dial back to. Production
+	// wiring pulls this from mgr.GetConfig().Host at SetupWithManager time.
+	// Empty string is the disabled-resolver signal.
+	ManagementAPIServer string
+}
+
+// Resolve performs the same idempotent SA/Role/RoleBinding upsert as the
+// removed KairosConfigReconciler.ensureKubeconfigPushConfig and mints a fresh
+// 24h serviceaccount token via the TokenRequest subresource API.
+//
+// Returns (nil, nil) when ManagementAPIServer is empty — the same "REST
+// config not available" disabled signal the legacy method used. Callers
+// (currently generateK0sCloudConfig / generateK3sCloudConfig) must treat that
+// as "render without the push block", not as an error.
+//
+// TODO(KD-33b): cache tokens; refresh when <30m remaining. Each Reconcile
+// that renders today re-mints, which costs one TokenRequest API call per
+// reconcile per CAPK control-plane Machine. Acceptable for alpha-2; revisit
+// once we have lab data on Reconcile frequency under steady-state. Caching
+// belongs here in the resolver, not on the reconciler.
+func (r *kubeVirtTokenResolver) Resolve(ctx context.Context, kc *bootstrapv1beta2.KairosConfig, cluster *clusterv1.Cluster) (*ManagementEndpoint, error) {
+	log := ctrl.LoggerFrom(ctx)
+	if r.ManagementAPIServer == "" {
+		log.Info("Skipping kubeconfig push config; REST config not available")
+		return nil, nil
+	}
+
+	secretName := fmt.Sprintf("%s-kubeconfig", cluster.Name)
+	saName := kubeconfigWriterName(cluster.Name)
+
+	serviceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      saName,
+			Namespace: cluster.Namespace,
+		},
+	}
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, serviceAccount, func() error {
+		if serviceAccount.Labels == nil {
+			serviceAccount.Labels = map[string]string{}
+		}
+		serviceAccount.Labels[clusterv1.ClusterNameLabel] = cluster.Name
+		return controllerutil.SetControllerReference(kc, serviceAccount, r.Scheme)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to ensure kubeconfig writer serviceaccount: %w", err)
+	}
+
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      saName,
+			Namespace: cluster.Namespace,
+		},
+	}
+	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, role, func() error {
+		role.Rules = []rbacv1.PolicyRule{
+			{
+				APIGroups:     []string{""},
+				Resources:     []string{"secrets"},
+				ResourceNames: []string{secretName},
+				Verbs:         []string{"get", "create", "update", "patch"},
+			},
+			{
+				APIGroups: []string{"kubevirt.io"},
+				Resources: []string{"virtualmachineinstances"},
+				Verbs:     []string{"get"},
+			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"services"},
+				Verbs:     []string{"get"},
+			},
+		}
+		if role.Labels == nil {
+			role.Labels = map[string]string{}
+		}
+		role.Labels[clusterv1.ClusterNameLabel] = cluster.Name
+		return controllerutil.SetControllerReference(kc, role, r.Scheme)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to ensure kubeconfig writer role: %w", err)
+	}
+
+	roleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      saName,
+			Namespace: cluster.Namespace,
+		},
+	}
+	_, err = controllerutil.CreateOrUpdate(ctx, r.Client, roleBinding, func() error {
+		roleBinding.RoleRef = rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     role.Name,
+		}
+		roleBinding.Subjects = []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      serviceAccount.Name,
+				Namespace: serviceAccount.Namespace,
+			},
+		}
+		if roleBinding.Labels == nil {
+			roleBinding.Labels = map[string]string{}
+		}
+		roleBinding.Labels[clusterv1.ClusterNameLabel] = cluster.Name
+		return controllerutil.SetControllerReference(kc, roleBinding, r.Scheme)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to ensure kubeconfig writer rolebinding: %w", err)
+	}
+
+	expirationSeconds := int64(24 * 60 * 60)
+	tokenRequest := &authenticationv1.TokenRequest{
+		Spec: authenticationv1.TokenRequestSpec{
+			Audiences:         []string{"https://kubernetes.default.svc"},
+			ExpirationSeconds: &expirationSeconds,
+		},
+	}
+	if err := r.SubResource("token").Create(ctx, serviceAccount, tokenRequest); err != nil {
+		return nil, fmt.Errorf("failed to create serviceaccount token: %w", err)
+	}
+	if tokenRequest.Status.Token == "" {
+		return nil, fmt.Errorf("serviceaccount token request returned empty token")
+	}
+
+	return &ManagementEndpoint{
+		Token:                     tokenRequest.Status.Token,
+		APIServer:                 r.ManagementAPIServer,
+		KubeconfigSecretName:      secretName,
+		KubeconfigSecretNamespace: cluster.Namespace,
+	}, nil
+}
+
+// Compile-time guard that kubeVirtTokenResolver satisfies the interface.
+var _ ManagementEndpointResolver = (*kubeVirtTokenResolver)(nil)
+
+// NewKubeVirtTokenResolver constructs the production resolver wiring the
+// controller-runtime client's SubResource method directly. main.go calls this
+// at manager startup; tests in this package construct the struct literally
+// with a fake SubResource client.
+func NewKubeVirtTokenResolver(c client.Client, scheme *runtime.Scheme, mgmtAPIServer string) ManagementEndpointResolver {
+	return &kubeVirtTokenResolver{
+		Client:              c,
+		SubResource:         c.SubResource,
+		Scheme:              scheme,
+		ManagementAPIServer: mgmtAPIServer,
+	}
+}

--- a/internal/controllers/bootstrap/management_endpoint_resolver_test.go
+++ b/internal/controllers/bootstrap/management_endpoint_resolver_test.go
@@ -1,0 +1,256 @@
+/*
+Copyright 2024 The Kairos CAPI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	bootstrapv1beta2 "github.com/kairos-io/cluster-api-provider-kairos/api/bootstrap/v1beta2"
+)
+
+// fakeSubResourceClient is the minimum surface tests need to drive
+// kubeVirtTokenResolver — just the Create path against the "token"
+// subresource. Get/Update/Patch are not exercised by the resolver, so they
+// remain unimplemented (calling them in a test would surface the omission as
+// a panic, which is the desired failure mode).
+type fakeSubResourceClient struct {
+	createCalls int
+	// token is the token string the fake returns on Create. Empty means the
+	// fake returns success but with an empty token, exercising the
+	// "TokenRequest returned empty token" error path.
+	token string
+	// err, if non-nil, is returned from Create — exercising the
+	// SubResource("token").Create failure path.
+	err error
+}
+
+func (f *fakeSubResourceClient) Get(_ context.Context, _ client.Object, _ client.Object, _ ...client.SubResourceGetOption) error {
+	return errors.New("fakeSubResourceClient.Get not implemented")
+}
+
+func (f *fakeSubResourceClient) Create(_ context.Context, _ client.Object, sub client.Object, _ ...client.SubResourceCreateOption) error {
+	f.createCalls++
+	if f.err != nil {
+		return f.err
+	}
+	tr, ok := sub.(*authenticationv1.TokenRequest)
+	if !ok {
+		return errors.New("fake: Create called with non-TokenRequest subResource")
+	}
+	tr.Status.Token = f.token
+	return nil
+}
+
+func (f *fakeSubResourceClient) Update(_ context.Context, _ client.Object, _ ...client.SubResourceUpdateOption) error {
+	return errors.New("fakeSubResourceClient.Update not implemented")
+}
+
+func (f *fakeSubResourceClient) Patch(_ context.Context, _ client.Object, _ client.Patch, _ ...client.SubResourcePatchOption) error {
+	return errors.New("fakeSubResourceClient.Patch not implemented")
+}
+
+func newResolverScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	g := NewWithT(t)
+	scheme := runtime.NewScheme()
+	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(rbacv1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(authenticationv1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(clusterv1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(bootstrapv1beta2.AddToScheme(scheme)).To(Succeed())
+	return scheme
+}
+
+func newResolverFixture(scheme *runtime.Scheme, sub *fakeSubResourceClient, mgmtAPI string, seed ...client.Object) (*kubeVirtTokenResolver, *bootstrapv1beta2.KairosConfig, *clusterv1.Cluster) {
+	kc := &bootstrapv1beta2.KairosConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-config",
+			Namespace: "default",
+			UID:       "00000000-0000-0000-0000-000000000001",
+		},
+	}
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "default",
+		},
+	}
+	objects := append([]client.Object{kc, cluster}, seed...)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	r := &kubeVirtTokenResolver{
+		Client:              c,
+		SubResource:         func(string) client.SubResourceClient { return sub },
+		Scheme:              scheme,
+		ManagementAPIServer: mgmtAPI,
+	}
+	return r, kc, cluster
+}
+
+// TestResolve_HappyPath_ReturnsFullEndpoint exercises the success path: an
+// empty management cluster receives the SA/Role/RoleBinding upserts, the
+// fake TokenRequest returns a token, and the resolver assembles the
+// ManagementEndpoint with all four fields populated.
+func TestResolve_HappyPath_ReturnsFullEndpoint(t *testing.T) {
+	g := NewWithT(t)
+	scheme := newResolverScheme(t)
+	sub := &fakeSubResourceClient{token: "tok-abc"}
+	r, kc, cluster := newResolverFixture(scheme, sub, "https://mgmt:6443")
+
+	got, err := r.Resolve(context.Background(), kc, cluster)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(got).NotTo(BeNil())
+	g.Expect(got.Token).To(Equal("tok-abc"))
+	g.Expect(got.APIServer).To(Equal("https://mgmt:6443"))
+	g.Expect(got.KubeconfigSecretName).To(Equal("test-cluster-kubeconfig"))
+	g.Expect(got.KubeconfigSecretNamespace).To(Equal("default"))
+
+	// SA/Role/RoleBinding were created with the cluster-name label.
+	saName := kubeconfigWriterName("test-cluster")
+	sa := &corev1.ServiceAccount{}
+	g.Expect(r.Client.Get(context.Background(), types.NamespacedName{Name: saName, Namespace: "default"}, sa)).To(Succeed())
+	g.Expect(sa.Labels).To(HaveKeyWithValue(clusterv1.ClusterNameLabel, "test-cluster"))
+	role := &rbacv1.Role{}
+	g.Expect(r.Client.Get(context.Background(), types.NamespacedName{Name: saName, Namespace: "default"}, role)).To(Succeed())
+	g.Expect(role.Rules).To(HaveLen(3))
+	rb := &rbacv1.RoleBinding{}
+	g.Expect(r.Client.Get(context.Background(), types.NamespacedName{Name: saName, Namespace: "default"}, rb)).To(Succeed())
+	g.Expect(rb.RoleRef.Name).To(Equal(saName))
+	g.Expect(sub.createCalls).To(Equal(1))
+}
+
+// TestResolve_SubResourceError_ReturnsError asserts that a TokenRequest
+// failure from the SubResource client propagates as an error and the
+// resolver returns nil for the endpoint.
+func TestResolve_SubResourceError_ReturnsError(t *testing.T) {
+	g := NewWithT(t)
+	scheme := newResolverScheme(t)
+	sub := &fakeSubResourceClient{err: errors.New("boom")}
+	r, kc, cluster := newResolverFixture(scheme, sub, "https://mgmt:6443")
+
+	got, err := r.Resolve(context.Background(), kc, cluster)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("failed to create serviceaccount token"))
+	g.Expect(got).To(BeNil())
+}
+
+// TestResolve_EmptyToken_ReturnsError asserts that a successful TokenRequest
+// with an empty .Status.Token (which the apiserver can legitimately return
+// under some auth-plugin misconfigurations) is detected and returned as an
+// error rather than silently producing a useless ManagementEndpoint.
+func TestResolve_EmptyToken_ReturnsError(t *testing.T) {
+	g := NewWithT(t)
+	scheme := newResolverScheme(t)
+	sub := &fakeSubResourceClient{token: ""}
+	r, kc, cluster := newResolverFixture(scheme, sub, "https://mgmt:6443")
+
+	got, err := r.Resolve(context.Background(), kc, cluster)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("empty token"))
+	g.Expect(got).To(BeNil())
+}
+
+// TestResolve_EmptyManagementAPIServer_ReturnsNilNil verifies the documented
+// "disabled" signal: when ManagementAPIServer is empty (envtest, `go run`
+// outside a cluster), the resolver returns (nil, nil) and skips all
+// SA/Role/RoleBinding/TokenRequest work. This contract lets the reconciler
+// continue rendering without the in-node push block.
+func TestResolve_EmptyManagementAPIServer_ReturnsNilNil(t *testing.T) {
+	g := NewWithT(t)
+	scheme := newResolverScheme(t)
+	sub := &fakeSubResourceClient{token: "ignored"}
+	r, kc, cluster := newResolverFixture(scheme, sub, "")
+
+	got, err := r.Resolve(context.Background(), kc, cluster)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(got).To(BeNil())
+	g.Expect(sub.createCalls).To(Equal(0))
+	// The SA must not have been touched either.
+	saName := kubeconfigWriterName("test-cluster")
+	sa := &corev1.ServiceAccount{}
+	err = r.Client.Get(context.Background(), types.NamespacedName{Name: saName, Namespace: "default"}, sa)
+	g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+}
+
+// TestResolve_Idempotent_TwoCallsNoConflict asserts that calling Resolve
+// twice in a row against the same fixture does not error on the second call.
+// The first call creates the SA/Role/RoleBinding; the second goes through
+// controllerutil.CreateOrUpdate's update path. This is the property the
+// legacy ensureKubeconfigPushConfig depended on (Reconcile re-renders on
+// every Generation bump and we cannot afford a second-call conflict).
+func TestResolve_Idempotent_TwoCallsNoConflict(t *testing.T) {
+	g := NewWithT(t)
+	scheme := newResolverScheme(t)
+	sub := &fakeSubResourceClient{token: "tok-abc"}
+	r, kc, cluster := newResolverFixture(scheme, sub, "https://mgmt:6443")
+
+	first, err := r.Resolve(context.Background(), kc, cluster)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(first).NotTo(BeNil())
+
+	second, err := r.Resolve(context.Background(), kc, cluster)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(second).NotTo(BeNil())
+	g.Expect(second.Token).To(Equal("tok-abc"))
+	// Both calls produced a TokenRequest — no in-resolver caching today.
+	// (KD-33b will add caching; this assertion is the regression guard for
+	// the "remove caching by accident" reverse direction.)
+	g.Expect(sub.createCalls).To(Equal(2))
+}
+
+// TestResolve_PreExistingServiceAccount_StillSucceeds covers the case where
+// a previous reconcile (or another controller) already created the SA, but
+// not the Role or RoleBinding. The CreateOrUpdate path must adopt the
+// existing SA (setting our owner-ref + label on update) rather than fail.
+func TestResolve_PreExistingServiceAccount_StillSucceeds(t *testing.T) {
+	g := NewWithT(t)
+	scheme := newResolverScheme(t)
+	saName := kubeconfigWriterName("test-cluster")
+	preExisting := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      saName,
+			Namespace: "default",
+			// No labels, no owner-ref — the resolver must add them via the
+			// CreateOrUpdate mutate function.
+		},
+	}
+	sub := &fakeSubResourceClient{token: "tok-xyz"}
+	r, kc, cluster := newResolverFixture(scheme, sub, "https://mgmt:6443", preExisting)
+
+	got, err := r.Resolve(context.Background(), kc, cluster)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(got).NotTo(BeNil())
+	g.Expect(got.Token).To(Equal("tok-xyz"))
+
+	// The SA's label was added on the update path.
+	sa := &corev1.ServiceAccount{}
+	g.Expect(r.Client.Get(context.Background(), types.NamespacedName{Name: saName, Namespace: "default"}, sa)).To(Succeed())
+	g.Expect(sa.Labels).To(HaveKeyWithValue(clusterv1.ClusterNameLabel, "test-cluster"))
+}

--- a/main.go
+++ b/main.go
@@ -110,10 +110,21 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Wire the production management-endpoint resolver. Pulling the API
+	// server URL from mgr.GetConfig().Host preserves the pre-KD-33 behavior
+	// (the legacy ensureKubeconfigPushConfig used the same source). The
+	// resolver itself short-circuits to (nil, nil) when ManagementAPIServer
+	// is empty — the documented disabled signal — so an empty Host stays a
+	// graceful "render without push block" rather than a startup error.
+	mgmtResolver := bootstrap.NewKubeVirtTokenResolver(
+		mgr.GetClient(),
+		mgr.GetScheme(),
+		mgr.GetConfig().Host,
+	)
 	if err = (&bootstrap.KairosConfigReconciler{
-		Client:     mgr.GetClient(),
-		Scheme:     mgr.GetScheme(),
-		RESTConfig: mgr.GetConfig(),
+		Client:               mgr.GetClient(),
+		Scheme:               mgr.GetScheme(),
+		MgmtEndpointResolver: mgmtResolver,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KairosConfig")
 		os.Exit(1)


### PR DESCRIPTION
## Summary

- Collapses four flat `TemplateData` management fields into a single
  `*bootstrap.ManagementEndpoint` struct; pointer-nil replaces
  string-truthiness as the gate for emitting the kubeconfig-push block.
- Extracts `KairosConfigReconciler.ensureKubeconfigPushConfig` into a
  `kubeVirtTokenResolver` implementing a new `ManagementEndpointResolver`
  interface; interface is a field on the reconciler so PR-7 can drop in
  non-CAPK resolvers without touching the reconciler.
- Bundles the residual KD-2 shquote follow-up: `local ns/name=` lines in
  both CAPK templates switch from double-quoted raw interpolation to
  shquote single-quoted literals (the two fields had shquote treatment
  added to the validator but not the template in PR-5).

## What this refactors (not a fix; not a feature)

PR-6 is a pure internal restructuring. No CRD field is added or removed.
No CLI flag changes. No sample manifest changes. The public Go API as seen
from `kubectl explain` is identical before and after.

Render output is byte-identical for nil-endpoint paths. For a fully
populated `ManagementEndpoint`, the only output difference is the four
`local ns/name=` shell lines switching from `"value"` to `'value'`
(the bundled KD-2 shquote fix). Verified by golden pre/post diff.

## Design notes

**No CRD field.** `staff-architect` scoped this as an internal refactor.
A user-visible `Spec.ManagementEndpoint` override was deferred: no real
use case for it exists today, and adding a CRD field before we know the
multi-network shape would create upgrade pressure. The interface seam is
sufficient for PR-7's additive non-CAPK resolver.

**Resolver as adapter.** `kubeVirtTokenResolver` is the only
implementation today. It is identical in behavior to the removed
`ensureKubeconfigPushConfig` method: same SA/Role/RoleBinding shape, same
24h `TokenRequest` expiration, same `(nil, nil)` disabled signal when
`ManagementAPIServer` is empty. The `SubResource` field indirection (a
`func(string) client.SubResourceClient`) makes the resolver unit-testable
against a fake without envtest.

**Token caching deliberately deferred (KD-33b).** Each `Resolve` call
today re-mints a `TokenRequest`. A `TODO(KD-33b)` comment in the resolver
flags caching as the follow-on item. Acceptable for alpha-2; the test
suite asserts `createCalls==2` for two sequential calls (regression guard
against accidentally suppressing re-mint in a future change).

## Validation

- `go build ./...` and `go test ./...` green.
- `TestRenderK0sCloudConfig_CapkNoManagementEndpoint` and the k3s twin:
  push block absent when `ManagementEndpoint == nil`.
- `TestValidate_ManagementEndpointControlChars` (4 subcases): control
  characters in each nested field are rejected with the dotted field name
  in the error message.
- `TestValidate_NilManagementEndpointSkipsNestedCheck`: nil pointer does
  not panic.
- 8-subcase adversarial matrix (4 fields × 2 CAPK templates): rendered
  YAML still parses; payload appears inside shquote envelope; dangerous
  metacharacters never appear unquoted.
- 6-case resolver unit tests against a fake SubResourceClient: happy
  path, sub-resource error, empty token, empty APIServer (disabled
  signal), idempotent CreateOrUpdate, pre-existing ServiceAccount
  adoption.
- security-architect approved all 3 engineer commits with no required
  changes.

## Out of scope

- **KD-33b** — token caching in `kubeVirtTokenResolver`. Tracked in
  `PROJECT_CONTEXT.md`; small follow-up branch.
- **CAPV templates** — extending the push pattern to CAPV. That is PR-7
  (`fix/kd-3b-eliminate-ssh-kubeconfig`), which this PR unblocks.
- **SSHFallback** — `Spec.SSHFallback.Enabled` opt-in. That is PR-9
  (`feat/kd-3b-ssh-opt-in-fallback`).
- **KD-44** — sed metacharacter handling for `ControlPlaneLBEndpoint`.
  Low severity; tracked separately.
