### PR TITLE
fix(bootstrap): k0s ExecStartPre ProviderID drop-in (KD-3c, alpha-2 follow-up)

### DIFF
--- a/internal/bootstrap/template_test.go
+++ b/internal/bootstrap/template_test.go
@@ -881,3 +881,121 @@ func TestRenderK0sCloudConfig_WithoutInstallConfig(t *testing.T) {
 		t.Error("Install block should not be present when Install is nil")
 	}
 }
+
+// TestRenderK0sCloudConfig_ControlPlaneWithProviderID verifies the KD-3c
+// kubelet-arg injection: when ProviderID is known at render time, the k0s
+// args block must include `--kubelet-extra-args=--provider-id=<X>` so k0s
+// passes that flag to kubelet at startup. Without this, kubelet registers
+// the Node before the post-bootstrap kubectl patch can set ProviderID, and
+// ProviderID being immutable in K8s once set means the patch silently
+// no-ops. (PR-8 audit finding, ADR 0001 § E.)
+func TestRenderK0sCloudConfig_ControlPlaneWithProviderID(t *testing.T) {
+	data := TemplateData{
+		Role:         "control-plane",
+		SingleNode:   true,
+		Hostname:     "kairos-control-plane-k0s-0",
+		ProviderID:   "vsphere://422fa74a-5d60-3a4a-af24-1f07be515fcc",
+		UserName:     "kairos",
+		UserPassword: "kairos",
+		UserGroups:   []string{"admin"},
+	}
+	result, err := RenderK0sCloudConfig(data)
+	if err != nil {
+		t.Fatalf("Failed to render template: %v", err)
+	}
+
+	if !strings.Contains(result, "--kubelet-extra-args=--provider-id=vsphere://422fa74a-5d60-3a4a-af24-1f07be515fcc") {
+		t.Error("k0s args MUST include --kubelet-extra-args=--provider-id=<X> when ProviderID is set so kubelet registers the Node with the correct providerID from the start (KD-3c)")
+	}
+	// The args block must be rendered (the surrounding `args:` key must exist) — a missing key would mean
+	// the OR-gate in the template didn't pick up .ProviderID.
+	if !strings.Contains(result, "  args:") {
+		t.Error("k0s `args:` block missing entirely; the OR-gate for the args block must include .ProviderID")
+	}
+	// The post-bootstrap kubectl patch fallback stays — it's defense-in-depth
+	// for the case where the kubelet flag didn't take (e.g., a future k0s version
+	// that changes how --kubelet-extra-args is consumed). Assert it's still rendered.
+	if !strings.Contains(result, "kubectl patch node $(hostname)") {
+		t.Error("post-bootstrap kubectl patch fallback should still render for defense in depth")
+	}
+}
+
+// TestRenderK0sCloudConfig_ControlPlaneWithoutProviderID is the negative
+// case: with no ProviderID, the args block MUST NOT carry a
+// --kubelet-extra-args entry (would emit a syntactically invalid k0s flag).
+// The post-bootstrap patch block also adjusts — it logs "No providerID to
+// set" instead of attempting a patch.
+func TestRenderK0sCloudConfig_ControlPlaneWithoutProviderID(t *testing.T) {
+	data := TemplateData{
+		Role:         "control-plane",
+		SingleNode:   true,
+		Hostname:     "kairos-control-plane-k0s-0",
+		// ProviderID intentionally empty.
+		UserName:     "kairos",
+		UserPassword: "kairos",
+		UserGroups:   []string{"admin"},
+	}
+	result, err := RenderK0sCloudConfig(data)
+	if err != nil {
+		t.Fatalf("Failed to render template: %v", err)
+	}
+
+	if strings.Contains(result, "--kubelet-extra-args=--provider-id=") {
+		t.Error("k0s args MUST NOT include --kubelet-extra-args=--provider-id= when ProviderID is empty (would emit a malformed flag)")
+	}
+	// SingleNode=true should still render --single, so the args block exists.
+	if !strings.Contains(result, "--single") {
+		t.Error("SingleNode=true must still render --single")
+	}
+}
+
+// TestRenderK0sCloudConfig_WorkerWithProviderID verifies the same flag is
+// injected into the k0s-worker args block. Worker scope matters less today
+// (HA gated on KD-5), but the field exists and the rule is uniform.
+func TestRenderK0sCloudConfig_WorkerWithProviderID(t *testing.T) {
+	data := TemplateData{
+		Role:         "worker",
+		WorkerToken:  "fake-worker-token",
+		Hostname:     "kairos-worker-k0s-0",
+		ProviderID:   "kubevirt://kairos-worker-k0s-0",
+		UserName:     "kairos",
+		UserPassword: "kairos",
+		UserGroups:   []string{"admin"},
+	}
+	result, err := RenderK0sCloudConfig(data)
+	if err != nil {
+		t.Fatalf("Failed to render template: %v", err)
+	}
+
+	if !strings.Contains(result, "--kubelet-extra-args=--provider-id=kubevirt://kairos-worker-k0s-0") {
+		t.Error("k0s-worker args MUST include --kubelet-extra-args=--provider-id=<X> when ProviderID is set")
+	}
+	// The existing --token-file arg must still render.
+	if !strings.Contains(result, "--token-file /etc/k0s/token") {
+		t.Error("worker --token-file arg lost; the addition of the providerID conditional must not break the existing arg")
+	}
+}
+
+// TestRenderK0sCloudConfig_ProviderID_InjectionRejected pins the security
+// rationale that lets us interpolate .ProviderID bare in a shell-context
+// position (the args list value): the validator at internal/bootstrap/validate.go
+// must reject any value containing characters outside the strict providerID
+// regex. If a future refactor weakens the validator, this test catches it
+// before reaching the renderer.
+func TestRenderK0sCloudConfig_ProviderID_InjectionRejected(t *testing.T) {
+	injectionAttempts := []string{
+		`vsphere://X"; rm -rf /; echo "`,
+		`vsphere://X` + "\n" + `bash -c "rm -rf /"`,
+		`vsphere://X$(id)`,
+		`vsphere://X` + "`id`",
+		`vsphere://X--config=/etc/shadow`,
+	}
+	for _, p := range injectionAttempts {
+		p := p
+		t.Run("rejected:"+p[:min(len(p), 30)], func(t *testing.T) {
+			if err := ValidateProviderID(p); err == nil {
+				t.Errorf("ValidateProviderID(%q) returned nil; should have rejected (shell injection surface)", p)
+			}
+		})
+	}
+}

--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capk.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capk.yaml.tmpl
@@ -60,13 +60,23 @@ users:
 # Control-plane node configuration
 k0s:
   enabled: true
-  {{- if or .SingleNode .PodCIDR .ServiceCIDR .IsKubeVirt }}
+  {{- if or .SingleNode .PodCIDR .ServiceCIDR .IsKubeVirt .ProviderID }}
   args:
   {{- if .SingleNode }}
     - --single
   {{- end }}
   {{- if or .PodCIDR .ServiceCIDR .IsKubeVirt }}
     - --config /etc/k0s/k0s.yaml
+  {{- end }}
+  {{- if .ProviderID }}
+    # KD-3c: tell kubelet the providerID BEFORE the Node is registered so it
+    # appears in spec.providerID from first registration. The PR-8 audit
+    # surfaced that k0s would otherwise register the Node and the
+    # post-bootstrap kubectl patch would race the immutable-once-set
+    # ProviderID. Mirrors the k3s ExecStartPre pattern. Validator at
+    # internal/bootstrap/validate.go pins ProviderID to a strict regex,
+    # so direct interpolation here is safe (no shell injection surface).
+    - --kubelet-extra-args=--provider-id={{ .ProviderID }}
   {{- end }}
   {{- end }}
 
@@ -77,6 +87,10 @@ k0s-worker:
   enabled: true
   args:
     - --token-file /etc/k0s/token
+    {{- if .ProviderID }}
+    # KD-3c: same providerID-at-startup story as the control-plane block above.
+    - --kubelet-extra-args=--provider-id={{ .ProviderID }}
+    {{- end }}
 
 {{- end }}
 

--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
@@ -60,13 +60,23 @@ users:
 # Control-plane node configuration
 k0s:
   enabled: true
-  {{- if or .SingleNode .PodCIDR .ServiceCIDR }}
+  {{- if or .SingleNode .PodCIDR .ServiceCIDR .ProviderID }}
   args:
   {{- if .SingleNode }}
     - --single
   {{- end }}
   {{- if or .PodCIDR .ServiceCIDR }}
     - --config /etc/k0s/k0s.yaml
+  {{- end }}
+  {{- if .ProviderID }}
+    # KD-3c: tell kubelet the providerID BEFORE the Node is registered so it
+    # appears in spec.providerID from first registration. The PR-8 audit
+    # surfaced that k0s would otherwise register the Node and the
+    # post-bootstrap kubectl patch would race the immutable-once-set
+    # ProviderID. Mirrors the k3s ExecStartPre pattern. Validator at
+    # internal/bootstrap/validate.go pins ProviderID to a strict regex,
+    # so direct interpolation here is safe (no shell injection surface).
+    - --kubelet-extra-args=--provider-id={{ .ProviderID }}
   {{- end }}
   {{- end }}
 
@@ -77,6 +87,10 @@ k0s-worker:
   enabled: true
   args:
     - --token-file /etc/k0s/token
+    {{- if .ProviderID }}
+    # KD-3c: same providerID-at-startup story as the control-plane block above.
+    - --kubelet-extra-args=--provider-id={{ .ProviderID }}
+    {{- end }}
 
 {{- end }}
 


### PR DESCRIPTION
## Summary

Closes the k0s ProviderID immutability race surfaced in PR-8's audit
(`.claude/decisions/0001-pr8-providerid-elimination.md` § E). Mirrors the
k3s pattern already shipping in
`k3s_kairos_cloud_config_capv.yaml.tmpl:67-69,186`: pass
`--kubelet-extra-args=--provider-id=<X>` to k0s at startup so kubelet
registers the Node with the correct `ProviderID` from the first reconcile
of CAPI's NodeRef matcher.

## What this fixes

Without this PR, the in-VM cloud-config rendered by the k0s templates
relies on a **post-bootstrap `kubectl patch node`** to set
`Node.Spec.ProviderID`. That patch happens AFTER k0s is up — at which
point kubelet has already registered the Node with an empty or
`k0s://hostname` ProviderID, and **K8s makes ProviderID immutable once
set** (the patch silently no-ops). The CAPI Machine controller's
`NodeRef` matcher then fails to bind the Machine to the Node because
the values don't match.

After this PR:
- k0s starts with `--kubelet-extra-args=--provider-id=<X>` whenever
  `.ProviderID` is known at render time.
- kubelet registers the Node with `<X>` from the first registration.
- The post-bootstrap `kubectl patch` stays as defense-in-depth (it's
  idempotent — a Node already carrying the matching ProviderID is a
  no-op).
- CAPI Machine ↔ Node binding succeeds end-to-end on k0s, same as it
  already does on k3s.

## Implementation notes

One commit (`80595f3`). Touches:

- `internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl` (+19 LOC)
- `internal/bootstrap/templates/k0s_kairos_cloud_config_capk.yaml.tmpl` (+19 LOC)
- `internal/bootstrap/template_test.go` (+110 LOC, 4 new unit tests)

Template change:

```yaml
k0s:
  enabled: true
  {{- if or .SingleNode .PodCIDR .ServiceCIDR .ProviderID }}
  args:
  {{- if .SingleNode }}
    - --single
  {{- end }}
  {{- if or .PodCIDR .ServiceCIDR }}
    - --config /etc/k0s/k0s.yaml
  {{- end }}
  {{- if .ProviderID }}
    - --kubelet-extra-args=--provider-id={{ .ProviderID }}
  {{- end }}
  {{- end }}
```

Worker block (k0s-worker) gets the same conditional addition for
uniform behaviour. HA worker scope is gated on KD-5 so the effect is
currently nil — there for the day workers land.

The args-block OR-gate already included `.SingleNode .PodCIDR
.ServiceCIDR` (capv) and the same plus `.IsKubeVirt` (capk); the gate
now also includes `.ProviderID` so the args block renders when only
ProviderID is set (e.g. CAPV after CAPV resolves the VM UUID and the
bootstrap controller re-renders).

## Security

`ProviderID` is validated by `internal/bootstrap/validate.go`'s
`ValidateProviderID` against a strict regex
(`^[a-zA-Z][a-zA-Z0-9+.-]*://[a-zA-Z0-9._/-]+$`) per
`internal/bootstrap/CLAUDE.md` § 2. Bare `{{ .ProviderID }}`
interpolation in the new shell-context line matches the existing
pattern at line 245 (the post-bootstrap `kubectl patch`) which has
been in place since PR-7. The new
`TestRenderK0sCloudConfig_ProviderID_InjectionRejected` pins the
validator surface so a future weakening is caught at unit-test time.

## Validation

- `go test ./internal/bootstrap/... -count=1 -short` all green.
- 4 new unit tests:
  - `TestRenderK0sCloudConfig_ControlPlaneWithProviderID` (positive — args entry present)
  - `TestRenderK0sCloudConfig_ControlPlaneWithoutProviderID` (negative — args entry absent, no malformed flag)
  - `TestRenderK0sCloudConfig_WorkerWithProviderID` (worker parity)
  - `TestRenderK0sCloudConfig_ProviderID_InjectionRejected` (5 injection variants — all rejected by validator)
- `go test ./... -count=1 -short` all green.

### Lab regression
Not strictly required — the existing 4/4 Hadron lab manifests are
either CAPK (no immutability race) or CAPV with ProviderID populated
by re-render before VM boot. A new lab scenario where ProviderID is
known at first render of a CAPV k0s manifest would exercise this
path; maintainer can choose whether to add it to the lab matrix.

## Out of scope

- KD-46 (RBAC minimization in `kubeVirtTokenResolver`) — next PR.
- alpha-2 release prep — held on upstream Hadron #388 + a published
  Hadron variant with `vmtoolsd.service` enabled.
