### PR TITLE
test(envtest): injectable SSH-fallback cadence; enable envtest CI (KD-19)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,9 +130,6 @@ jobs:
 
   test-envtest:
     runs-on: ubuntu-latest
-    # Skip envtest tests for now - they require kubebuilder tools
-    # Uncomment when ready to run integration tests in CI
-    if: false
     strategy:
       fail-fast: false
       matrix:

--- a/internal/controllers/controlplane/ssh_fallback_controller.go
+++ b/internal/controllers/controlplane/ssh_fallback_controller.go
@@ -92,6 +92,26 @@ type SSHFallbackReconciler struct {
 	// reconciler enqueues jobs via Worker.Enqueue and uses
 	// Worker.IsInFlight as the dedup gate.
 	Worker *SSHFallbackWorker
+
+	// EvalRequeue overrides the time-based re-evaluation cadence used
+	// when the eligibility gate has not yet fired. Zero means use the
+	// production default (sshFallbackEvalRequeue, 1 minute). Tests set a
+	// short cadence so the gate is re-checked promptly instead of racing
+	// the 1-minute backstop; production leaves it unset. Read via
+	// evalRequeue(), never directly.
+	EvalRequeue time.Duration
+}
+
+// evalRequeue returns the cadence for the time-based eligibility
+// backstop: an explicit EvalRequeue override when set (envtest keeps the
+// gate responsive), otherwise the production sshFallbackEvalRequeue
+// default. This is the only backstop cadence source the reconciler
+// consults; watch events remain the primary wake path either way.
+func (r *SSHFallbackReconciler) evalRequeue() time.Duration {
+	if r.EvalRequeue > 0 {
+		return r.EvalRequeue
+	}
+	return sshFallbackEvalRequeue
 }
 
 //+kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=kairoscontrolplanes,verbs=get;list;watch
@@ -140,7 +160,7 @@ func (r *SSHFallbackReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 	if r.Worker.IsInFlight(req.NamespacedName) {
 		// Re-check on the next cadence; do NOT block.
-		return ctrl.Result{RequeueAfter: sshFallbackEvalRequeue}, nil
+		return ctrl.Result{RequeueAfter: r.evalRequeue()}, nil
 	}
 
 	// Initialize the patch helper BEFORE any returns so condition
@@ -169,7 +189,7 @@ func (r *SSHFallbackReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	cluster, err := util.GetClusterFromMetadata(ctx, r.Client, kcp.ObjectMeta)
 	if err != nil {
 		log.Info("could not resolve owning Cluster; will retry", "error", err.Error())
-		return ctrl.Result{RequeueAfter: sshFallbackEvalRequeue}, nil
+		return ctrl.Result{RequeueAfter: r.evalRequeue()}, nil
 	}
 
 	// Resolve the host IP from the first control-plane Machine.
@@ -178,7 +198,7 @@ func (r *SSHFallbackReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		log.Info("could not resolve control-plane host; will retry", "error", err.Error())
 		// Soft retry: no condition change, no job enqueue. The next
 		// reconcile (woken by Machine status update) will retry.
-		return ctrl.Result{RequeueAfter: sshFallbackEvalRequeue}, nil
+		return ctrl.Result{RequeueAfter: r.evalRequeue()}, nil
 	}
 
 	// Mark the condition Dialing and enqueue.
@@ -203,11 +223,11 @@ func (r *SSHFallbackReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		// Note: we deliberately do NOT downgrade the condition back
 		// from Dialing here — the in-flight job (if any) will produce
 		// its own outcome shortly.
-		return ctrl.Result{RequeueAfter: sshFallbackEvalRequeue}, nil
+		return ctrl.Result{RequeueAfter: r.evalRequeue()}, nil
 	}
 
 	log.Info("SSH fallback job enqueued", "host", host)
-	return ctrl.Result{RequeueAfter: sshFallbackEvalRequeue}, nil
+	return ctrl.Result{RequeueAfter: r.evalRequeue()}, nil
 }
 
 // evaluateEligibility returns (true, 0) when the KCP is eligible for an
@@ -228,7 +248,7 @@ func (r *SSHFallbackReconciler) evaluateEligibility(ctx context.Context, log log
 	if cond == nil || cond.Status != corev1.ConditionFalse {
 		// Condition is either unset (main reconciler hasn't run) or
 		// True (kubeconfig already ready). Nothing for us to do.
-		return false, sshFallbackEvalRequeue
+		return false, r.evalRequeue()
 	}
 	switch cond.Reason {
 	case controlplanev1beta2.WaitingForNodePushReason,
@@ -238,17 +258,17 @@ func (r *SSHFallbackReconciler) evaluateEligibility(ctx context.Context, log log
 	case controlplanev1beta2.SSHFallbackDialingReason:
 		// A job is in flight (or just enqueued); the worker's result
 		// envelope will wake us. Don't re-enqueue.
-		return false, sshFallbackEvalRequeue
+		return false, r.evalRequeue()
 	default:
 		// Some other Reason (operator-set?) — be conservative and
 		// don't fire.
-		return false, sshFallbackEvalRequeue
+		return false, r.evalRequeue()
 	}
 
 	if kcp.Status.LastNodePushObserved == nil {
 		// Main reconciler hasn't anchored the timestamp yet; not our
 		// turn.
-		return false, sshFallbackEvalRequeue
+		return false, r.evalRequeue()
 	}
 
 	activateAfter := 15 * time.Minute
@@ -261,8 +281,8 @@ func (r *SSHFallbackReconciler) evaluateEligibility(ctx context.Context, log log
 		// activation). Halfway is a heuristic that keeps the
 		// requeue cadence loose far from the gate and tight near it.
 		next := (activateAfter - elapsed) / 2
-		if next < sshFallbackEvalRequeue {
-			next = sshFallbackEvalRequeue
+		if next < r.evalRequeue() {
+			next = r.evalRequeue()
 		}
 		log.V(2).Info("SSH fallback gate not yet open",
 			"elapsed", elapsed.Round(time.Second).String(),

--- a/test/envtest/controlplane_integration_test.go
+++ b/test/envtest/controlplane_integration_test.go
@@ -267,6 +267,13 @@ func startKCPEnvtest(t *testing.T) (context.Context, client.Client, *rest.Config
 	)
 	sshReconciler := &controlplane.SSHFallbackReconciler{
 		Client: mgr.GetClient(), Scheme: mgr.GetScheme(), Worker: sshWorker,
+		// Collapse the 1-minute production re-evaluation backstop to a
+		// short cadence so the eligibility gate is re-checked promptly
+		// under envtest. Without this, TestSSHFallback_* races the
+		// 1-minute requeue: a watch event that arrives before the gate
+		// is open leaves the next re-check up to a full minute away,
+		// which exceeds the tests' ~60s Eventually windows and flakes.
+		EvalRequeue: 2 * time.Second,
 	}
 	g.Expect(sshReconciler.SetupWithManager(mgr)).To(Succeed())
 	g.Expect(mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {

--- a/test/envtest/controlplane_sshfallback_test.go
+++ b/test/envtest/controlplane_sshfallback_test.go
@@ -245,6 +245,13 @@ func TestSSHFallback_MisconfiguredSurfacesCondition(t *testing.T) {
 
 	// Eventually the worker fires, fails fast on the missing Secrets, and
 	// the result drain sets the Reason to SSHFallbackMisconfigured.
+	//
+	// Determinism: the sibling reconciler's time-based backstop is
+	// collapsed to EvalRequeue=2s in startKCPEnvtest, so once the gate is
+	// open the eligibility re-check fires within a couple of seconds
+	// rather than racing the 1-minute production cadence. The 90s window
+	// (well above that 2s cadence) is generous headroom so envtest
+	// start-up cost on a slow/contended CI runner cannot eat into it.
 	g.Eventually(func() string {
 		got := &controlplanev1beta2.KairosControlPlane{}
 		if err := c.Get(ctx, types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}, got); err != nil {
@@ -255,7 +262,7 @@ func TestSSHFallback_MisconfiguredSurfacesCondition(t *testing.T) {
 			return ""
 		}
 		return cond.Reason
-	}, 60*time.Second, 2*time.Second).Should(Equal(controlplanev1beta2.SSHFallbackMisconfiguredReason),
+	}, 90*time.Second, 2*time.Second).Should(Equal(controlplanev1beta2.SSHFallbackMisconfiguredReason),
 		"missing SSHFallback Secrets MUST surface SSHFallbackMisconfigured on KubeconfigReadyCondition")
 }
 


### PR DESCRIPTION
## What & why (KD-19)

Enables the dormant `test-envtest` CI job by dropping its `if: false` gate, so envtest integration tests run on every PR/push.

Enabling it was blocked by a **pre-existing timing flake** in `TestSSHFallback_MisconfiguredSurfacesCondition` (unrelated to the HA work — it lives in an untouched file and only surfaced once the suite actually ran in CI):

- The test's ~60s `Eventually(...)` waits for `KubeconfigReadyCondition.Reason` to flip to `SSHFallbackMisconfigured`.
- The sibling `SSHFallbackReconciler` only re-evaluates eligibility every `sshFallbackEvalRequeue = 1 * time.Minute`. A watch event arriving *before* the eligibility gate opens left the next re-check up to a full minute away — so the 60s wait raced the 1-minute cadence and intermittently observed `WaitingForNodePush` instead. It passed on isolated retry, i.e. flaky, not broken.

## Fix — make the backstop cadence injectable (root cause)

- Add `SSHFallbackReconciler.EvalRequeue` (read via a new `evalRequeue()` accessor). **Zero keeps the 1-minute production default**, so `main.go` behavior is unchanged — the value source just moves from a bare `const` to the accessor.
- `startKCPEnvtest` sets `EvalRequeue = 2s` so the eligibility gate is re-checked promptly under envtest instead of racing the production cadence.
- Widen the test's `Eventually` window to 90s as extra headroom against envtest start-up cost on slow/contended CI runners.

## Verification

- `make test-envtest` — full suite green (the previously-flaky test resolves in ~30s against the 90s window).
- `TestSSHFallback_MisconfiguredSurfacesCondition` — **8/8 isolated runs passed** (12–37s each, all well under the window).
- `go build ./...`, `go vet ./...`, and `go test ./... -short` all pass.
- Security review pass on the controller change: no findings (the `EvalRequeue` knob is set only in code — `main.go` leaves it at the default, envtest sets 2s — and is not wired to any user/CRD-controllable input; no new attack surface).

Production reconcile behavior is unchanged; the only runtime difference is under envtest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)