### PR TITLE
docs(release): stage v0.1.0-alpha.2 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,105 @@
+# Changelog
+
+All notable changes to the Kairos Cluster API provider are documented in this
+file. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+This project is pre-1.0. Alpha releases may include breaking changes; those are
+called out explicitly under **Breaking changes**. Per-scenario migration steps
+live in [docs/UPGRADING.md](docs/UPGRADING.md).
+
+## [v0.1.0-alpha.2] — unreleased
+
+> **Release gate.** This version is staged for review but **not yet tagged**.
+> It will not be cut until a Kairos (Hadron) OS image that includes and enables
+> `open-vm-tools` (`vmtoolsd` present and running) is published — CAPV relies on
+> VMware Tools to report guest IP addresses. The entry below is frozen here
+> until that image exists.
+
+Alpha-2 resolves the two security notices that shipped with alpha-1: it removes
+**synchronous SSH from the controller's reconcile path** (KD-3b) and removes the
+**insecure `kairos:kairos` default credentials** (KD-3a). See
+[docs/UPGRADING.md](docs/UPGRADING.md#v010-alpha1--v010-alpha2) for the
+per-scenario upgrade impact before rolling existing clusters forward.
+
+### Breaking changes
+
+- **Default credentials removed.** The bootstrap provider no longer seeds the
+  node user with `kairos:kairos`, and no longer injects `PasswordAuthentication yes`
+  into `sshd_config`. A node now requires an explicit `spec.userPassword`,
+  `spec.userPasswordSecretRef`, or SSH key. (#49, KD-3a)
+- **`KairosControlPlane.spec.replicas > 1` is rejected** by the validating
+  webhook. Alpha-1 silently accepted it and produced N independent single-node
+  clusters rather than an HA control plane. HA join logic is still on the
+  roadmap; stay on `replicas: 1`. (#48, KD-5a)
+- **KCP no longer writes `Cluster.Spec.ControlPlaneEndpoint`.** The endpoint is
+  now owned exclusively by CAPI core (copied from the infra cluster), per the
+  v1beta2 contract. Clusters that relied on KCP auto-discovering the endpoint
+  from Machine IPs must set it on the infrastructure cluster. (#60, KD-12)
+
+### Security
+
+- Eliminated synchronous SSH from the controller hot path. After k0s/k3s
+  starts, the **node** POSTs its own workload kubeconfig back to a Secret in the
+  management cluster using a short-lived, audience-scoped bearer token; the
+  control-plane controller waits for that Secret via a label-filtered watch.
+  CAPV is extended to the same node-push pattern as CAPK. (#54, #55, #58, KD-3b/KD-10)
+- Removed `ssh.InsecureIgnoreHostKey()`. The new opt-in SSH fallback mandates
+  `known_hosts` host-key verification and public-key-only authentication, runs
+  off the reconcile path in a bounded worker pool, and never logs key material.
+  (#59)
+- Closed a shell-injection (RCE) vector in `Hostname` cloud-config rendering and
+  routed every shell-context field through the `shquote` filter. (#53, KD-22/KD-28/KD-43)
+- Minimized the per-cluster node ServiceAccount RBAC: dropped the dead
+  `services:get` grant and scoped `virtualmachineinstances:get` to k0s
+  control-plane nodes only (the sole config shape that consumes it). (#63, KD-46)
+- Added `spec.userPasswordSecretRef` so the node password no longer has to live
+  inline in the `KairosConfig` spec. (#49, KD-3a)
+
+### Added
+
+- Opt-in `spec.sshFallback` on `KairosControlPlane` for air-gapped CAPV
+  environments where the VM cannot reach the management API server. Webhook
+  defaults and validates the field (mandatory key + known-hosts Secret refs,
+  no cross-namespace refs, `activateAfter` bounded above the kubeconfig-ready
+  timeout). (#59)
+- Validating + defaulting webhook for `KairosControlPlaneTemplate`, mirroring
+  the `KairosControlPlane` webhook (including SSH-fallback validation). (#61)
+- `ManagementEndpoint` type and `ManagementEndpointResolver` interface; the CAPK
+  kubeconfig-push path is now resolver-driven and unit-testable without
+  envtest. (#54, KD-33)
+- Persistent-state-paths configuration injected via cloud-config so node state
+  survives reboots. (#52, KD-23)
+
+### Changed
+
+- `Node.Spec.ProviderID` is now set exclusively in-VM: k3s via a kubelet
+  `config.yaml.d` drop-in, k0s via a post-bootstrap systemd patch service plus a
+  `--kubelet-extra-args=--provider-id` `ExecStartPre` drop-in. The controller no
+  longer reaches into the workload cluster to patch it. (#58, #62, KD-3b/KD-3c)
+
+### Fixed
+
+- `reconcileDelete` now enumerates and removes child resources (KairosConfigs,
+  owned Secrets, InfraMachines) before stripping the finalizer, and latched
+  `FailureReason`/`FailureMessage` recover on the success path. (#50, KD-4/KD-14)
+
+### Removed
+
+- `ensureProviderIDOnNodes` — the last piece of synchronous workload-cluster I/O
+  in `Reconcile`. ProviderID is now owned entirely in-VM (see **Changed**).
+  (#58, KD-10)
+- The `kairos:kairos` default user and the `PasswordAuthentication yes` sshd
+  injection (see **Breaking changes**). (#49, KD-3a)
+
+## [v0.1.0-alpha.1] — 2026-05-18
+
+Initial public alpha. Two providers ship together: the bootstrap provider
+(`bootstrap.cluster.x-k8s.io/v1beta2`) and the control-plane provider
+(`controlplane.cluster.x-k8s.io/v1beta2`). Single-node k0s and k3s clusters on
+CAPD (Docker), CAPV (vSphere), and CAPK (KubeVirt). See the
+[release notes](docs/release-notes/v0.1.0-alpha.1.md) for the full feature list
+and the alpha-1 security notices.
+
+[v0.1.0-alpha.2]: https://github.com/kairos-io/cluster-api-provider-kairos/compare/v0.1.0-alpha.1...HEAD
+[v0.1.0-alpha.1]: https://github.com/kairos-io/cluster-api-provider-kairos/releases/tag/v0.1.0-alpha.1

--- a/config/clusterctl/metadata.yaml
+++ b/config/clusterctl/metadata.yaml
@@ -1,20 +1,30 @@
 # clusterctl metadata.yaml
-# This file is used by clusterctl to discover and install the provider
-# It should be published alongside the components.yaml in releases
+# This file is used by clusterctl to discover and install the provider.
+# It is published alongside the components manifest in each release.
+#
+# NOTE: clusterctl integration is not yet claimed for the v0.1.0-alpha line —
+# the provider currently ships as a flat manifest installed via
+# `kubectl apply -f kairos-capi-provider.yaml` (see docs/INSTALL.md). This file
+# is forward-looking scaffolding. Before clusterctl support is advertised, a
+# release-and-supply-chain pass must reconcile: the `contract` value against the
+# CAPI version actually vendored (go.mod), the artifact file names against what
+# the release workflow publishes, and `sha256` population in CI. Per policy,
+# `sha256` keys are intentionally omitted here rather than left empty — an empty
+# checksum defeats clusterctl's integrity check. CI populates them at tag time.
 
 apiVersion: clusterctl.cluster.x-k8s.io/v1beta1
 kind: Metadata
 releaseSeries:
   - major: 0
     minor: 1
+    contract: v1beta2
     patches:
-      - version: v0.1.0
-        releaseDate: "2024-11-21"
-        url: https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0/components.yaml
-        contract: v1beta2
-        files:
-          - url: https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0/components.yaml
-            sha256: "" # TODO: Add SHA256 checksum
-          - url: https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0/metadata.yaml
-            sha256: "" # TODO: Add SHA256 checksum
-
+      - version: v0.1.0-alpha.1
+        releaseDate: "2026-05-18"
+        url: https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-alpha.1/kairos-capi-provider.yaml
+      # v0.1.0-alpha.2 is staged but NOT yet released. The release is gated on a
+      # published Kairos (Hadron) image with open-vm-tools enabled; see
+      # docs/release-notes/v0.1.0-alpha.2.md. Date is filled in at tag time.
+      - version: v0.1.0-alpha.2
+        releaseDate: "TBD"
+        url: https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-alpha.2/kairos-capi-provider.yaml

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -30,7 +30,7 @@ Use this if you want to consume a tagged release.
 ### Install
 
 ```bash
-kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-alpha.1/kairos-capi-provider.yaml
+kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-alpha.2/kairos-capi-provider.yaml
 ```
 
 This applies the all-in-one provider manifest: CRDs, RBAC, webhook configurations, and the controller Deployment in the `kairos-capi-system` namespace.
@@ -52,7 +52,7 @@ Expected: one Deployment `kairos-capi-controller-manager` in `kairos-capi-system
 ### Uninstall
 
 ```bash
-kubectl delete -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-alpha.1/kairos-capi-provider.yaml
+kubectl delete -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-alpha.2/kairos-capi-provider.yaml
 ```
 
 **Re-install note**: if you are re-installing across a name-prefix change or a previous failed install, stale `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration` objects from the previous install may point at a webhook Service that no longer exists. Delete them before re-installing:
@@ -126,8 +126,10 @@ before deploying:
 curl -k https://<mgmt-api-server-host>:6443/api
 ```
 
-For air-gapped or strictly-segmented network environments, see the planned
-`SSHFallback` opt-in mechanism (post-alpha-2, PR-9).
+For air-gapped or strictly-segmented network environments, enable
+`spec.sshFallback` on the `KairosControlPlane`. See
+[CAPV quickstart — Air-gapped fallback (SSHFallback)](QUICKSTART_CAPV.md#air-gapped-fallback-sshfallback)
+for the full operator procedure.
 
 ---
 
@@ -137,4 +139,4 @@ For air-gapped or strictly-segmented network environments, see the planned
 - [CAPV Quickstart](QUICKSTART_CAPV.md) — create a cluster with vSphere.
 - [CAPK Quickstart](QUICKSTART_CAPK.md) — create a cluster with KubeVirt.
 
-For the current release status, known issues, and security caveats, read the [release notes](release-notes/v0.1.0-alpha.1.md).
+For the current release status, known issues, and security caveats, read the [release notes](release-notes/v0.1.0-alpha.2.md).

--- a/docs/QUICKSTART_CAPD.md
+++ b/docs/QUICKSTART_CAPD.md
@@ -28,7 +28,7 @@ Install CAPI and CAPD using your preferred method. See the [Cluster API book](ht
 **Recommended (released artifact):**
 
 ```bash
-kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-alpha.1/kairos-capi-provider.yaml
+kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-alpha.2/kairos-capi-provider.yaml
 ```
 
 **Developer install (from source):**

--- a/docs/QUICKSTART_CAPK.md
+++ b/docs/QUICKSTART_CAPK.md
@@ -167,7 +167,7 @@ Do not use `clusterctl init --bootstrap kairos` — clusterctl integration is de
   - A LoadBalancer implementation (MetalLB or equivalent)
 - Kairos CAPI provider installed:
   ```bash
-  kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-alpha.1/kairos-capi-provider.yaml
+  kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-alpha.2/kairos-capi-provider.yaml
   ```
 - A Kairos image uploaded to CDI as a DataVolume named `kairos-rootdisk` (for k0s) or `kairos-k3s-rootdisk` (for k3s) in namespace `default`. The image must be a Kairos live-installer image — not a pre-installed disk image.
 

--- a/docs/QUICKSTART_CAPV.md
+++ b/docs/QUICKSTART_CAPV.md
@@ -69,7 +69,7 @@ kubectl label namespace default vsphere-identity=allowed
 **Recommended (released artifact):**
 
 ```bash
-kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-alpha.1/kairos-capi-provider.yaml
+kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-alpha.2/kairos-capi-provider.yaml
 ```
 
 **Developer install (from source):**

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -2,30 +2,8 @@
 
 > This file is a stub. The canonical upgrade procedures land in a later PR
 > (`docs/kd-35-kd-36-install-upgrade`). For now this captures the
-> alpha-1 → alpha-2 KD-3b impact and the alpha-2 → alpha-3 KD-12 impact.
-
-## v0.1.0-alpha.2 → v0.1.0-alpha.3
-
-### KD-12: KCP no longer writes `Cluster.Spec.ControlPlaneEndpoint`
-
-The alpha-3 release removes the two blocks in `updateClusterStatus` that wrote
-`Cluster.Spec.ControlPlaneEndpoint` from Machine IP addresses (CAPV/CAPD) or
-from the LoadBalancer Service Ingress IP (CAPK). `Cluster.Spec.ControlPlaneEndpoint`
-is now written exclusively by CAPI core, which copies it from the infra-cluster's
-own `Spec.ControlPlaneEndpoint`. This is the behaviour the CAPI v1beta2 contract
-requires.
-
-| Cluster state at upgrade | Behaviour after KD-12 | Operator action |
-|---|---|---|
-| Healthy cluster, `Cluster.Spec.ControlPlaneEndpoint` already populated | No change. The endpoint is preserved; the KCP controller stops overwriting it. CAPI core is now the sole writer, which is byte-identical to what KCP was writing. | None. |
-| Mid-provisioning cluster, infra provider has already populated `<Infra>Cluster.Spec.ControlPlaneEndpoint` | CAPI core copies it on its next reconcile; everything proceeds. | None. |
-| CAPV / CAPD / CAPK cluster whose `<Infra>Cluster.Spec.ControlPlaneEndpoint` (CAPV/CAPD) or `KubevirtCluster.Spec.ControlPlaneServiceTemplate` (CAPK) is unset — including any cluster that relied on KCP auto-discovering the endpoint from Machine IPs | `Cluster.Spec.ControlPlaneEndpoint` stays empty. KCP stalls with `KairosControlPlane.Status.Conditions[Available].Reason=WaitingForInfrastructureControlPlaneEndpoint`. | Set `VSphereCluster.Spec.ControlPlaneEndpoint` (CAPV), `DockerCluster.Spec.ControlPlaneEndpoint` (CAPD), or supply a LoadBalancer IP via the sample's `Cluster.spec.controlPlaneEndpoint` placeholder (CAPK) per the upstream provider's contract. For an in-flight cluster: `kubectl edit cluster <name>` and set `spec.controlPlaneEndpoint.host` and `spec.controlPlaneEndpoint.port` directly. CAPI core does not overwrite a populated value. |
-
-No CRD changes in this release for KD-12. The new condition Reason
-(`WaitingForInfrastructureControlPlaneEndpoint`) is additive — clients
-that treat unknown Reasons as opaque strings are unaffected.
-
----
+> alpha-1 → alpha-2 migration impact (KD-3b SSH elimination, KD-3b part 2
+> in-VM ProviderID, and the KD-12 control-plane-endpoint contract fix).
 
 ## v0.1.0-alpha.1 → v0.1.0-alpha.2
 
@@ -44,12 +22,12 @@ via a label-filtered watch.
 | CAPK control-plane mid-bootstrap (Secret not yet pushed) | Controller renders a NEW bootstrap Secret on next reconcile. The node, when it comes up, uses the new template's push payload. | None unless a rollout is needed for unrelated reasons. |
 | CAPV control-plane healthy, kubeconfig Secret present (was SSH-fetched in alpha-1) | Controller's existing-Secret check still passes. Cluster keeps working. | None. |
 | CAPV control-plane mid-bootstrap | **Old KairosConfig has no push block.** Controller's SSH path is GONE. The node will never push; the controller will never SSH. The cluster will sit indefinitely on `KubeconfigReadyCondition=False(WaitingForNodePush)`. | **Required**: delete the KairosConfig (or trigger a KCP rollout) so the bootstrap controller renders a new userdata with the push block. CAPV will create a new VM with new userdata. |
-| Air-gapped CAPV control-plane (no network reachability from VM to management cluster API server) | Cluster stuck on `KubeconfigReadyCondition=False(WaitingForNodePush)` indefinitely; condition severity transitions Info → Warning after 10 minutes. | Enable `Spec.SSHFallback`: (1) create a `kubernetes.io/ssh-auth` Secret with an `ssh-privatekey` key in the cluster's namespace; (2) create an Opaque Secret with a `known_hosts` key containing the node's SSH host-key lines; (3) set `spec.sshFallback.enabled: true`, `spec.sshFallback.identitySecretRef.name`, and `spec.sshFallback.knownHostsSecretRef.name` on the `KairosControlPlane`; (4) leave `spec.sshFallback.activateAfter` at the default `15m` unless you have a reason to change it. The fallback fires after `activateAfter` elapses from `KubeconfigReadyCondition` first becoming `False(WaitingForNodePush)`. See [Air-gapped fallback (SSHFallback)](QUICKSTART_CAPV.md#air-gapped-fallback-sshfallback) for worked examples. Or open a network path from the VM to `<management-cluster-api-server-host>:6443`. |
-| Bootstrap Secret rendered before alpha-2 (no post-bootstrap providerID service block in the cloud-config) | Controller no longer patches `Node.Spec.ProviderID` (PR-8 deleted `ensureProviderIDOnNodes`). The old Secret also has no in-node patch script. `Node.Spec.ProviderID` stays empty → CAPI Machine controller cannot match the NodeRef → Machine stays `NodeNotFound`. | **Required**: trigger a KCP rollout (or delete the KairosConfig) so the bootstrap controller re-renders the Secret with the alpha-2 template, which includes the post-bootstrap providerID service. |
+| Air-gapped CAPV control-plane (no network reachability from VM to management cluster API server) | Cluster stuck on `KubeconfigReadyCondition=False(WaitingForNodePush)` indefinitely; condition severity transitions Info → Warning after 10 minutes. | Enable `spec.sshFallback`: (1) create a `kubernetes.io/ssh-auth` Secret with an `ssh-privatekey` key in the cluster's namespace; (2) create an Opaque Secret with a `known_hosts` key containing the node's SSH host-key lines; (3) set `spec.sshFallback.enabled: true`, `spec.sshFallback.identitySecretRef.name`, and `spec.sshFallback.knownHostsSecretRef.name` on the `KairosControlPlane`; (4) leave `spec.sshFallback.activateAfter` at the default `15m` unless you have a reason to change it. The fallback fires after `activateAfter` elapses from `KubeconfigReadyCondition` first becoming `False(WaitingForNodePush)`. See [Air-gapped fallback (SSHFallback)](QUICKSTART_CAPV.md#air-gapped-fallback-sshfallback) for worked examples. Or open a network path from the VM to `<management-cluster-api-server-host>:6443`. |
+| Bootstrap Secret rendered before alpha-2 (no post-bootstrap providerID service block in the cloud-config) | Controller no longer patches `Node.Spec.ProviderID` (alpha-2 deleted `ensureProviderIDOnNodes`, #58). The old Secret also has no in-node patch script. `Node.Spec.ProviderID` stays empty → CAPI Machine controller cannot match the NodeRef → Machine stays `NodeNotFound`. | **Required**: trigger a KCP rollout (or delete the KairosConfig) so the bootstrap controller re-renders the Secret with the alpha-2 template, which includes the post-bootstrap providerID service. |
 
 ### KD-3b part 2: Node.Spec.ProviderID is now set exclusively in-VM
 
-PR-8 deletes `ensureProviderIDOnNodes` — the management-controller helper
+Alpha-2 deletes `ensureProviderIDOnNodes` (#58) — the management-controller helper
 that patched `Node.Spec.ProviderID` from outside the VM. That function was
 the last piece of controller-side synchronous workload-cluster I/O (KD-10).
 
@@ -63,19 +41,21 @@ The in-VM cloud-config now owns `Node.Spec.ProviderID` exclusively:
   `Node.Spec.ProviderID` using the local `/var/lib/k0s/pki/admin.conf`
   after k0s starts, retrying 30 times at 5-second intervals. When ProviderID
   is empty at render time the patch is deferred to the next reconcile cycle,
-  which re-renders the Secret with the correct value.
+  which re-renders the Secret with the correct value. A complementary k0s
+  `ExecStartPre` drop-in (KD-3c) passes `--kubelet-extra-args=--provider-id=<value>`
+  to the k0s worker process when the providerID is known at render time.
 
 **For most operators this is a no-op.** If `Node.Spec.ProviderID` was already
 set (alpha-1 or alpha-2 healthy clusters), the in-VM scripts either write the
 same value idempotently (k3s) or skip the patch because the Node field is
 already populated (k0s, which treats a non-empty providerID as immutable).
 
-**If you maintain a fork or derivative that re-added `ensureProviderIDOnNodes`
-between PR-7 and PR-8:** that helper is gone from the upstream source; the
+**If you maintain a fork or derivative that re-added `ensureProviderIDOnNodes`:**
+that helper is gone from the upstream source; the
 code will not compile. Remove the derivative — the in-VM scripts cover the
 same contract without management-cluster Node access.
 
-To diagnose a stuck `Node.Spec.ProviderID` after PR-8, inspect the VM journal
+To diagnose a stuck `Node.Spec.ProviderID` after upgrading, inspect the VM journal
 rather than controller logs:
 
 ```bash
@@ -85,6 +65,25 @@ journalctl -u kairos-k0s-post-bootstrap --no-pager
 # On the workload node (k3s):
 journalctl -u kairos-k3s-post-bootstrap --no-pager
 ```
+
+### KD-12: KCP no longer writes `Cluster.Spec.ControlPlaneEndpoint`
+
+The alpha-2 release removes the two blocks in `updateClusterStatus` that wrote
+`Cluster.Spec.ControlPlaneEndpoint` from Machine IP addresses (CAPV/CAPD) or
+from the LoadBalancer Service Ingress IP (CAPK). `Cluster.Spec.ControlPlaneEndpoint`
+is now written exclusively by CAPI core, which copies it from the infra-cluster's
+own `Spec.ControlPlaneEndpoint`. This is the behaviour the CAPI v1beta2 contract
+requires.
+
+| Cluster state at upgrade | Behaviour after KD-12 | Operator action |
+|---|---|---|
+| Healthy cluster, `Cluster.Spec.ControlPlaneEndpoint` already populated | No change. The endpoint is preserved; the KCP controller stops overwriting it. CAPI core is now the sole writer, which is byte-identical to what KCP was writing. | None. |
+| Mid-provisioning cluster, infra provider has already populated `<Infra>Cluster.Spec.ControlPlaneEndpoint` | CAPI core copies it on its next reconcile; everything proceeds. | None. |
+| CAPV / CAPD / CAPK cluster whose `<Infra>Cluster.Spec.ControlPlaneEndpoint` (CAPV/CAPD) or `KubevirtCluster.Spec.ControlPlaneServiceTemplate` (CAPK) is unset — including any cluster that relied on KCP auto-discovering the endpoint from Machine IPs | `Cluster.Spec.ControlPlaneEndpoint` stays empty. KCP stalls with `KairosControlPlane.Status.Conditions[Available].Reason=WaitingForInfrastructureControlPlaneEndpoint`. | Set `VSphereCluster.Spec.ControlPlaneEndpoint` (CAPV), `DockerCluster.Spec.ControlPlaneEndpoint` (CAPD), or supply a LoadBalancer IP via the sample's `Cluster.spec.controlPlaneEndpoint` placeholder (CAPK) per the upstream provider's contract. For an in-flight cluster: `kubectl edit cluster <name>` and set `spec.controlPlaneEndpoint.host` and `spec.controlPlaneEndpoint.port` directly. CAPI core does not overwrite a populated value. |
+
+No CRD changes in this release for KD-12. The new condition Reason
+(`WaitingForInfrastructureControlPlaneEndpoint`) is additive — clients
+that treat unknown Reasons as opaque strings are unaffected.
 
 ### Network reachability requirement
 
@@ -96,6 +95,6 @@ curl -k https://<mgmt-api-server-host>:6443/api
 ```
 
 For air-gapped or strictly-segmented network environments, enable
-`Spec.SSHFallback` on the `KairosControlPlane`. See
+`spec.sshFallback` on the `KairosControlPlane`. See
 [Air-gapped fallback (SSHFallback)](QUICKSTART_CAPV.md#air-gapped-fallback-sshfallback)
 for the full operator procedure.

--- a/docs/release-notes/v0.1.0-alpha.2.md
+++ b/docs/release-notes/v0.1.0-alpha.2.md
@@ -1,0 +1,206 @@
+# v0.1.0-alpha.2 — security hardening
+
+Second alpha of the Kairos Cluster API provider. This release closes the two
+security notices that shipped with alpha-1: it removes the insecure
+`kairos:kairos` **default credentials** (KD-3a) and eliminates **synchronous SSH
+from the controller's reconcile path** (KD-3b). It also tightens the cloud-config
+rendering layer, minimizes the per-cluster node RBAC, and brings the
+control-plane controller into line with the CAPI v1beta2 contract.
+
+This is still an **alpha**. The API surface, defaults, and on-disk layout may
+change before v0.1.0 ships. It is intended for early adopters who can read the
+source and the upgrade notes carefully.
+
+> **Upgrading from alpha-1?** Read [docs/UPGRADING.md](https://github.com/kairos-io/cluster-api-provider-kairos/blob/v0.1.0-alpha.2/docs/UPGRADING.md)
+> first. Several changes (SSH removal, in-VM ProviderID, the control-plane
+> endpoint contract fix) require a control-plane rollout for clusters that were
+> mid-bootstrap at upgrade time.
+
+---
+
+## ⚠️ Release gate — open-vm-tools
+
+CAPV depends on **VMware Tools** (`open-vm-tools` / `vmtoolsd`) running inside
+the guest to report the node's IP address back to vSphere — without it the
+`VSphereMachine` never reports an address and the node-push kubeconfig flow
+cannot complete. The Kairos (Hadron) base images current at the time of writing
+do **not** ship `open-vm-tools` enabled. Until a Kairos image with
+`open-vm-tools` present and `vmtoolsd` enabled is published and consumable, this
+release is **staged but not tagged**. CAPK and CAPD are unaffected by this gate.
+
+Tracking: [kairos-io/kairos#4092](https://github.com/kairos-io/kairos/issues/4092).
+
+---
+
+## Security — what changed since alpha-1
+
+### Default credentials removed (KD-3a) — **breaking**
+
+The bootstrap provider no longer seeds the node user with `kairos:kairos`, and
+no longer injects `PasswordAuthentication yes` into `sshd_config`. A node now
+requires an explicit credential:
+
+- Set `spec.userPassword`, **or**
+- Reference a Secret via the new `spec.userPasswordSecretRef`, **or**
+- Provide `spec.sshPublicKey` / `spec.gitHubUser` for key-only access.
+
+A `KairosConfig` that supplies none of these is rejected by the validating
+webhook. The alpha-1 "default credentials are insecure" notice is **resolved**.
+
+### SSH removed from the controller hot path (KD-3b / KD-10)
+
+The control-plane controller no longer SSHes into nodes during normal
+operation. After k0s/k3s starts, the **node** POSTs its own workload kubeconfig
+back to a Secret in the management cluster using a short-lived,
+audience-scoped bearer token minted per cluster; the controller waits for that
+Secret via a label-filtered watch. CAPV now uses the same node-push pattern that
+CAPK introduced in alpha-1.
+
+`Node.Spec.ProviderID` is likewise now set **exclusively in-VM** (k3s via a
+kubelet drop-in, k0s via a post-bootstrap systemd service plus an `ExecStartPre`
+drop-in). The controller no longer reaches into the workload cluster to patch
+Nodes — the last piece of synchronous workload-cluster I/O in `Reconcile`
+(`ensureProviderIDOnNodes`) is gone.
+
+`ssh.InsecureIgnoreHostKey()` is removed. For air-gapped or strictly-segmented
+networks where the VM cannot reach the management API server, an **opt-in**
+`spec.sshFallback` is available on `KairosControlPlane`; it mandates
+`known_hosts` host-key verification and public-key-only authentication, runs off
+the reconcile path in a bounded worker pool, and never logs key material. The
+alpha-1 "InsecureIgnoreHostKey" notice is **resolved**.
+
+### Cloud-config rendering hardened
+
+A shell-injection (RCE) vector in `Hostname` rendering is closed, and every
+shell-context field now passes through the `shquote` filter (POSIX
+single-quoted literal — no bash interpretation possible). (KD-22/KD-28/KD-43.)
+
+### Node RBAC minimized (KD-46)
+
+The per-cluster node ServiceAccount lost the dead `services:get` grant, and
+`virtualmachineinstances:get` is now scoped to k0s control-plane nodes only —
+the single config shape (CAPK k0s SAN-detection) that actually consumes it.
+
+### `replicas > 1` is now rejected (KD-5a) — **breaking**
+
+`KairosControlPlane.spec.replicas > 1` is rejected by the validating webhook.
+Alpha-1 silently accepted it and produced N independent single-node clusters.
+HA join logic remains on the roadmap; stay on `replicas: 1`.
+
+---
+
+## Other breaking changes
+
+### KCP no longer writes `Cluster.Spec.ControlPlaneEndpoint` (KD-12)
+
+Per the CAPI v1beta2 contract, `Cluster.Spec.ControlPlaneEndpoint` is owned
+exclusively by CAPI core (copied from the infra cluster). The control-plane
+controller no longer writes it. Clusters that relied on KCP auto-discovering the
+endpoint from Machine IPs must now set it on the infrastructure cluster
+(`VSphereCluster`/`DockerCluster.Spec.ControlPlaneEndpoint`, or the CAPK
+LoadBalancer). The controller surfaces
+`WaitingForInfrastructureControlPlaneEndpoint` while the endpoint is unset. See
+[UPGRADING.md](https://github.com/kairos-io/cluster-api-provider-kairos/blob/v0.1.0-alpha.2/docs/UPGRADING.md#kd-12-kcp-no-longer-writes-clusterspeccontrolplaneendpoint).
+
+---
+
+## What works
+
+- **Single-node** k0s and k3s clusters via CAPD (Docker, dev only), CAPV
+  (vSphere), and CAPK (KubeVirt).
+- Bootstrap-secret generation from `KairosConfig` / `KairosConfigTemplate`.
+- Node-push kubeconfig publication on CAPV and CAPK (no controller SSH).
+- In-VM `Node.Spec.ProviderID` assignment on k0s and k3s.
+- `reconcileDelete` cleanup of child resources (KairosConfigs, owned Secrets,
+  InfraMachines) on cluster/control-plane deletion (KD-4).
+- Validating + defaulting webhooks on `KairosControlPlane` **and**
+  `KairosControlPlaneTemplate`.
+- Cloud-config field escaping with adversarial-input round-trip tests; shell
+  contexts routed through `shquote`; `ProviderID` regex-validated.
+
+## What does not work yet
+
+- **HA control planes** (`replicas > 1`) — now rejected by the webhook.
+- **CAPV without `open-vm-tools`** — see the release gate above.
+- **`spec.kubernetesVersion`** is advisory; the installed k8s version is
+  whatever is bundled in your Kairos image at build time.
+- **Metal3 (CAPM3), Tinkerbell, hyperscalers** — infrastructure providers
+  beyond CAPV/CAPK/CAPD are not yet exercised.
+
+## Install
+
+### Prerequisites
+
+1. A management Kubernetes cluster (kind, EKS, etc.).
+2. [**cert-manager**](https://cert-manager.io) **v1.15+** installed:
+   ```bash
+   kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.15.2/cert-manager.yaml
+   kubectl wait --for=condition=Available --timeout=2m -n cert-manager deploy/cert-manager-webhook
+   ```
+3. **Cluster API core** installed:
+   ```bash
+   clusterctl init --infrastructure docker   # or vsphere, kubevirt, …
+   ```
+
+### Install the Kairos CAPI provider
+
+```bash
+kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-alpha.2/kairos-capi-provider.yaml
+```
+
+Verify:
+
+```bash
+kubectl get pods -n kairos-capi-system
+kubectl get crds | grep kairos
+```
+
+You should see the `kairos-capi-controller-manager` Deployment ready and four
+CRDs: `kairosconfigs`, `kairosconfigtemplates`, `kairoscontrolplanes`,
+`kairoscontrolplanetemplates` (all under `*.cluster.x-k8s.io`).
+
+### Quickstarts
+
+- [CAPD (Docker) quickstart](https://github.com/kairos-io/cluster-api-provider-kairos/blob/v0.1.0-alpha.2/docs/QUICKSTART_CAPD.md)
+- [CAPV (vSphere) quickstart](https://github.com/kairos-io/cluster-api-provider-kairos/blob/v0.1.0-alpha.2/docs/QUICKSTART_CAPV.md)
+- [CAPK (KubeVirt) quickstart](https://github.com/kairos-io/cluster-api-provider-kairos/blob/v0.1.0-alpha.2/docs/QUICKSTART_CAPK.md)
+
+## Compatibility
+
+| Component | Tested version |
+| --- | --- |
+| Cluster API | v1.8.x |
+| Kubernetes (workload) | bundled in the Kairos image (k3s/k0s, typically v1.30+) |
+| Kubernetes (management) | v1.30+ |
+| Kairos | v3.6.0+ (CAPV additionally requires an image with `open-vm-tools` enabled) |
+| Go (build) | 1.26.x |
+| cert-manager | v1.15+ |
+
+Future releases will bump the Cluster API contract dependency to v1.11.x.
+
+## Artifacts
+
+| File | Description |
+| --- | --- |
+| `kairos-capi-provider.yaml` | All-in-one manifest: CRDs, RBAC, webhook configs, manager Deployment. |
+| `sha256sums.txt` | SHA-256 checksum of the manifest. |
+
+Container image:
+`ghcr.io/kairos-io/cluster-api-provider-kairos:v0.1.0-alpha.2` (linux/amd64, linux/arm64).
+
+## Verifying artifacts
+
+```bash
+curl -LO https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-alpha.2/kairos-capi-provider.yaml
+curl -LO https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-alpha.2/sha256sums.txt
+sha256sum -c sha256sums.txt
+```
+
+Image signing (cosign), SBOMs, and SLSA provenance remain planned for a
+subsequent alpha.
+
+## Acknowledgements
+
+Thanks to the upstream Kairos maintainers for the `open-vm-tools` work tracked
+in this release's gate, and to the early adopters whose lab feedback drove the
+SSH-elimination and node-push design.


### PR DESCRIPTION
## Summary

Stages the user-facing release artifacts for **v0.1.0-alpha.2**. Docs-only / metadata-only — no code changes. Opened as a **Draft** on purpose (see the gate below); it does **not** tag or publish anything.

- **`CHANGELOG.md`** (new) — Keep-a-Changelog entry for the alpha-2 arc (#48–#63), grouped Breaking / Security / Added / Changed / Fixed / Removed, plus an alpha-1 backstop entry. The three breaking changes (KD-3a default credentials, KD-5a `replicas>1`, KD-12 `ControlPlaneEndpoint`) are flagged explicitly.
- **`docs/release-notes/v0.1.0-alpha.2.md`** (new) — narrative release notes modeled on the alpha-1 notes. Both alpha-1 security notices (default creds, `InsecureIgnoreHostKey`) are marked **RESOLVED**.
- **`docs/UPGRADING.md`** — moves the KD-12 section out from under the erroneous `alpha-2 → alpha-3` heading into `v0.1.0-alpha.1 → v0.1.0-alpha.2`. **KD-12 ships in alpha-2; there is no alpha-3.** Also normalized internal `PR-N` shorthand to GitHub PR numbers and `Spec.SSHFallback` → `spec.sshFallback`.
- **`docs/INSTALL.md`, `QUICKSTART_{CAPD,CAPV,CAPK}.md`** — bump released-artifact install/delete URLs and the release-notes link `v0.1.0-alpha.1` → `v0.1.0-alpha.2`.
- **`config/clusterctl/metadata.yaml`** — fix the bogus `2024-11-21` date, record actual alpha-1 (2026-05-18) + staged alpha-2 (TBD), and **drop the empty `sha256` keys** (an empty checksum defeats clusterctl's integrity check; CI populates at tag time per the release-and-supply-chain policy).

## ⛔ Hard gate — do NOT flip to Ready or tag until this clears

This release must **not** be tagged or this PR flipped to Ready until a Kairos (Hadron) image with **`open-vm-tools` present and `vmtoolsd` enabled** is published and consumable — CAPV depends on VMware Tools to report guest IPs. Tracking: kairos-io/kairos#4092. CAPK and CAPD are unaffected by the gate.

## Pre-Ready checklist

- [x] tech-writer review pass (accuracy, anchors, house style)
- [ ] release-and-supply-chain pass on `config/clusterctl/metadata.yaml` (contract value vs vendored CAPI, artifact-name alignment, CI `sha256` population)
- [ ] Hadron `open-vm-tools` image published & validated (the hard gate)
- [ ] Fill in the alpha-2 `releaseDate` in `metadata.yaml` and the CHANGELOG date at tag time

## Test plan

- [ ] Markdown anchors resolve on GitHub (CHANGELOG → UPGRADING, UPGRADING/release-notes → CAPV quickstart SSHFallback section)
- [ ] No `alpha-3` references remain anywhere (verified locally)
- [ ] Install URLs resolve once the `v0.1.0-alpha.2` tag/release exists (will 404 until tagged — expected for a draft)