### PR TITLE
fix(bootstrap): minimize per-cluster node SA RBAC (KD-46, alpha-2 follow-up)

### DIFF
--- a/internal/controllers/bootstrap/management_endpoint_resolver.go
+++ b/internal/controllers/bootstrap/management_endpoint_resolver.go
@@ -131,6 +131,26 @@ func (r *kubeVirtTokenResolver) Resolve(ctx context.Context, kc *bootstrapv1beta
 		// per-cluster Role+RoleBinding scope (a node only ever has its own
 		// cluster's bearer token) and is least-privilege relative to
 		// granting `create` on all Secrets cluster-wide.
+		// KD-46 (RBAC minimization): the per-cluster node SA only needs the
+		// permissions the rendered cloud-config's bearer-token requests
+		// actually exercise. Audited against every template under
+		// internal/bootstrap/templates/:
+		//
+		//   secrets:create                        — node-push POST (all
+		//                                            distros/infra) when the
+		//                                            kubeconfig Secret is absent.
+		//   secrets:get/update/patch (named)      — node-push PUT (all
+		//                                            distros/infra) to refresh
+		//                                            the existing Secret.
+		//   virtualmachineinstances:get           — ONLY the k0s CAPK
+		//                                            control-plane SAN-detection
+		//                                            block (fetch_vmi_ip_from_management
+		//                                            in k0s_kairos_cloud_config_capk.yaml.tmpl,
+		//                                            gated `and .IsKubeVirt (eq .Role "control-plane")`).
+		//                                            Granted conditionally below.
+		//   services:get                          — REMOVED. No template path
+		//                                            reads Services with the node
+		//                                            SA token; it was a dead grant.
 		role.Rules = []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{""},
@@ -143,16 +163,20 @@ func (r *kubeVirtTokenResolver) Resolve(ctx context.Context, kc *bootstrapv1beta
 				ResourceNames: []string{secretName},
 				Verbs:         []string{"get", "update", "patch"},
 			},
-			{
+		}
+		// Grant virtualmachineinstances:get only for the exact config shape
+		// that consumes it. This resolver is the CAPK (KubeVirt) resolver, so
+		// IsKubeVirt is implied; the SAN-detection block additionally requires
+		// the control-plane role and the k0s distribution (the k3s CAPK
+		// template has no VMI query). Distribution is webhook-defaulted to
+		// "k0s" when empty, so this comparison is reliable. k3s control-plane
+		// SAs and all worker SAs no longer receive this grant.
+		if kc.Spec.Role == "control-plane" && (kc.Spec.Distribution == "k0s" || kc.Spec.Distribution == "") {
+			role.Rules = append(role.Rules, rbacv1.PolicyRule{
 				APIGroups: []string{"kubevirt.io"},
 				Resources: []string{"virtualmachineinstances"},
 				Verbs:     []string{"get"},
-			},
-			{
-				APIGroups: []string{""},
-				Resources: []string{"services"},
-				Verbs:     []string{"get"},
-			},
+			})
 		}
 		if role.Labels == nil {
 			role.Labels = map[string]string{}

--- a/internal/controllers/bootstrap/management_endpoint_resolver_test.go
+++ b/internal/controllers/bootstrap/management_endpoint_resolver_test.go
@@ -123,6 +123,10 @@ func TestResolve_HappyPath_ReturnsFullEndpoint(t *testing.T) {
 	scheme := newResolverScheme(t)
 	sub := &fakeSubResourceClient{token: "tok-abc"}
 	r, kc, cluster := newResolverFixture(scheme, sub, "https://mgmt:6443")
+	// k0s control-plane is the config shape that exercises every rule the
+	// resolver can grant (incl. the conditional VMI/get for SAN detection).
+	kc.Spec.Role = "control-plane"
+	kc.Spec.Distribution = "k0s"
 
 	got, err := r.Resolve(context.Background(), kc, cluster)
 	g.Expect(err).NotTo(HaveOccurred())
@@ -139,15 +143,102 @@ func TestResolve_HappyPath_ReturnsFullEndpoint(t *testing.T) {
 	g.Expect(sa.Labels).To(HaveKeyWithValue(clusterv1.ClusterNameLabel, "test-cluster"))
 	role := &rbacv1.Role{}
 	g.Expect(r.Client.Get(context.Background(), types.NamespacedName{Name: saName, Namespace: "default"}, role)).To(Succeed())
-	// 4 rules after KD-3b: secrets/create (no resourceNames, K8s RBAC
-	// silent-fail workaround), secrets/get,update,patch on the named
-	// kubeconfig Secret, kubevirt.io VMI/get (CAPK SAN detection),
-	// services/get (CAPK LB endpoint discovery).
-	g.Expect(role.Rules).To(HaveLen(4))
+	// KD-46 minimization: a k0s control-plane (CAPK) SA gets exactly 3 rules:
+	//   1. secrets/create (no resourceNames — K8s RBAC silent-fail workaround)
+	//   2. secrets/get,update,patch on the named kubeconfig Secret
+	//   3. kubevirt.io VMI/get (k0s CAPK control-plane SAN detection only)
+	// services/get was removed (dead grant — no template reads Services
+	// with the node SA token).
+	g.Expect(role.Rules).To(HaveLen(3))
+	g.Expect(roleGrantsVMIGet(role)).To(BeTrue(), "k0s control-plane SA must retain virtualmachineinstances:get for SAN detection")
+	g.Expect(roleGrantsServicesGet(role)).To(BeFalse(), "services:get is a dead grant and must be removed (KD-46)")
 	rb := &rbacv1.RoleBinding{}
 	g.Expect(r.Client.Get(context.Background(), types.NamespacedName{Name: saName, Namespace: "default"}, rb)).To(Succeed())
 	g.Expect(rb.RoleRef.Name).To(Equal(saName))
 	g.Expect(sub.createCalls).To(Equal(1))
+}
+
+// roleGrantsVMIGet reports whether the Role grants get on kubevirt.io
+// virtualmachineinstances.
+func roleGrantsVMIGet(role *rbacv1.Role) bool {
+	for _, rule := range role.Rules {
+		for _, g := range rule.APIGroups {
+			if g != "kubevirt.io" {
+				continue
+			}
+			for _, res := range rule.Resources {
+				if res == "virtualmachineinstances" {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// roleGrantsServicesGet reports whether the Role grants any verb on core
+// Services — used to assert the KD-46 removal of the dead services:get rule.
+func roleGrantsServicesGet(role *rbacv1.Role) bool {
+	for _, rule := range role.Rules {
+		coreGroup := false
+		for _, g := range rule.APIGroups {
+			if g == "" {
+				coreGroup = true
+				break
+			}
+		}
+		if !coreGroup {
+			continue
+		}
+		for _, res := range rule.Resources {
+			if res == "services" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestResolve_RBACMinimization_VMIGetScopedToK0sControlPlane verifies the
+// KD-46 conditional grant: only a k0s control-plane config receives
+// virtualmachineinstances:get. k3s control-planes and all workers get the
+// minimal 2-rule Secret-only Role.
+func TestResolve_RBACMinimization_VMIGetScopedToK0sControlPlane(t *testing.T) {
+	cases := []struct {
+		name         string
+		role         string
+		distribution string
+		wantVMIGet   bool
+		wantRuleLen  int
+	}{
+		{"k0s-control-plane-gets-vmi", "control-plane", "k0s", true, 3},
+		{"k0s-empty-distribution-defaults-k0s", "control-plane", "", true, 3},
+		{"k3s-control-plane-no-vmi", "control-plane", "k3s", false, 2},
+		{"k0s-worker-no-vmi", "worker", "k0s", false, 2},
+		{"k3s-worker-no-vmi", "worker", "k3s", false, 2},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			scheme := newResolverScheme(t)
+			sub := &fakeSubResourceClient{token: "tok"}
+			r, kc, cluster := newResolverFixture(scheme, sub, "https://mgmt:6443")
+			kc.Spec.Role = tc.role
+			kc.Spec.Distribution = tc.distribution
+
+			_, err := r.Resolve(context.Background(), kc, cluster)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			role := &rbacv1.Role{}
+			saName := kubeconfigWriterName("test-cluster")
+			g.Expect(r.Client.Get(context.Background(), types.NamespacedName{Name: saName, Namespace: "default"}, role)).To(Succeed())
+			g.Expect(role.Rules).To(HaveLen(tc.wantRuleLen))
+			g.Expect(roleGrantsVMIGet(role)).To(Equal(tc.wantVMIGet))
+			// services:get must never appear regardless of config shape.
+			g.Expect(roleGrantsServicesGet(role)).To(BeFalse())
+		})
+	}
 }
 
 // TestResolve_SubResourceError_ReturnsError asserts that a TokenRequest


### PR DESCRIPTION
## Summary

RBAC minimization (KD-46) on the per-cluster ServiceAccount that the KD-3b
node-push path uses. The `kubeVirtTokenResolver` mints a per-cluster
SA + Role + bound token; the token is embedded in the rendered cloud-config
and the workload node uses it to push its kubeconfig back to the management
cluster. That Role is the only thing standing between a leaked node token
and the management API, so it should grant exactly what the node's
bearer-token requests exercise — no more.

Audited the Role's 4 grants against every bearer-token request the four
cloud-config templates actually make. Two were over-broad:

| Grant | Before | After |
|---|---|---|
| `secrets:create` (namespace) | ✅ | ✅ unchanged (node-push POST) |
| `secrets:get/update/patch` (named `<cluster>-kubeconfig`) | ✅ | ✅ unchanged (node-push PUT) |
| `kubevirt.io/virtualmachineinstances:get` (namespace) | granted to **every** SA | granted **only** to k0s control-plane SAs |
| `services:get` (namespace) | granted to every SA | **removed** (dead grant) |

## What this fixes

**`services:get` was a dead grant.** No template path reads Services with
the node SA token — grepped all four templates for `/api/v1/namespaces/*/services`
calls: zero. (Likely a leftover from a pre-KD-3b LB-discovery design that
the controller — using its own SA, not this one — handles.) Removed.

**`virtualmachineinstances:get` is now conditional.** It's consumed only by
the k0s CAPK control-plane SAN-detection block (`fetch_vmi_ip_from_management`
in `k0s_kairos_cloud_config_capk.yaml.tmpl`, gated
`{{- if and .IsKubeVirt (eq .Role "control-plane") }}`; the k3s CAPK template
has no VMI query, workers never query). Now granted only when
`kc.Spec.Role == "control-plane" && (Distribution == "k0s" || "")`.
**k3s control-plane SAs and ALL worker SAs no longer receive it.**
`Distribution` is webhook-defaulted to `"k0s"` when empty, so the comparison
is reliable; the `|| ""` covers the empty case (over-grant direction = safe).

## Security review

**security-architect verdict: MERGE.** No HIGH, no blocking MEDIUM. Both
audit claims independently confirmed (services:get dead; conditional VMI
grant matches template usage; empty-distribution fallback over-grants in the
safe direction only). Review covered the RBAC delta, the templates, and the
Distribution-defaulting path.

## Known limitation (tracked, NOT alpha-2-blocking)

The resolver gates the VMI grant on **raw** `kc.Spec.Role`/`Distribution`,
while the controller renders the cloud-config on the **effective** role
(derived from the Machine label when `kc.Spec.Role == ""`). For an HA
control-plane config with unset `spec.role` whose admission was bypassed,
the controller would render the VMI-fetch block but the resolver would deny
the grant → the SAN-detection's `fetch_vmi_ip_from_management` gets 403 and
**gracefully falls back** to local IP detection. This is the safe
(under-grant) direction — a functional fallback, not a security regression.

Tracked as KD-46-followup, bundled with a further tightening
(`resourceNames`-scope the VMI get to the single queried VMI = `.MachineName`)
since both need the resolver to know the machine identity. Both deferred
pending lab verification of the CAPK VMI-name == Machine-name assumption.

`secrets:create` namespace-wide is pre-existing (K8s ignores resourceNames
for `create`); security-architect concurs it's acceptable, bounded by the
per-cluster Role scope. Not expanded by this PR.

## Validation

- `go build ./... && go vet ./...` clean.
- `go test ./... -count=1 -short` all green.
- `TestResolve_HappyPath_ReturnsFullEndpoint` updated: k0s control-plane
  asserts exactly 3 rules, VMI/get present, services/get absent.
- New `TestResolve_RBACMinimization_VMIGetScopedToK0sControlPlane`:
  5-case table (k0s CP, k0s empty-distro→default, k3s CP, k0s worker,
  k3s worker) asserting VMI/get presence + rule count + services/get
  always absent.
- Two helper predicates make assertions resilient to rule ordering.

## Out of scope

- KD-46-followup (effective-role plumbing + resourceNames scoping).
- alpha-2 release prep — held on upstream Hadron #388 + a published
  Hadron variant with `vmtoolsd.service` enabled.
