### PR TITLE
feat(api): add KairosControlPlaneTemplate webhook (alpha-2 follow-up)

### DIFF
--- a/api/controlplane/v1beta2/kairoscontrolplanetemplate_webhook.go
+++ b/api/controlplane/v1beta2/kairoscontrolplanetemplate_webhook.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2024 The Kairos CAPI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// log is for logging in this package.
+var kairoscontrolplanetemplateLog = logf.Log.WithName("kairoscontrolplanetemplate-resource")
+
+// SetupWebhookWithManager sets up the webhook with the Manager.
+func (r *KairosControlPlaneTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+//+kubebuilder:webhook:path=/mutate-controlplane-cluster-x-k8s-io-v1beta2-kairoscontrolplanetemplate,mutating=true,failurePolicy=fail,sideEffects=None,groups=controlplane.cluster.x-k8s.io,resources=kairoscontrolplanetemplates,verbs=create;update,versions=v1beta2,name=mkairoscontrolplanetemplate.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Defaulter = &KairosControlPlaneTemplate{}
+
+// Default implements webhook.Defaulter. Applies the same field defaults
+// the KCP webhook applies, but on the nested template spec
+// (r.Spec.Template.Spec). Operators creating a template should see the
+// same defaulted shape they would see on a KCP after admission, so
+// `kubectl get kairoscontrolplanetemplate -o yaml` reflects the values
+// CAPI's MachineDeployment / template stamping will produce.
+func (r *KairosControlPlaneTemplate) Default() {
+	kairoscontrolplanetemplateLog.Info("default", "name", r.Name)
+
+	s := &r.Spec.Template.Spec
+
+	// Replicas default — mirrors KCP.Default().
+	if s.Replicas == nil {
+		replicas := int32(1)
+		s.Replicas = &replicas
+	}
+
+	// Distribution default — mirrors KCP.Default().
+	if s.Distribution == "" {
+		s.Distribution = "k0s"
+	}
+
+	// SSHFallback default — shared helper with KCP, defined in
+	// kairoscontrolplane_webhook.go. The helper is a no-op on nil
+	// blocks, so leaving SSHFallback unset on a template is idiomatic
+	// and admission-clean.
+	defaultSSHFallback(s.SSHFallback)
+}
+
+//+kubebuilder:webhook:path=/validate-controlplane-cluster-x-k8s-io-v1beta2-kairoscontrolplanetemplate,mutating=false,failurePolicy=fail,sideEffects=None,groups=controlplane.cluster.x-k8s.io,resources=kairoscontrolplanetemplates,verbs=create;update,versions=v1beta2,name=vkairoscontrolplanetemplate.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Validator = &KairosControlPlaneTemplate{}
+
+// ValidateCreate implements webhook.Validator.
+func (r *KairosControlPlaneTemplate) ValidateCreate() (admission.Warnings, error) {
+	kairoscontrolplanetemplateLog.Info("validate create", "name", r.Name)
+	return nil, r.validate()
+}
+
+// ValidateUpdate implements webhook.Validator.
+func (r *KairosControlPlaneTemplate) ValidateUpdate(_ runtime.Object) (admission.Warnings, error) {
+	kairoscontrolplanetemplateLog.Info("validate update", "name", r.Name)
+	return nil, r.validate()
+}
+
+// ValidateDelete implements webhook.Validator.
+func (r *KairosControlPlaneTemplate) ValidateDelete() (admission.Warnings, error) {
+	kairoscontrolplanetemplateLog.Info("validate delete", "name", r.Name)
+	return nil, nil
+}
+
+// validate mirrors the KairosControlPlane webhook's validate() against
+// the nested template spec. The two validation functions share the same
+// per-field rules and the SSHFallback helper; the field paths in error
+// messages differ (`spec.template.spec.*` vs. `spec.*`) so operators
+// reading admission errors can tell which resource type the rejection
+// came from.
+//
+// Per CAPI convention, anything invalid in the controlled KCP type
+// MUST be invalid in the template too — otherwise an operator can
+// stage a known-invalid template and only discover the problem at KCP
+// creation time, which defeats the purpose of templating.
+func (r *KairosControlPlaneTemplate) validate() error {
+	var allErrs field.ErrorList
+	s := &r.Spec.Template.Spec
+	base := field.NewPath("spec", "template", "spec")
+
+	// Replicas: same bounds as KCP (min 1, max 1 in this release; see
+	// KD-5 for the HA roadmap).
+	if s.Replicas != nil {
+		switch {
+		case *s.Replicas < 1:
+			allErrs = append(allErrs, field.Invalid(
+				base.Child("replicas"),
+				*s.Replicas,
+				"spec.template.spec.replicas must be greater than or equal to 1",
+			))
+		case *s.Replicas > 1:
+			allErrs = append(allErrs, field.Invalid(
+				base.Child("replicas"),
+				*s.Replicas,
+				"spec.template.spec.replicas > 1 is not supported in this release: the current "+
+					"control-plane implementation would produce N independent "+
+					"single-node clusters instead of an HA cluster. HA support "+
+					"(both classic and P2P/decentralized) is planned for a "+
+					"future release. Use spec.template.spec.replicas: 1 for now.",
+			))
+		}
+	}
+
+	// Distribution: same enum as KCP.
+	if s.Distribution != "" && s.Distribution != "k0s" && s.Distribution != "k3s" {
+		allErrs = append(allErrs, field.Invalid(
+			base.Child("distribution"),
+			s.Distribution,
+			"spec.template.spec.distribution must be one of [k0s, k3s]",
+		))
+	}
+
+	// SSHFallback: shared helper with KCP. The helper takes the owner
+	// namespace because cross-namespace Secret refs are rejected and
+	// the template's namespace is the same one a stamped KCP would
+	// live in.
+	allErrs = append(allErrs, validateSSHFallback(s.SSHFallback, r.Namespace, base.Child("sshFallback"))...)
+
+	if len(allErrs) > 0 {
+		return errors.NewInvalid(
+			schema.GroupKind{Group: GroupVersion.Group, Kind: "KairosControlPlaneTemplate"},
+			r.Name,
+			allErrs,
+		)
+	}
+
+	return nil
+}

--- a/api/controlplane/v1beta2/kairoscontrolplanetemplate_webhook_test.go
+++ b/api/controlplane/v1beta2/kairoscontrolplanetemplate_webhook_test.go
@@ -1,0 +1,254 @@
+/*
+Copyright 2024 The Kairos CAPI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// newValidKCPTemplate returns a KairosControlPlaneTemplate that satisfies
+// every validation rule when no SSHFallback block is configured. Tests
+// mutate one field at a time on the nested template spec to isolate what
+// they're checking.
+func newValidKCPTemplate() *KairosControlPlaneTemplate {
+	return &KairosControlPlaneTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kcp-tmpl",
+			Namespace: "default",
+		},
+		Spec: KairosControlPlaneTemplateSpec{
+			Template: KairosControlPlaneTemplateResource{
+				Spec: KairosControlPlaneSpec{
+					Replicas:     ptr(int32(1)),
+					Version:      "v1.30.0",
+					Distribution: "k0s",
+					MachineTemplate: KairosControlPlaneMachineTemplate{
+						InfrastructureRef: corev1.ObjectReference{
+							APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+							Kind:       "DockerMachineTemplate",
+							Name:       "kcp-tmpl-infra",
+						},
+					},
+					KairosConfigTemplate: KairosConfigTemplateReference{
+						Name: "kcp-tmpl-config",
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestKairosControlPlaneTemplate_Validate_Replicas(t *testing.T) {
+	cases := []struct {
+		name       string
+		replicas   *int32
+		wantSubstr string
+	}{
+		{"nil-replicas-valid", nil, ""},
+		{"one-replica-valid", ptr(int32(1)), ""},
+		{"zero-replica-rejected", ptr(int32(0)), "must be greater than or equal to 1"},
+		{"two-replicas-rejected", ptr(int32(2)), "not supported in this release"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			tmpl := newValidKCPTemplate()
+			tmpl.Spec.Template.Spec.Replicas = tc.replicas
+			err := tmpl.validate()
+			if tc.wantSubstr == "" {
+				if err != nil {
+					t.Fatalf("validate() returned %v; expected nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validate() returned nil; expected error containing %q", tc.wantSubstr)
+			}
+			if !strings.Contains(err.Error(), tc.wantSubstr) {
+				t.Errorf("validate() error %q does not contain %q", err.Error(), tc.wantSubstr)
+			}
+			// Field path MUST reflect the template nesting — that's the
+			// distinguishing feature of this webhook vs. KCP's.
+			if !strings.Contains(err.Error(), "spec.template.spec") {
+				t.Errorf("validate() error %q must include `spec.template.spec.*` field path, not the bare `spec.*` form", err.Error())
+			}
+		})
+	}
+}
+
+func TestKairosControlPlaneTemplate_Validate_Distribution(t *testing.T) {
+	cases := []struct {
+		name       string
+		dist       string
+		wantSubstr string
+	}{
+		{"empty-valid", "", ""},
+		{"k0s-valid", "k0s", ""},
+		{"k3s-valid", "k3s", ""},
+		{"unknown-rejected", "kthreesomething", "must be one of [k0s, k3s]"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			tmpl := newValidKCPTemplate()
+			tmpl.Spec.Template.Spec.Distribution = tc.dist
+			err := tmpl.validate()
+			if tc.wantSubstr == "" {
+				if err != nil {
+					t.Fatalf("validate() returned %v; expected nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validate() returned nil; expected error containing %q", tc.wantSubstr)
+			}
+			if !strings.Contains(err.Error(), tc.wantSubstr) {
+				t.Errorf("validate() error %q does not contain %q", err.Error(), tc.wantSubstr)
+			}
+		})
+	}
+}
+
+// TestKairosControlPlaneTemplate_Validate_SSHFallback verifies the
+// template webhook adopts the same validateSSHFallback helper that KCP
+// uses (PR-9), and that the field-path component of admission errors
+// reflects the template nesting (`spec.template.spec.sshFallback.*`
+// rather than `spec.sshFallback.*`).
+//
+// The cases below are a representative subset of KCP's
+// TestKairosControlPlane_Validate_SSHFallback — the helper itself is
+// already exhaustively tested there. Here we verify the helper IS being
+// called from the template path with the correct base field.
+func TestKairosControlPlaneTemplate_Validate_SSHFallback(t *testing.T) {
+	validRef := func(name string) *SSHFallbackSecretReference {
+		return &SSHFallbackSecretReference{Name: name}
+	}
+
+	cases := []struct {
+		name       string
+		fallback   *SSHFallback
+		wantSubstr string
+	}{
+		{
+			name:     "nil-block-valid",
+			fallback: nil,
+		},
+		{
+			name: "enabled-no-known-hosts-rejected",
+			fallback: &SSHFallback{
+				Enabled:           true,
+				IdentitySecretRef: validRef("id"),
+				ActivateAfter:     &metav1.Duration{Duration: 15 * time.Minute},
+			},
+			wantSubstr: "knownHostsSecretRef is required",
+		},
+		{
+			name: "enabled-activate-after-too-small-rejected",
+			fallback: &SSHFallback{
+				Enabled:             true,
+				KnownHostsSecretRef: validRef("kh"),
+				IdentitySecretRef:   validRef("id"),
+				ActivateAfter:       &metav1.Duration{Duration: 5 * time.Minute},
+			},
+			wantSubstr: "activateAfter must be strictly greater than",
+		},
+		{
+			name: "enabled-valid-minimal",
+			fallback: &SSHFallback{
+				Enabled:             true,
+				KnownHostsSecretRef: validRef("kh"),
+				IdentitySecretRef:   validRef("id"),
+				ActivateAfter:       &metav1.Duration{Duration: 16 * time.Minute},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			tmpl := newValidKCPTemplate()
+			tmpl.Spec.Template.Spec.SSHFallback = tc.fallback
+			err := tmpl.validate()
+			if tc.wantSubstr == "" {
+				if err != nil {
+					t.Fatalf("validate() returned %v; expected nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validate() returned nil; expected error containing %q", tc.wantSubstr)
+			}
+			if !strings.Contains(err.Error(), tc.wantSubstr) {
+				t.Errorf("validate() error %q does not contain %q", err.Error(), tc.wantSubstr)
+			}
+			// Distinguishing assertion vs. the KCP test: errors must
+			// carry the template-nested field path. If a future refactor
+			// breaks the field.NewPath("spec", "template", "spec")
+			// argument in validate(), THIS test catches it where the
+			// KCP test cannot.
+			if !strings.Contains(err.Error(), "spec.template.spec.sshFallback") {
+				t.Errorf("validate() error %q must include `spec.template.spec.sshFallback.*` field path (got the bare `spec.sshFallback.*` form?)", err.Error())
+			}
+		})
+	}
+}
+
+func TestKairosControlPlaneTemplate_Default_FillsDefaults(t *testing.T) {
+	tmpl := newValidKCPTemplate()
+	// Wipe defaults so Default() has work to do.
+	tmpl.Spec.Template.Spec.Replicas = nil
+	tmpl.Spec.Template.Spec.Distribution = ""
+	tmpl.Spec.Template.Spec.SSHFallback = &SSHFallback{
+		Enabled:             true,
+		KnownHostsSecretRef: &SSHFallbackSecretReference{Name: "kh"},
+		IdentitySecretRef:   &SSHFallbackSecretReference{Name: "id"},
+		// User/Port/ActivateAfter empty — defaulter should fill them.
+	}
+
+	tmpl.Default()
+
+	if tmpl.Spec.Template.Spec.Replicas == nil || *tmpl.Spec.Template.Spec.Replicas != 1 {
+		t.Errorf("Replicas not defaulted to 1: %v", tmpl.Spec.Template.Spec.Replicas)
+	}
+	if tmpl.Spec.Template.Spec.Distribution != "k0s" {
+		t.Errorf("Distribution not defaulted to k0s: %q", tmpl.Spec.Template.Spec.Distribution)
+	}
+	s := tmpl.Spec.Template.Spec.SSHFallback
+	if s.User != "kairos" {
+		t.Errorf("SSHFallback.User not defaulted to kairos: %q", s.User)
+	}
+	if s.Port != 22 {
+		t.Errorf("SSHFallback.Port not defaulted to 22: %d", s.Port)
+	}
+	if s.ActivateAfter == nil {
+		t.Errorf("SSHFallback.ActivateAfter not defaulted: nil")
+	}
+}
+
+func TestKairosControlPlaneTemplate_Default_NilSSHFallbackStaysNil(t *testing.T) {
+	tmpl := newValidKCPTemplate()
+	tmpl.Spec.Template.Spec.SSHFallback = nil
+	tmpl.Default()
+	if tmpl.Spec.Template.Spec.SSHFallback != nil {
+		t.Errorf("nil SSHFallback became non-nil after Default(); got %+v", tmpl.Spec.Template.Spec.SSHFallback)
+	}
+}

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -44,6 +44,26 @@ webhooks:
     resources:
     - kairoscontrolplanes
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-controlplane-cluster-x-k8s-io-v1beta2-kairoscontrolplanetemplate
+  failurePolicy: Fail
+  name: mkairoscontrolplanetemplate.kb.io
+  rules:
+  - apiGroups:
+    - controlplane.cluster.x-k8s.io
+    apiVersions:
+    - v1beta2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kairoscontrolplanetemplates
+  sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -89,4 +109,24 @@ webhooks:
     - UPDATE
     resources:
     - kairoscontrolplanes
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-controlplane-cluster-x-k8s-io-v1beta2-kairoscontrolplanetemplate
+  failurePolicy: Fail
+  name: vkairoscontrolplanetemplate.kb.io
+  rules:
+  - apiGroups:
+    - controlplane.cluster.x-k8s.io
+    apiVersions:
+    - v1beta2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kairoscontrolplanetemplates
   sideEffects: None

--- a/main.go
+++ b/main.go
@@ -196,6 +196,10 @@ func main() {
 		setupLog.Error(err, "unable to create webhook", "webhook", "KairosControlPlane")
 		os.Exit(1)
 	}
+	if err = (&controlplanev1beta2.KairosControlPlaneTemplate{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "KairosControlPlaneTemplate")
+		os.Exit(1)
+	}
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {


### PR DESCRIPTION
## Summary

Defense-in-depth follow-up to PR-9 (#59). Adds the missing
`KairosControlPlaneTemplate` webhook so SSHFallback validation runs at
template-creation time, not just at KCP-creation time. Per CAPI
convention, anything invalid in the controlled KCP type MUST be invalid
in the template too — otherwise operators can stage a known-invalid
template and only discover the problem at KCP creation, defeating the
purpose of templating.

PR-9's ADR § A.3 designed `validateSSHFallback` to be adoptable by this
webhook; this PR consummates that adoption.

## What this fixes

Before this PR:
- `KairosControlPlaneTemplate` had **no webhook at all** — operators
  could create templates with `Replicas=99`, `Distribution=k1s`, or
  `SSHFallback.Enabled=true && KnownHostsSecretRef=nil` and admission
  would accept them.
- The KCP webhook would catch these at KCP creation time, but a
  template that fails to instantiate is a worse operator experience
  than one that's rejected at the source.

After this PR:
- Template admission runs the same rules as KCP admission, with field
  paths under `spec.template.spec.*` to make the error message clear
  about which resource type the rejection came from.
- The shared `validateSSHFallback` helper from PR-9 is unchanged — both
  webhooks call it with the appropriate base path + namespace.
- Defaulter on the template applies the same defaults the KCP gets
  (`Replicas=1`, `Distribution=k0s`, `SSHFallback.User=kairos`,
  `SSHFallback.Port=22`, `SSHFallback.ActivateAfter=15m`), so
  `kubectl get kairoscontrolplanetemplate -o yaml` reflects the
  defaulted shape.

## Implementation notes

One commit (`287f10b`). Files:

- `api/controlplane/v1beta2/kairoscontrolplanetemplate_webhook.go`
  (new, ~160 LOC) — `SetupWebhookWithManager`, `Default()`,
  `ValidateCreate()`/`ValidateUpdate()`/`ValidateDelete()`,
  `validate()`. Structure mirrors `kairoscontrolplane_webhook.go`
  with field paths under `spec.template.spec` and the validation
  rules mirrored from KCP's `validate()`.
- `api/controlplane/v1beta2/kairoscontrolplanetemplate_webhook_test.go`
  (new, ~250 LOC) — 13 cases across Replicas (4), Distribution (4),
  SSHFallback (4), plus defaulter (2). Each SSHFallback case
  explicitly asserts the `spec.template.spec.sshFallback.*` field
  path component so a future refactor that points the webhook at
  `spec.sshFallback.*` (the KCP path) gets caught here.
- `main.go` (4 LOC) — wires the new webhook alongside the KCP webhook.
- `config/webhook/manifests.yaml` (40 LOC) — regenerated via `make
  manifests`; adds two new webhook entries (mutating + validating)
  for the
  `/mutate|/validate-controlplane-cluster-x-k8s-io-v1beta2-kairoscontrolplanetemplate`
  paths.

## Validation

- `go build ./...` clean.
- `go test ./... -count=1 -short` all green.
- 13 new template-webhook unit tests pass.
- Existing KCP webhook tests unchanged (the shared helpers landed
  unchanged).

## Out of scope

- KD-3c (k0s ProviderID immutability race — PR-8 audit follow-up).
- KD-46 (RBAC minimization in `kubeVirtTokenResolver`).
- alpha-2 release prep (gated on upstream Hadron #388 + a published
  Hadron variant with `vmtoolsd.service` enabled).
