### PR TITLE
fix(controlplane): stop writing Cluster.Spec.ControlPlaneEndpoint; CAPI v1beta2 contract (KD-12)

### DIFF
--- a/api/controlplane/v1beta2/conditions.go
+++ b/api/controlplane/v1beta2/conditions.go
@@ -99,4 +99,37 @@ const (
 	// Warning. Resolution: fix the referenced Secret; the path retries
 	// on next reconcile.
 	SSHFallbackMisconfiguredReason = "SSHFallbackMisconfigured"
+
+	// WaitingForInfrastructureControlPlaneEndpointReason is the False
+	// reason for the KairosControlPlane AvailableCondition and the
+	// derived ReadyCondition while `Cluster.Spec.ControlPlaneEndpoint`
+	// is not yet populated. Severity Info.
+	//
+	// Per the CAPI v1beta2 contract, the infrastructure provider's
+	// `<Infra>Cluster` resource is the source of truth for the
+	// control-plane endpoint:
+	//   - CAPV operators set `VSphereCluster.Spec.ControlPlaneEndpoint`.
+	//   - CAPK operators set
+	//     `KubevirtCluster.Spec.ControlPlaneServiceTemplate`; CAPK then
+	//     creates the LoadBalancer Service and reflects its IP into
+	//     `KubevirtCluster.Spec.ControlPlaneEndpoint`.
+	//   - CAPD operators set `Cluster.Spec.ControlPlaneEndpoint`
+	//     directly (CAPD does not auto-discover).
+	// CAPI core then copies `<Infra>Cluster.Spec.ControlPlaneEndpoint`
+	// into `Cluster.Spec.ControlPlaneEndpoint`. This Reason names that
+	// upstream wait so operators see clearly that the control-plane
+	// controller is correctly NOT writing the field (KD-12). Closely
+	// related to CAPI's own
+	// `InfrastructureReadyV1Beta1Condition` /
+	// `WaitingForInfrastructureFallback` on the Cluster — when the
+	// infrastructure provider is itself stalled, this Reason on KCP
+	// and that condition on the Cluster show up together; operators
+	// fix the InfraCluster spec and both clear.
+	//
+	// Resolution: set the endpoint on the InfraCluster per the
+	// upstream provider's contract. For an in-flight cluster, also
+	// valid to `kubectl edit cluster <name>` and populate
+	// `spec.controlPlaneEndpoint.host`/`port` directly — CAPI core
+	// does not overwrite a populated value.
+	WaitingForInfrastructureControlPlaneEndpointReason = "WaitingForInfrastructureControlPlaneEndpoint"
 )

--- a/config/samples/capk/kubevirt_cluster_k0s_single_node.yaml
+++ b/config/samples/capk/kubevirt_cluster_k0s_single_node.yaml
@@ -51,6 +51,19 @@ spec:
     apiGroup: controlplane.cluster.x-k8s.io
     kind: KairosControlPlane
     name: kairos-control-plane-kv-capk
+  # Required: set to the IP that MetalLB (or your LB implementation) will
+  # assign to the control-plane LoadBalancer Service before applying.
+  # If the IP is not yet known, apply the manifest with this placeholder,
+  # wait for MetalLB to assign an IP to the <cluster>-control-plane-lb
+  # Service, then run:
+  #   kubectl edit cluster kairos-cluster-kv
+  # and set spec.controlPlaneEndpoint.host to the assigned IP.
+  # CAPI core does not overwrite a populated value.
+  # Without a valid endpoint, KairosControlPlane stalls with
+  # Available=False(WaitingForInfrastructureControlPlaneEndpoint).
+  controlPlaneEndpoint:
+    host: "TODO-REPLACE-WITH-LB-IP"
+    port: 6443
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: KubevirtCluster

--- a/config/samples/capk/kubevirt_cluster_k3s_single_node.yaml
+++ b/config/samples/capk/kubevirt_cluster_k3s_single_node.yaml
@@ -52,10 +52,18 @@ spec:
     apiGroup: controlplane.cluster.x-k8s.io
     kind: KairosControlPlane
     name: kairos-control-plane-kv-capk
-  # controlPlaneEndpoint is auto-populated by the controller from the LoadBalancer Service.
-  # Placeholder required for initial apply; MetalLB or similar assigns the LB IP.
+  # Required: set to the IP that MetalLB (or your LB implementation) will
+  # assign to the control-plane LoadBalancer Service before applying.
+  # If the IP is not yet known, apply the manifest with this placeholder,
+  # wait for MetalLB to assign an IP to the <cluster>-control-plane-lb
+  # Service, then run:
+  #   kubectl edit cluster kairos-cluster-kv
+  # and set spec.controlPlaneEndpoint.host to the assigned IP.
+  # CAPI core does not overwrite a populated value.
+  # Without a valid endpoint, KairosControlPlane stalls with
+  # Available=False(WaitingForInfrastructureControlPlaneEndpoint).
   controlPlaneEndpoint:
-    host: "PLACEHOLDER-FOR-LB-IP"
+    host: "TODO-REPLACE-WITH-LB-IP"
     port: 6443
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1

--- a/config/samples/capv/kairos_cluster_k0s_single_node.yaml
+++ b/config/samples/capv/kairos_cluster_k0s_single_node.yaml
@@ -45,6 +45,16 @@ spec:
     apiGroup: controlplane.cluster.x-k8s.io
     kind: KairosControlPlane
     name: kairos-control-plane
+  # Required: set a stable API endpoint before applying.
+  # Pre-allocate a LoadBalancer IP or VIP; CAPV does not auto-discover the
+  # endpoint. Without this, KairosControlPlane stalls with
+  # Available=False(WaitingForInfrastructureControlPlaneEndpoint).
+  # For an in-flight cluster: kubectl edit cluster kairos-cluster and set
+  # spec.controlPlaneEndpoint.host/port directly (CAPI does not overwrite a
+  # populated value).
+  controlPlaneEndpoint:
+    host: "TODO-REPLACE-WITH-LB-OR-VIP"
+    port: 6443
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereCluster

--- a/docs/QUICKSTART_CAPD.md
+++ b/docs/QUICKSTART_CAPD.md
@@ -8,6 +8,8 @@ This guide walks you through creating a single-node k0s cluster on Kairos using 
 
 **Note:** CAPD is a development-only infrastructure provider. Docker-based Kairos clusters do not represent a production topology.
 
+**Note on `controlPlaneEndpoint`**: the sample manifest requires `Cluster.spec.controlPlaneEndpoint` to be set to a reachable host and port before applying. CAPD (like CAPV) does not auto-provision an endpoint; you must supply one. For local kind-based management clusters the Docker container's IP or a host port mapping is the typical choice. Without a valid endpoint, `KairosControlPlane` stalls with `Available=False(WaitingForInfrastructureControlPlaneEndpoint)`.
+
 ## Prerequisites
 
 1. **Management Cluster**: A Kubernetes cluster (kind, minikube, or any Kubernetes cluster).

--- a/docs/QUICKSTART_CAPK.md
+++ b/docs/QUICKSTART_CAPK.md
@@ -9,6 +9,8 @@ This guide covers two paths:
 
 Both paths use the 2-disk Kairos installer pattern, described below.
 
+**Note on `controlPlaneEndpoint`**: the sample manifests require `Cluster.spec.controlPlaneEndpoint` to be set to the IP that your LoadBalancer implementation (MetalLB or equivalent) will assign to the control-plane Service. The provider does not auto-populate this field. If the IP is unknown at apply time, use the `TODO-REPLACE-WITH-LB-IP` placeholder in the sample, wait for MetalLB to assign the LB IP to the `<cluster>-control-plane-lb` Service, then update the field with `kubectl edit cluster <name>`. CAPI core does not overwrite a populated value. Without a valid endpoint, `KairosControlPlane` stalls with `Available=False(WaitingForInfrastructureControlPlaneEndpoint)`.
+
 ---
 
 ## The 2-disk Kairos installer pattern

--- a/docs/QUICKSTART_CAPV.md
+++ b/docs/QUICKSTART_CAPV.md
@@ -4,7 +4,7 @@ Last verified against: Kairos v3.6.0+, CAPI v1.8.x, CAPV v1.11.x, provider v0.1.
 
 This guide walks you through creating a single-node k0s or k3s cluster on Kairos using Cluster API with the vSphere provider (CAPV).
 
-**Note on k3s vs k0s**: the k3s flavor requires `Cluster.spec.controlPlaneEndpoint` to be set to a stable LoadBalancer IP or VIP before applying the manifest, because k3s agents join via the control-plane endpoint. The k0s flavor does not require a pre-set endpoint — the controller discovers the node IP after the VM is provisioned.
+**Note on `controlPlaneEndpoint`**: both the k0s and k3s flavors require `Cluster.spec.controlPlaneEndpoint` (or `VSphereCluster.spec.controlPlaneEndpoint`) to be set to a stable LoadBalancer IP or VIP before applying the manifest. The provider does not auto-discover the endpoint. Standard CAPV practice is to pre-allocate an IP via your load-balancer solution and reference it in the sample before applying. If you apply without a valid endpoint, `KairosControlPlane` will stall with `Available=False(WaitingForInfrastructureControlPlaneEndpoint)` until the endpoint is set.
 
 ## Prerequisites
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -2,7 +2,30 @@
 
 > This file is a stub. The canonical upgrade procedures land in a later PR
 > (`docs/kd-35-kd-36-install-upgrade`). For now this captures the
-> alpha-1 → alpha-2 KD-3b impact only.
+> alpha-1 → alpha-2 KD-3b impact and the alpha-2 → alpha-3 KD-12 impact.
+
+## v0.1.0-alpha.2 → v0.1.0-alpha.3
+
+### KD-12: KCP no longer writes `Cluster.Spec.ControlPlaneEndpoint`
+
+The alpha-3 release removes the two blocks in `updateClusterStatus` that wrote
+`Cluster.Spec.ControlPlaneEndpoint` from Machine IP addresses (CAPV/CAPD) or
+from the LoadBalancer Service Ingress IP (CAPK). `Cluster.Spec.ControlPlaneEndpoint`
+is now written exclusively by CAPI core, which copies it from the infra-cluster's
+own `Spec.ControlPlaneEndpoint`. This is the behaviour the CAPI v1beta2 contract
+requires.
+
+| Cluster state at upgrade | Behaviour after KD-12 | Operator action |
+|---|---|---|
+| Healthy cluster, `Cluster.Spec.ControlPlaneEndpoint` already populated | No change. The endpoint is preserved; the KCP controller stops overwriting it. CAPI core is now the sole writer, which is byte-identical to what KCP was writing. | None. |
+| Mid-provisioning cluster, infra provider has already populated `<Infra>Cluster.Spec.ControlPlaneEndpoint` | CAPI core copies it on its next reconcile; everything proceeds. | None. |
+| CAPV / CAPD / CAPK cluster whose `<Infra>Cluster.Spec.ControlPlaneEndpoint` (CAPV/CAPD) or `KubevirtCluster.Spec.ControlPlaneServiceTemplate` (CAPK) is unset — including any cluster that relied on KCP auto-discovering the endpoint from Machine IPs | `Cluster.Spec.ControlPlaneEndpoint` stays empty. KCP stalls with `KairosControlPlane.Status.Conditions[Available].Reason=WaitingForInfrastructureControlPlaneEndpoint`. | Set `VSphereCluster.Spec.ControlPlaneEndpoint` (CAPV), `DockerCluster.Spec.ControlPlaneEndpoint` (CAPD), or supply a LoadBalancer IP via the sample's `Cluster.spec.controlPlaneEndpoint` placeholder (CAPK) per the upstream provider's contract. For an in-flight cluster: `kubectl edit cluster <name>` and set `spec.controlPlaneEndpoint.host` and `spec.controlPlaneEndpoint.port` directly. CAPI core does not overwrite a populated value. |
+
+No CRD changes in this release for KD-12. The new condition Reason
+(`WaitingForInfrastructureControlPlaneEndpoint`) is additive — clients
+that treat unknown Reasons as opaque strings are unaffected.
+
+---
 
 ## v0.1.0-alpha.1 → v0.1.0-alpha.2
 

--- a/internal/controllers/controlplane/kairoscontrolplane_controller.go
+++ b/internal/controllers/controlplane/kairoscontrolplane_controller.go
@@ -283,7 +283,19 @@ func (r *KairosControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		// Don't fail the reconcile, just log the error
 	}
 
-	// Update conditions based on status
+	// Update conditions based on status.
+	//
+	// Per CAPI v1beta2 contract + KD-12: when the infrastructure provider
+	// has not yet populated Cluster.Spec.ControlPlaneEndpoint, the KCP
+	// MUST report that wait state distinctly from "waiting for machines"
+	// so operators can tell whether they need to fix the InfraCluster's
+	// endpoint or just wait for VM provisioning. The endpoint check runs
+	// FIRST on the False branches because an empty endpoint is the
+	// operator-actionable wait; "waiting for machines" implies the
+	// endpoint is already populated and the controller is just waiting
+	// on bootstrap.
+	endpointReady := cluster.Spec.ControlPlaneEndpoint.IsValid()
+
 	if kcp.Status.Initialized {
 		conditions.MarkTrue(kcp, clusterv1.ReadyCondition)
 		conditions.MarkTrue(kcp, controlplanev1beta2.AvailableCondition)
@@ -292,6 +304,13 @@ func (r *KairosControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		} else {
 			conditions.MarkFalse(kcp, clusterv1.ReadyCondition, controlplanev1beta2.WaitingForMachinesReadyReason, clusterv1.ConditionSeverityInfo, "Waiting for control plane machines to be ready")
 		}
+	} else if !endpointReady {
+		const endpointMsg = "Waiting for the infrastructure provider to populate Cluster.Spec.ControlPlaneEndpoint. " +
+			"Set VSphereCluster.spec.controlPlaneEndpoint (CAPV), " +
+			"KubevirtCluster.spec.controlPlaneServiceTemplate (CAPK), " +
+			"or Cluster.spec.controlPlaneEndpoint (CAPD / direct) per the provider's contract."
+		conditions.MarkFalse(kcp, clusterv1.ReadyCondition, controlplanev1beta2.WaitingForInfrastructureControlPlaneEndpointReason, clusterv1.ConditionSeverityInfo, "%s", endpointMsg)
+		conditions.MarkFalse(kcp, controlplanev1beta2.AvailableCondition, controlplanev1beta2.WaitingForInfrastructureControlPlaneEndpointReason, clusterv1.ConditionSeverityInfo, "%s", endpointMsg)
 	} else {
 		conditions.MarkFalse(kcp, clusterv1.ReadyCondition, controlplanev1beta2.WaitingForMachinesReason, clusterv1.ConditionSeverityInfo, "Waiting for control plane initialization")
 		conditions.MarkFalse(kcp, controlplanev1beta2.AvailableCondition, controlplanev1beta2.WaitingForMachinesReason, clusterv1.ConditionSeverityInfo, "Waiting for control plane initialization")

--- a/internal/controllers/controlplane/kairoscontrolplane_controller.go
+++ b/internal/controllers/controlplane/kairoscontrolplane_controller.go
@@ -925,123 +925,24 @@ func (r *KairosControlPlaneReconciler) updateClusterStatus(ctx context.Context, 
 		Namespace: cluster.Namespace,
 	}
 
-	// Re-fetch the cluster to ensure we have the latest version before updating
-	// This prevents conflicts with other controllers that might be updating the cluster
-	clusterKey := types.NamespacedName{
-		Name:      cluster.Name,
-		Namespace: cluster.Namespace,
-	}
-	clusterToPatch := &clusterv1.Cluster{}
-	if err := r.Get(ctx, clusterKey, clusterToPatch); err != nil {
-		return fmt.Errorf("failed to re-fetch cluster for updating: %w", err)
-	}
+	// KD-12: this controller MUST NOT write Cluster.Spec.ControlPlaneEndpoint.
+	// The infrastructure provider populates <Infra>Cluster.Spec.ControlPlaneEndpoint,
+	// CAPI core copies it into Cluster.Spec.ControlPlaneEndpoint, and this
+	// control-plane provider only reads. See ADR 0003.
+	//
+	// The one remaining concern of this function is the CAPK-specific
+	// kubeconfig-server rewrite: when the kubeconfig Secret exists, we may
+	// need to retarget its `server:` URL at the LoadBalancer endpoint so
+	// `clusterctl get kubeconfig` and downstream tooling reach the cluster
+	// through the LB instead of the in-cluster API server address baked in
+	// by the distribution. (A follow-up split will rename this function to
+	// reconcileKubeconfigServer; out of scope for KD-12.)
 
-	// Set controlPlaneEndpoint if not already set (runs before kubeconfig check so LB endpoint
-	// is set as soon as LoadBalancer has an IP, enabling SSH retrieval and Machine controller)
-	needsSpecUpdate := false
-	currentHost := clusterToPatch.Spec.ControlPlaneEndpoint.Host
-	currentPort := clusterToPatch.Spec.ControlPlaneEndpoint.Port
-	log.V(4).Info("Checking controlPlaneEndpoint", "cluster", clusterToPatch.Name, "currentHost", currentHost, "currentPort", currentPort)
-
-	if isKubevirtControlPlane(kcp) {
-		lbHost, lbPort, err := r.getControlPlaneLBEndpoint(ctx, log, clusterToPatch)
-		if err != nil && !apierrors.IsNotFound(err) {
-			log.Error(err, "Failed to get control plane LoadBalancer endpoint", "cluster", clusterToPatch.Name)
-		}
-		if lbHost != "" && lbPort != 0 {
-			shouldUpdate := currentHost == "" || currentPort == 0 || currentHost != lbHost || currentPort != lbPort
-			if shouldUpdate {
-				clusterToPatch.Spec.ControlPlaneEndpoint.Host = lbHost
-				clusterToPatch.Spec.ControlPlaneEndpoint.Port = lbPort
-				needsSpecUpdate = true
-				log.Info("Setting controlPlaneEndpoint from LoadBalancer", "cluster", clusterToPatch.Name, "host", lbHost, "port", lbPort)
-			} else {
-				log.V(4).Info("controlPlaneEndpoint already set to LoadBalancer", "currentHost", currentHost, "currentPort", currentPort)
-			}
-			// ensureKubeconfigServer runs below, only when secret exists
-		} else {
-			log.Info("LoadBalancer endpoint not ready yet", "cluster", clusterToPatch.Name)
-		}
-	} else {
-		machines, err := r.getControlPlaneMachines(ctx, kcp, clusterToPatch)
-		if err != nil {
-			log.V(4).Info("Failed to get machines", "error", err)
-		} else if len(machines) == 0 {
-			log.V(4).Info("No machines found")
-		} else {
-			log.V(4).Info("Found machines", "count", len(machines))
-			// Find the first machine with an IP address
-			// Try machine.Status.Addresses first, then fallback to VSphereMachine/VSphereVM
-			for _, machine := range machines {
-				log.V(4).Info("Checking machine", "machine", machine.Name, "addressCount", len(machine.Status.Addresses))
-				var controlPlaneAddress string
-
-				// First, try machine.Status.Addresses (if populated)
-				if len(machine.Status.Addresses) > 0 {
-					var controlPlaneIP string
-					var controlPlaneHostname string
-					for _, addr := range machine.Status.Addresses {
-						log.V(4).Info("Machine address", "machine", machine.Name, "type", addr.Type, "address", addr.Address)
-						if addr.Type == clusterv1.MachineExternalIP || addr.Type == clusterv1.MachineInternalIP {
-							controlPlaneIP = addr.Address
-						}
-						if addr.Type == clusterv1.MachineInternalDNS {
-							controlPlaneHostname = addr.Address
-						}
-					}
-					// Prefer IP address, fallback to hostname
-					controlPlaneAddress = controlPlaneIP
-					if controlPlaneAddress == "" && controlPlaneHostname != "" {
-						controlPlaneAddress = controlPlaneHostname
-						log.V(4).Info("Using hostname from machine status", "hostname", controlPlaneHostname)
-					}
-				}
-
-				// Fallback: Get IP from infrastructure provider (same method used for kubeconfig)
-				if controlPlaneAddress == "" {
-					log.V(4).Info("Machine.Status.Addresses empty, trying infrastructure provider", "machine", machine.Name)
-					if ip, err := r.getNodeIP(ctx, log, machine); err == nil && ip != "" {
-						controlPlaneAddress = ip
-						log.V(4).Info("Found IP from infrastructure provider", "machine", machine.Name, "ip", ip)
-					} else if err != nil {
-						log.V(4).Info("Failed to get IP from infrastructure provider", "machine", machine.Name, "error", err)
-					}
-				}
-
-				if controlPlaneAddress != "" {
-					shouldUpdate := currentHost == "" || currentPort == 0 || currentHost != controlPlaneAddress
-					if shouldUpdate {
-						clusterToPatch.Spec.ControlPlaneEndpoint.Host = controlPlaneAddress
-						clusterToPatch.Spec.ControlPlaneEndpoint.Port = 6443 // Default k0s API server port
-						needsSpecUpdate = true
-						log.Info("Setting controlPlaneEndpoint", "cluster", clusterToPatch.Name, "host", controlPlaneAddress, "port", 6443)
-						break
-					}
-					log.V(4).Info("controlPlaneEndpoint already set", "currentHost", currentHost, "currentPort", currentPort)
-				} else {
-					log.V(4).Info("No IP or hostname found for machine", "machine", machine.Name)
-				}
-			}
-		}
-	}
-
-	// Check if kubeconfig secret exists - early exit if not, but controlPlaneEndpoint already updated above
+	// Check if the kubeconfig secret exists yet; if not, nothing to do here.
 	secret := &corev1.Secret{}
 	if err := r.Get(ctx, secretKey, secret); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.V(4).Info("Kubeconfig secret not found, skipping cluster status update", "secret", secretName)
-			// Still update spec if controlPlaneEndpoint was set (e.g. from LB)
-			if needsSpecUpdate {
-				log.Info("Updating cluster spec with controlPlaneEndpoint", "cluster", clusterToPatch.Name, "host", clusterToPatch.Spec.ControlPlaneEndpoint.Host, "port", clusterToPatch.Spec.ControlPlaneEndpoint.Port)
-				if err := r.Update(ctx, clusterToPatch); err != nil {
-					if apierrors.IsConflict(err) {
-						log.V(4).Info("Conflict updating cluster spec, will retry on next reconcile", "cluster", clusterToPatch.Name, "error", err)
-						return nil
-					}
-					return fmt.Errorf("failed to update cluster spec: %w", err)
-				}
-				log.Info("Successfully updated cluster spec with controlPlaneEndpoint", "cluster", clusterToPatch.Name)
-			}
 			return nil
 		}
 		return err
@@ -1051,41 +952,16 @@ func (r *KairosControlPlaneReconciler) updateClusterStatus(ctx context.Context, 
 
 	// For KubeVirt, ensure kubeconfig server URL matches LoadBalancer endpoint (only when secret exists)
 	if isKubevirtControlPlane(kcp) {
-		lbHost, lbPort, err := r.getControlPlaneLBEndpoint(ctx, log, clusterToPatch)
+		lbHost, lbPort, err := r.getControlPlaneLBEndpoint(ctx, log, cluster)
 		if err != nil && !apierrors.IsNotFound(err) {
-			log.Error(err, "Failed to get control plane LoadBalancer endpoint for kubeconfig", "cluster", clusterToPatch.Name)
+			log.Error(err, "Failed to get control plane LoadBalancer endpoint for kubeconfig", "cluster", cluster.Name)
 		} else if lbHost != "" && lbPort != 0 {
 			updated, err := r.ensureKubeconfigServer(ctx, log, secret, lbHost, lbPort)
 			if err != nil {
-				log.Error(err, "Failed to ensure kubeconfig server", "cluster", clusterToPatch.Name)
+				log.Error(err, "Failed to ensure kubeconfig server", "cluster", cluster.Name)
 			} else if updated {
-				log.Info("Updated kubeconfig server to match LoadBalancer endpoint", "cluster", clusterToPatch.Name, "host", lbHost, "port", lbPort)
+				log.Info("Updated kubeconfig server to match LoadBalancer endpoint", "cluster", cluster.Name, "host", lbHost, "port", lbPort)
 			}
-		}
-	}
-
-	// The Cluster API Cluster controller manages the ControlPlaneInitialized condition
-	// based on the control plane's status.Initialized field.
-	// We should NOT try to set this condition directly, as it causes reconcile loops
-	// and conflicts with the Cluster controller's logic.
-	// Instead, we ensure status.Initialized is set correctly on the KCP resource,
-	// and let the Cluster controller manage the condition on the Cluster resource.
-
-	// Update spec first if needed (controlPlaneEndpoint)
-	if needsSpecUpdate {
-		log.Info("Updating cluster spec with controlPlaneEndpoint", "cluster", clusterToPatch.Name, "host", clusterToPatch.Spec.ControlPlaneEndpoint.Host, "port", clusterToPatch.Spec.ControlPlaneEndpoint.Port)
-		// Use Update() for spec changes
-		if err := r.Update(ctx, clusterToPatch); err != nil {
-			if apierrors.IsConflict(err) {
-				log.V(4).Info("Conflict updating cluster spec, will retry on next reconcile", "cluster", clusterToPatch.Name, "error", err)
-				return nil // Will retry on next reconcile
-			}
-			return fmt.Errorf("failed to update cluster spec: %w", err)
-		}
-		log.Info("Successfully updated cluster spec with controlPlaneEndpoint", "cluster", clusterToPatch.Name)
-		// Re-fetch after spec update to ensure we have latest version
-		if err := r.Get(ctx, client.ObjectKeyFromObject(clusterToPatch), clusterToPatch); err != nil {
-			return fmt.Errorf("failed to re-fetch cluster after spec update: %w", err)
 		}
 	}
 

--- a/test/envtest/controlplane_kd12_no_cluster_spec_writes_test.go
+++ b/test/envtest/controlplane_kd12_no_cluster_spec_writes_test.go
@@ -1,0 +1,333 @@
+/*
+Copyright 2024 The Kairos CAPI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package envtest
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
+
+	controlplanev1beta2 "github.com/kairos-io/cluster-api-provider-kairos/api/controlplane/v1beta2"
+)
+
+// TestKD12_KCPDoesNotWriteClusterSpecEndpoint is the KD-12 regression
+// guard: per CAPI v1beta2 contract, `Cluster.Spec.ControlPlaneEndpoint` is
+// the infrastructure provider's responsibility. The KairosControlPlane
+// controller MUST read it, never write it. Before KD-12 (commits
+// b5c6307 + fb9eab1 of this PR), the controller polled the LB Service
+// (CAPK) or the first Machine's status.addresses (CAPV/CAPD) and copied
+// the result into Cluster.Spec. This test pins the "never write"
+// invariant so a future refactor can't accidentally reintroduce a write
+// path.
+//
+// The test creates a fully-populated KCP environment where the OLD
+// controller would have absolutely written the endpoint (Machine with
+// status.addresses, no pre-set endpoint on the Cluster), then asserts
+// Consistently that the host stays empty AND the KCP shows the new
+// WaitingForInfrastructureControlPlaneEndpoint Reason on its Available
+// condition.
+func TestKD12_KCPDoesNotWriteClusterSpecEndpoint(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping envtest in short mode")
+	}
+	g := NewWithT(t)
+	ctx, c, _, _, teardown := startKCPEnvtest(t)
+	defer teardown()
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kd12-no-writes-ns"}}
+	g.Expect(c.Create(ctx, ns)).To(Succeed())
+
+	clusterName := "kd12-no-writes-cluster"
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: ns.Name},
+		Spec: clusterv1.ClusterSpec{
+			ControlPlaneRef: &corev1.ObjectReference{
+				APIVersion: controlplanev1beta2.GroupVersion.String(),
+				Kind:       "KairosControlPlane",
+				Name:       clusterName + "-kcp",
+				Namespace:  ns.Name,
+			},
+			// ControlPlaneEndpoint intentionally left empty — the
+			// INVARIANT under test is that the controller does NOT
+			// populate it.
+		},
+	}
+	g.Expect(c.Create(ctx, cluster)).To(Succeed())
+
+	kcp := &controlplanev1beta2.KairosControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName + "-kcp",
+			Namespace: ns.Name,
+			Labels:    map[string]string{clusterv1.ClusterNameLabel: clusterName},
+		},
+		Spec: controlplanev1beta2.KairosControlPlaneSpec{
+			Replicas: ptr.To(int32(1)),
+			Version:  "v1.30.0+k0s.0",
+			MachineTemplate: controlplanev1beta2.KairosControlPlaneMachineTemplate{
+				InfrastructureRef: corev1.ObjectReference{
+					APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+					Kind:       "DockerMachineTemplate",
+					Name:       "missing-on-purpose",
+					Namespace:  ns.Name,
+				},
+			},
+			KairosConfigTemplate: controlplanev1beta2.KairosConfigTemplateReference{
+				Name: "missing-on-purpose",
+			},
+		},
+	}
+	g.Expect(c.Create(ctx, kcp)).To(Succeed())
+
+	// Pre-create a control-plane Machine with a usable IP address. Before
+	// KD-12 this would have caused the controller to copy the IP into
+	// Cluster.Spec.ControlPlaneEndpoint. After KD-12 it must NOT.
+	machine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kcp.Name + "-0",
+			Namespace: ns.Name,
+			Labels: map[string]string{
+				clusterv1.ClusterNameLabel:         clusterName,
+				clusterv1.MachineControlPlaneLabel: "",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: controlplanev1beta2.GroupVersion.String(),
+					Kind:       "KairosControlPlane",
+					Name:       kcp.Name,
+					UID:        kcp.UID,
+					Controller: ptr.To(true),
+				},
+			},
+		},
+		Spec: clusterv1.MachineSpec{
+			ClusterName: clusterName,
+			Bootstrap:   clusterv1.Bootstrap{DataSecretName: ptr.To("placeholder")},
+			Version:     ptr.To("v1.30.0+k0s.0"),
+		},
+	}
+	g.Expect(c.Create(ctx, machine)).To(Succeed())
+
+	// Populate the Machine's status.addresses — the old write path's
+	// preferred trigger.
+	g.Eventually(func() error {
+		got := &clusterv1.Machine{}
+		if err := c.Get(ctx, types.NamespacedName{Name: machine.Name, Namespace: machine.Namespace}, got); err != nil {
+			return err
+		}
+		got.Status.Addresses = []clusterv1.MachineAddress{
+			{Type: clusterv1.MachineInternalIP, Address: "10.99.99.1"},
+		}
+		return c.Status().Update(ctx, got)
+	}, 30*time.Second, time.Second).Should(Succeed())
+
+	// Wait for the controller to reconcile + emit the new Reason. The
+	// Eventually here is the "controller has run at least once with the
+	// Machine in place" gate; the actual regression assertion is the
+	// Consistently below.
+	g.Eventually(func() string {
+		got := &controlplanev1beta2.KairosControlPlane{}
+		if err := c.Get(ctx, types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}, got); err != nil {
+			return "ERR: " + err.Error()
+		}
+		cond := conditions.Get(got, controlplanev1beta2.AvailableCondition)
+		if cond == nil {
+			return ""
+		}
+		return cond.Reason
+	}, 30*time.Second, time.Second).Should(Equal(controlplanev1beta2.WaitingForInfrastructureControlPlaneEndpointReason),
+		"with Cluster.Spec.ControlPlaneEndpoint empty, the KCP MUST surface WaitingForInfrastructureControlPlaneEndpoint on Available — not WaitingForMachines")
+
+	// The regression assertion: for 30s, neither the host nor the port
+	// of Cluster.Spec.ControlPlaneEndpoint may be written by the
+	// controller. A regression that resurrects the auto-write would
+	// fail this assertion within the first reconcile after the Machine
+	// status was populated.
+	g.Consistently(func() string {
+		got := &clusterv1.Cluster{}
+		if err := c.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: ns.Name}, got); err != nil {
+			return "ERR: " + err.Error()
+		}
+		// Return a stringified Endpoint so the failure message shows the
+		// actual value that leaked in.
+		ep := got.Spec.ControlPlaneEndpoint
+		if ep.Host == "" && ep.Port == 0 {
+			return ""
+		}
+		return ep.Host + ":" + string(rune(ep.Port))
+	}, 30*time.Second, 5*time.Second).Should(BeEmpty(),
+		"KairosControlPlane controller MUST NOT write Cluster.Spec.ControlPlaneEndpoint — that field is the infrastructure provider's responsibility (KD-12)")
+}
+
+// TestKD12_KCPReadsClusterSpecEndpointAfterInfraSets verifies the
+// transition: when the infrastructure provider (or CAPI core copying from
+// an InfraCluster) eventually populates `Cluster.Spec.ControlPlaneEndpoint`,
+// the KairosControlPlane controller observes it and transitions the
+// Available condition's Reason AWAY from WaitingForInfrastructureControlPlaneEndpoint.
+// (The next gate is reconcileMachines / kubeconfig readiness, which we
+// don't exercise here — the controller will land on either
+// WaitingForMachines or WaitingForNodePush depending on what else is
+// pending. We only assert the endpoint-wait Reason clears.)
+//
+// This is the happy-path companion to TestKD12_KCPDoesNotWriteClusterSpecEndpoint
+// and pins the read-don't-write data flow that PR-8's PR-9's KD-12's PRs
+// all converge on.
+func TestKD12_KCPReadsClusterSpecEndpointAfterInfraSets(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping envtest in short mode")
+	}
+	g := NewWithT(t)
+	ctx, c, _, _, teardown := startKCPEnvtest(t)
+	defer teardown()
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kd12-reads-after-set-ns"}}
+	g.Expect(c.Create(ctx, ns)).To(Succeed())
+
+	clusterName := "kd12-reads-after-set-cluster"
+	cluster := &clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: ns.Name},
+		Spec: clusterv1.ClusterSpec{
+			ControlPlaneRef: &corev1.ObjectReference{
+				APIVersion: controlplanev1beta2.GroupVersion.String(),
+				Kind:       "KairosControlPlane",
+				Name:       clusterName + "-kcp",
+				Namespace:  ns.Name,
+			},
+		},
+	}
+	g.Expect(c.Create(ctx, cluster)).To(Succeed())
+
+	kcp := &controlplanev1beta2.KairosControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName + "-kcp",
+			Namespace: ns.Name,
+			Labels:    map[string]string{clusterv1.ClusterNameLabel: clusterName},
+		},
+		Spec: controlplanev1beta2.KairosControlPlaneSpec{
+			Replicas: ptr.To(int32(1)),
+			Version:  "v1.30.0+k0s.0",
+			MachineTemplate: controlplanev1beta2.KairosControlPlaneMachineTemplate{
+				InfrastructureRef: corev1.ObjectReference{
+					APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+					Kind:       "DockerMachineTemplate",
+					Name:       "missing-on-purpose",
+					Namespace:  ns.Name,
+				},
+			},
+			KairosConfigTemplate: controlplanev1beta2.KairosConfigTemplateReference{
+				Name: "missing-on-purpose",
+			},
+		},
+	}
+	g.Expect(c.Create(ctx, kcp)).To(Succeed())
+
+	// Pre-create a control-plane Machine so reconcileMachines doesn't
+	// fail before reaching the condition-set block. Same gating pattern
+	// as PR-7's TestKD3b_KubeconfigReady_TransitionsOnNodePush — without
+	// the Machine, the Reconcile path goes through the failure-set arm
+	// and never reaches the WaitingForInfrastructureControlPlaneEndpoint
+	// surface we're testing.
+	machine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kcp.Name + "-0",
+			Namespace: ns.Name,
+			Labels: map[string]string{
+				clusterv1.ClusterNameLabel:         clusterName,
+				clusterv1.MachineControlPlaneLabel: "",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: controlplanev1beta2.GroupVersion.String(),
+					Kind:       "KairosControlPlane",
+					Name:       kcp.Name,
+					UID:        kcp.UID,
+					Controller: ptr.To(true),
+				},
+			},
+		},
+		Spec: clusterv1.MachineSpec{
+			ClusterName: clusterName,
+			Bootstrap:   clusterv1.Bootstrap{DataSecretName: ptr.To("placeholder")},
+			Version:     ptr.To("v1.30.0+k0s.0"),
+		},
+	}
+	g.Expect(c.Create(ctx, machine)).To(Succeed())
+
+	// First, observe the KCP settles on WaitingForInfrastructureControlPlaneEndpoint —
+	// the precondition for testing the transition.
+	g.Eventually(func() string {
+		got := &controlplanev1beta2.KairosControlPlane{}
+		if err := c.Get(ctx, types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}, got); err != nil {
+			return "ERR: " + err.Error()
+		}
+		cond := conditions.Get(got, controlplanev1beta2.AvailableCondition)
+		if cond == nil {
+			return ""
+		}
+		return cond.Reason
+	}, 30*time.Second, time.Second).Should(Equal(controlplanev1beta2.WaitingForInfrastructureControlPlaneEndpointReason))
+
+	// Simulate the infrastructure provider populating the endpoint. In
+	// production this is CAPI core copying from
+	// <Infra>Cluster.Spec.ControlPlaneEndpoint; the effect on the
+	// Cluster spec is identical.
+	g.Eventually(func() error {
+		got := &clusterv1.Cluster{}
+		if err := c.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: ns.Name}, got); err != nil {
+			return err
+		}
+		got.Spec.ControlPlaneEndpoint = clusterv1.APIEndpoint{
+			Host: "10.99.99.1",
+			Port: 6443,
+		}
+		return c.Update(ctx, got)
+	}, 30*time.Second, time.Second).Should(Succeed())
+
+	// The Available condition's Reason MUST transition away from
+	// WaitingForInfrastructureControlPlaneEndpoint. Where it lands
+	// depends on the next gate (no machines / no kubeconfig / etc.),
+	// so we only assert "not the endpoint-wait reason anymore".
+	g.Eventually(func() string {
+		got := &controlplanev1beta2.KairosControlPlane{}
+		if err := c.Get(ctx, types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}, got); err != nil {
+			return "ERR: " + err.Error()
+		}
+		cond := conditions.Get(got, controlplanev1beta2.AvailableCondition)
+		if cond == nil {
+			return ""
+		}
+		return cond.Reason
+	}, 30*time.Second, time.Second).ShouldNot(Equal(controlplanev1beta2.WaitingForInfrastructureControlPlaneEndpointReason),
+		"once Cluster.Spec.ControlPlaneEndpoint is populated, the KCP MUST transition away from WaitingForInfrastructureControlPlaneEndpoint")
+
+	// The Cluster's endpoint MUST stay at the value we set (the
+	// controller MUST NOT overwrite it).
+	g.Consistently(func() string {
+		got := &clusterv1.Cluster{}
+		if err := c.Get(ctx, types.NamespacedName{Name: clusterName, Namespace: ns.Name}, got); err != nil {
+			return "ERR: " + err.Error()
+		}
+		return got.Spec.ControlPlaneEndpoint.Host
+	}, 15*time.Second, 3*time.Second).Should(Equal("10.99.99.1"),
+		"KCP MUST NOT mutate Cluster.Spec.ControlPlaneEndpoint after the infrastructure provider sets it")
+}


### PR DESCRIPTION
## Summary

CAPI v1beta2 contract correctness fix. The `KairosControlPlane` controller
was writing `Cluster.Spec.ControlPlaneEndpoint` — a field the infrastructure
provider's `<Infra>Cluster` owns per the contract. This PR removes the
write paths, replaces them with a clear operator-facing condition Reason
when the infrastructure provider hasn't populated the endpoint yet, and
documents the behavior change in the QUICKSTARTS + UPGRADING.

After this PR the controlplane provider exclusively READS
`Cluster.Spec.ControlPlaneEndpoint`. The data flow is:

  Operator → `<Infra>Cluster.Spec.ControlPlaneEndpoint`
    → CAPI core copies → `Cluster.Spec.ControlPlaneEndpoint`
    → KCP reads → KCP transitions away from
                  `WaitingForInfrastructureControlPlaneEndpoint`

## What this fixes

Per `internal/controllers/CLAUDE.md` § 6:
> Never write `Cluster.Spec.*` from the control-plane controller. That's
> the infrastructure provider's job.

PR-7 (#55), PR-8 (#58), PR-9 (#59) finished the KD-3b SSH-elimination arc.
This PR (KD-12) finishes the CAPI-contract-correctness arc on the same
controller. Previously the KCP shortcut two upstream flows:

- **CAPK**: polled the `<cluster>-control-plane-lb` Service it had created,
  copied the IP into `Cluster.Spec`. The standard CAPK contract is for
  operators to set `KubevirtCluster.Spec.ControlPlaneServiceTemplate`,
  then CAPK populates `KubevirtCluster.Spec.ControlPlaneEndpoint`, then
  CAPI core copies. The KCP shortcut was masking the standard flow.
- **CAPV / CAPD**: walked control-plane Machines, took the first usable
  IP from `Status.Addresses`, wrote that with port 6443. The standard
  CAPV contract requires the operator to pre-set
  `VSphereCluster.Spec.ControlPlaneEndpoint` (typically a pre-allocated
  VIP/LB IP); CAPV propagates, CAPI core copies. The KCP's
  "auto-discovery on first boot" was an operator-friendly behaviour
  but a CAPI-contract violation that masked the missing endpoint until
  AFTER VM provisioning.

## Implementation notes

ADR at `.claude/decisions/0003-kd-12-stop-writing-cluster-spec.md`
(gitignored under `.claude/`). Five commits, in order:

1. `bf209ff` — **API**: add `WaitingForInfrastructureControlPlaneEndpointReason`
   string constant. Doc comment cross-references CAPI's
   `InfrastructureReadyV1Beta1Condition` / `WaitingForInfrastructureFallback`
   so operators understand the relationship between the KCP-level Reason
   and the Cluster-level condition.
2. `b5c6307` — **Controller**: delete the two write blocks in
   `updateClusterStatus`. -142 / +18 LOC. patch.Helper invariant verified
   intact by `staff-engineer` review (the deleted writes targeted a
   re-fetched Cluster object, not the patch-helper-tracked `kcp`).
   `<cluster>-control-plane-lb` Service code (the LB Service the KCP
   creates) stays — layering smell flagged in ADR § G.3 for a separate
   future ADR; out of scope here.
3. `fb9eab1` — **Controller**: emit the new Reason on
   `AvailableCondition` / `ReadyCondition` False states when
   `cluster.Spec.ControlPlaneEndpoint.IsValid()` is false. Operator-
   facing message names the three per-infra fields the operator can
   populate (`VSphereCluster.spec.controlPlaneEndpoint`,
   `KubevirtCluster.spec.controlPlaneServiceTemplate`,
   `Cluster.spec.controlPlaneEndpoint`).
4. `d758150` — **Envtest**: two regression tests modelled on PR-8's
   `TestProviderID_NotPatchedByController`:
   - `TestKD12_KCPDoesNotWriteClusterSpecEndpoint`: Eventually asserts
     the new Reason appears; Consistently for 30s asserts
     `Cluster.Spec.ControlPlaneEndpoint` stays empty even with a Machine
     that has populated `Status.Addresses` (the old write trigger).
   - `TestKD12_KCPReadsClusterSpecEndpointAfterInfraSets`: simulates
     CAPI core copying the endpoint, asserts KCP's Reason transitions
     away AND the KCP does not subsequently mutate the populated value.
   Both pass 3× consecutively locally (187s total) plus the full
   envtest suite (199s).
5. `2fe6194` — **Docs + samples sweep**:
   - `docs/QUICKSTART_CAPV.md:7` callout rewritten — the k0s
     "auto-discovery" claim was the lie KD-12 fixes; replaced with the
     operator-action wording.
   - `docs/QUICKSTART_CAPD.md` + `docs/QUICKSTART_CAPK.md` — new
     `controlPlaneEndpoint` sections (both were missing).
   - `config/samples/capv/kairos_cluster_k0s_single_node.yaml` — added
     `controlPlaneEndpoint` block with `TODO-REPLACE-WITH-LB-OR-VIP`
     placeholder.
   - `config/samples/capk/kubevirt_cluster_*_single_node.yaml` (both
     k0s and k3s) — added `controlPlaneEndpoint` block with
     `TODO-REPLACE-WITH-LB-IP` placeholder + recovery procedure note
     (`kubectl edit cluster` for in-flight clusters; CAPI core does
     not overwrite a populated value).
   - `docs/UPGRADING.md` — new alpha-2 → alpha-3 section with KD-12
     row covering the three cluster states (healthy, mid-provisioning,
     stalled).

`tech-writer` agent owned commits 5 per CLAUDE.md. `staff-engineer`
owned commit 2 per the patch-helper risk surface. Other commits
(1, 3, 4) were mechanical and driven directly.

## Validation

### Unit + integration (all green locally)
- `go build ./...` clean. `go vet ./...` clean.
- `go test ./... -count=1 -short` all green.
- KD-12 envtests verified against real envtest:
  `KUBEBUILDER_ASSETS=...` + `go test -run TestKD12 -count=3` →
  6/6 passes in 187s. Full envtest suite (all KD-3b + KD-12) green
  in 199s.

### Lab E2E (maintainer-owned per ADR § H.3)
The existing 4/4 alpha-2 lab scenarios (PR-7/PR-8/PR-9 validation)
pre-set `Cluster.Spec.ControlPlaneEndpoint` in their manifests
(`/tmp/kd3b-cap*-k0s.yaml`, `/tmp/kd3b-cap*-k3s.yaml`), so they
continue to pass without modification. Maintainer should run a
fresh CAPV-k0s scenario WITHOUT a pre-set endpoint to verify:
- Eventually `KairosControlPlane.Status.Conditions[Available]`
  shows `Reason=WaitingForInfrastructureControlPlaneEndpoint` (Info)
- `kubectl edit cluster <name>` and setting the endpoint correctly
  unblocks reconciliation
- Net result: same `Available=True` end state as before, with one
  manual operator step that the QUICKSTART documents

## Upgrade impact

See `docs/UPGRADING.md` for the full v0.1.0-alpha.2 → v0.1.0-alpha.3
section. Short version:

- **alpha-2 cluster, healthy**: no action. The endpoint stays
  populated; the KCP stops trying to overwrite it (which was a no-op
  anyway when the value matched).
- **alpha-2 cluster mid-provisioning, infra populated endpoint**:
  no action. CAPI core copies, things proceed.
- **alpha-2 cluster mid-provisioning, infra did NOT populate the
  endpoint** (CAPV operator forgot; CAPK
  `controlPlaneServiceTemplate` empty): stalls on the new
  `WaitingForInfrastructureControlPlaneEndpoint` Reason. Operator
  sets the InfraCluster's endpoint per the upstream provider's
  contract, OR `kubectl edit cluster <name>` to populate
  `spec.controlPlaneEndpoint` directly. CAPI core does not
  overwrite a populated value.

No CRD storage-version bump. No new spec fields. Additive condition
Reason only (Reasons are not part of a contract surface that needs
a deprecation cycle).

## Out of scope

- The `<cluster>-control-plane-lb` Service the KCP creates is a
  layering smell flagged in ADR § G.3 — KCP shouldn't be in the
  infrastructure-provider business of standing up LBs. Three
  options for a future ADR are listed in that section. Not in KD-12.
- `KairosControlPlaneTemplate` webhook adoption of
  `validateSSHFallback` (PR-9 follow-up).
- KD-3c k0s ProviderID immutability race (PR-8 follow-up).
- KD-46 per-infra RBAC minimization.
- alpha-3 release prep (CHANGELOG, version bump).
