### PR TITLE
feat(ha): kube-vip DaemonSet + RBAC and Cluster-owned kubeconfig-writer for multi-node (ADR 0005 §D)

### DIFF
--- a/internal/bootstrap/funcs.go
+++ b/internal/bootstrap/funcs.go
@@ -57,10 +57,18 @@ func newFuncMap() template.FuncMap {
 // versions). Bump deliberately in a reviewed change.
 const kubeVIPImage = "ghcr.io/kube-vip/kube-vip:v0.8.7"
 
-// kubeVIPManifest renders the kube-vip static-pod manifest for the supplied
-// VIP config as a marshaled YAML document.
+// kubeVIPManifest renders the kube-vip manifest set for the supplied VIP config
+// as a multi-document marshaled YAML string.
 //
-// SECURITY (ADR 0005 §C, VIP-INV-2): the manifest is built as a typed Go value
+// TOPOLOGY (ADR 0005 § D.1): the output is FOUR `---`-separated documents — a
+// ServiceAccount, a ClusterRole, a ClusterRoleBinding, and a DaemonSet. kube-vip
+// runs as a DaemonSet (one instance per control-plane Node), not a single bare
+// Pod: the instances leader-elect on the kube-system/plndr-cp-lock Lease (the
+// reason the RBAC exists) and the leader ARPs the floating control-plane VIP, so
+// VIP ownership fails over when the current leader's Node dies. A single Pod
+// would be a SPOF that never reschedules — HA theatre (Phase-4 lab finding).
+//
+// SECURITY (ADR 0005 §C, VIP-INV-2): every document is built as a typed Go value
 // tree and serialized with gopkg.in/yaml.v3 — there is NO string concatenation
 // or interpolation of the operator-controlled Address/Interface/Mode into YAML.
 // yaml.v3 emits each value as a properly-quoted scalar, so a value containing
@@ -69,10 +77,11 @@ const kubeVIPImage = "ghcr.io/kube-vip/kube-vip:v0.8.7"
 // re-validates Address and Interface at render time (VIP-INV-3), so a
 // semantically-invalid value never reaches this function in the first place.
 //
-// The returned document is the full Pod object (no leading/trailing newline)
-// so callers embed it with `| nindent N` into the write_files content block,
-// matching how Manifest.Content is handled elsewhere. v is required non-nil;
-// templates gate the call on .RenderKubeVIP so it is never invoked with nil.
+// The returned string has no leading/trailing newline so callers embed it with
+// `| indent N` into the write_files content block. Multi-document YAML under a
+// single `content: |` block scalar is applied doc-by-doc by both the k0s stack
+// applier and the k3s deploy controller. v is required non-nil; templates gate
+// the call on .RenderKubeVIP so it is never invoked with nil.
 func kubeVIPManifest(v *VIPConfig) (string, error) {
 	if v == nil {
 		// Defensive: templates gate on .RenderKubeVIP, but never panic on a
@@ -83,18 +92,123 @@ func kubeVIPManifest(v *VIPConfig) (string, error) {
 	if mode == "" {
 		mode = "ARP" // empty Mode defaults to ARP (matches the CRD default).
 	}
-	// kube-vip control-plane env. The arp-vs-bgp toggle is a pair of string
-	// booleans; everything else is passed verbatim as scalars marshaled by
-	// yaml.v3. We deliberately keep this to the documented control-plane VIP
-	// envelope (ADR 0005 §C: "not operator-injectable beyond the bounded VIP
-	// block") — no operator field becomes an arbitrary kube-vip flag.
+	container, volume := kubeVIPContainer(v, mode)
+
+	const (
+		saName  = "kube-vip"
+		crName  = "system:kube-vip-role"
+		crbName = "system:kube-vip-binding"
+		ns      = "kube-system"
+	)
+	appLabels := map[string]string{"app.kubernetes.io/name": "kube-vip"}
+
+	sa := kvServiceAccount{
+		APIVersion: "v1",
+		Kind:       "ServiceAccount",
+		Metadata:   kvMeta{Name: saName, Namespace: ns},
+	}
+	// ClusterRole. The `leases` grant is load-bearing: kube-vip's leader
+	// election acquires the kube-system/plndr-cp-lock Lease, and without it the
+	// VIP never binds — the exact failure root-caused live in the Phase-4 lab
+	// (the rendered Pod ran as the `default` SA, which cannot get leases). The
+	// services/services-status/nodes/endpoints grants mirror kube-vip's own
+	// published ClusterRole and are the validated-working set. With
+	// svc_enable=false a least-privilege trim to leases+nodes is plausible but
+	// is deferred to a security-architect-adjudicated follow-up rather than
+	// gambled here against a costly lab regression (ADR 0005 § D.1).
+	cr := kvClusterRole{
+		APIVersion: "rbac.authorization.k8s.io/v1",
+		Kind:       "ClusterRole",
+		Metadata:   kvMeta{Name: crName},
+		Rules: []kvPolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"services", "services/status", "nodes", "endpoints"},
+				Verbs:     []string{"get", "list", "watch", "update"},
+			},
+			{
+				APIGroups: []string{"coordination.k8s.io"},
+				Resources: []string{"leases"},
+				Verbs:     []string{"get", "list", "watch", "update", "create"},
+			},
+		},
+	}
+	crb := kvClusterRoleBinding{
+		APIVersion: "rbac.authorization.k8s.io/v1",
+		Kind:       "ClusterRoleBinding",
+		Metadata:   kvMeta{Name: crbName},
+		RoleRef: kvRoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     crName,
+		},
+		Subjects: []kvSubject{{
+			Kind:      "ServiceAccount",
+			Name:      saName,
+			Namespace: ns,
+		}},
+	}
+	// DaemonSet: one kube-vip per control-plane Node. nodeSelector
+	// node-role.kubernetes.io/control-plane is the cross-distro union (k3s
+	// servers carry it; k0s controllers carry it once they run with
+	// --enable-worker), and the tolerations clear the control-plane NoSchedule
+	// taint so it lands on the CP Nodes while general workloads stay off.
+	ds := kvDaemonSet{
+		APIVersion: "apps/v1",
+		Kind:       "DaemonSet",
+		Metadata:   kvMeta{Name: saName, Namespace: ns, Labels: appLabels},
+		Spec: kvDaemonSetSpec{
+			Selector: kvLabelSelector{MatchLabels: appLabels},
+			Template: kvPodTemplate{
+				Metadata: kvPodTemplateMeta{Labels: appLabels},
+				Spec: kvPodSpec{
+					ServiceAccountName: saName,
+					HostNetwork:        true,
+					NodeSelector:       map[string]string{"node-role.kubernetes.io/control-plane": "true"},
+					Tolerations: []kvToleration{
+						{Key: "node-role.kubernetes.io/control-plane", Operator: "Exists", Effect: "NoSchedule"},
+						{Key: "node-role.kubernetes.io/master", Operator: "Exists", Effect: "NoSchedule"},
+					},
+					Containers: []kvContainer{container},
+					Volumes:    []kvVolume{volume},
+				},
+			},
+			UpdateStrategy: kvDaemonSetUpdateStrategy{Type: "RollingUpdate"},
+		},
+	}
+
+	var sb strings.Builder
+	for i, obj := range []any{sa, cr, crb, ds} {
+		if i > 0 {
+			sb.WriteString("---\n")
+		}
+		b, err := yaml.Marshal(obj)
+		if err != nil {
+			return "", err
+		}
+		sb.Write(b)
+	}
+	return strings.TrimRight(sb.String(), "\n"), nil
+}
+
+// kubeVIPContainer builds the kube-vip control-plane container and its
+// admin.conf host-path volume from the VIP config. Extracted so the container
+// envelope (env, capabilities, image, mount) has a single definition; it is
+// byte-identical to the pre-DaemonSet Pod container (ADR 0005 § D.1 keeps the
+// container spec unchanged — only the enclosing workload kind changed).
+//
+// The arp-vs-bgp toggle is a pair of string booleans; everything else is passed
+// verbatim as scalars marshaled by yaml.v3. We deliberately keep this to the
+// documented control-plane VIP envelope (ADR 0005 §C: "not operator-injectable
+// beyond the bounded VIP block") — no operator field becomes an arbitrary
+// kube-vip flag.
+func kubeVIPContainer(v *VIPConfig, mode string) (kvContainer, kvVolume) {
 	arpEnabled := "true"
 	bgpEnabled := "false"
 	if mode == "BGP" {
 		arpEnabled = "false"
 		bgpEnabled = "true"
 	}
-
 	env := []kvEnvVar{
 		{Name: "vip_arp", Value: arpEnabled},
 		{Name: "vip_interface", Value: v.Interface},
@@ -108,67 +222,124 @@ func kubeVIPManifest(v *VIPConfig) (string, error) {
 		{Name: "vip_retryperiod", Value: "1"},
 		{Name: "bgp_enable", Value: bgpEnabled},
 	}
-
-	pod := kvPod{
-		APIVersion: "v1",
-		Kind:       "Pod",
-		Metadata: kvMeta{
-			Name:      "kube-vip",
-			Namespace: "kube-system",
+	container := kvContainer{
+		Name:            "kube-vip",
+		Image:           kubeVIPImage,
+		ImagePullPolicy: "IfNotPresent",
+		Args:            []string{"manager"},
+		Env:             env,
+		SecurityContext: kvSecurityContext{
+			Capabilities: kvCapabilities{
+				Add: []string{"NET_ADMIN", "NET_RAW"},
+			},
 		},
-		Spec: kvPodSpec{
-			HostNetwork: true,
-			Containers: []kvContainer{{
-				Name:            "kube-vip",
-				Image:           kubeVIPImage,
-				ImagePullPolicy: "IfNotPresent",
-				Args:            []string{"manager"},
-				Env:             env,
-				SecurityContext: kvSecurityContext{
-					Capabilities: kvCapabilities{
-						Add: []string{"NET_ADMIN", "NET_RAW"},
-					},
-				},
-				VolumeMounts: []kvVolumeMount{{
-					MountPath: "/etc/kubernetes/admin.conf",
-					Name:      "kubeconfig",
-				}},
-			}},
-			Volumes: []kvVolume{{
-				Name: "kubeconfig",
-				HostPath: kvHostPath{
-					Path: "/etc/kubernetes/admin.conf",
-				},
-			}},
+		VolumeMounts: []kvVolumeMount{{
+			MountPath: "/etc/kubernetes/admin.conf",
+			Name:      "kubeconfig",
+		}},
+	}
+	volume := kvVolume{
+		Name: "kubeconfig",
+		HostPath: kvHostPath{
+			Path: "/etc/kubernetes/admin.conf",
 		},
 	}
-	b, err := yaml.Marshal(pod)
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimRight(string(b), "\n"), nil
+	return container, volume
 }
 
-// kube-vip static-pod manifest types. These are a minimal, purpose-built
-// schema (not the full k8s core/v1 types) so the rendered manifest is a fixed,
-// auditable shape with only the bounded VIP fields flowing through it. The yaml
-// tags reproduce the k8s field names with their standard ordering.
-type kvPod struct {
-	APIVersion string    `yaml:"apiVersion"`
-	Kind       string    `yaml:"kind"`
-	Metadata   kvMeta    `yaml:"metadata"`
-	Spec       kvPodSpec `yaml:"spec"`
+// kube-vip manifest types. These are a minimal, purpose-built schema (not the
+// full k8s core/v1 / apps/v1 / rbac/v1 types) so the rendered manifest set is a
+// fixed, auditable shape with only the bounded VIP fields flowing through it.
+// The yaml tags reproduce the k8s field names with their standard ordering.
+
+type kvServiceAccount struct {
+	APIVersion string `yaml:"apiVersion"`
+	Kind       string `yaml:"kind"`
+	Metadata   kvMeta `yaml:"metadata"`
 }
 
-type kvMeta struct {
+type kvClusterRole struct {
+	APIVersion string         `yaml:"apiVersion"`
+	Kind       string         `yaml:"kind"`
+	Metadata   kvMeta         `yaml:"metadata"`
+	Rules      []kvPolicyRule `yaml:"rules"`
+}
+
+type kvPolicyRule struct {
+	APIGroups []string `yaml:"apiGroups"`
+	Resources []string `yaml:"resources"`
+	Verbs     []string `yaml:"verbs"`
+}
+
+type kvClusterRoleBinding struct {
+	APIVersion string      `yaml:"apiVersion"`
+	Kind       string      `yaml:"kind"`
+	Metadata   kvMeta      `yaml:"metadata"`
+	RoleRef    kvRoleRef   `yaml:"roleRef"`
+	Subjects   []kvSubject `yaml:"subjects"`
+}
+
+type kvRoleRef struct {
+	APIGroup string `yaml:"apiGroup"`
+	Kind     string `yaml:"kind"`
+	Name     string `yaml:"name"`
+}
+
+type kvSubject struct {
+	Kind      string `yaml:"kind"`
 	Name      string `yaml:"name"`
 	Namespace string `yaml:"namespace"`
 }
 
+type kvDaemonSet struct {
+	APIVersion string          `yaml:"apiVersion"`
+	Kind       string          `yaml:"kind"`
+	Metadata   kvMeta          `yaml:"metadata"`
+	Spec       kvDaemonSetSpec `yaml:"spec"`
+}
+
+type kvDaemonSetSpec struct {
+	Selector       kvLabelSelector           `yaml:"selector"`
+	Template       kvPodTemplate             `yaml:"template"`
+	UpdateStrategy kvDaemonSetUpdateStrategy `yaml:"updateStrategy"`
+}
+
+type kvDaemonSetUpdateStrategy struct {
+	Type string `yaml:"type"`
+}
+
+type kvLabelSelector struct {
+	MatchLabels map[string]string `yaml:"matchLabels"`
+}
+
+type kvPodTemplate struct {
+	Metadata kvPodTemplateMeta `yaml:"metadata"`
+	Spec     kvPodSpec         `yaml:"spec"`
+}
+
+type kvPodTemplateMeta struct {
+	Labels map[string]string `yaml:"labels"`
+}
+
+type kvMeta struct {
+	Name      string            `yaml:"name"`
+	Namespace string            `yaml:"namespace,omitempty"`
+	Labels    map[string]string `yaml:"labels,omitempty"`
+}
+
 type kvPodSpec struct {
-	Containers  []kvContainer `yaml:"containers"`
-	HostNetwork bool          `yaml:"hostNetwork"`
-	Volumes     []kvVolume    `yaml:"volumes"`
+	ServiceAccountName string            `yaml:"serviceAccountName,omitempty"`
+	HostNetwork        bool              `yaml:"hostNetwork"`
+	NodeSelector       map[string]string `yaml:"nodeSelector,omitempty"`
+	Tolerations        []kvToleration    `yaml:"tolerations,omitempty"`
+	Containers         []kvContainer     `yaml:"containers"`
+	Volumes            []kvVolume        `yaml:"volumes"`
+}
+
+type kvToleration struct {
+	Key      string `yaml:"key"`
+	Operator string `yaml:"operator"`
+	Effect   string `yaml:"effect"`
 }
 
 type kvContainer struct {

--- a/internal/bootstrap/ha_test.go
+++ b/internal/bootstrap/ha_test.go
@@ -17,6 +17,7 @@ permissions and limitations under the License.
 package bootstrap
 
 import (
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -312,13 +313,71 @@ func TestHA_KubeVIP_OnlyCAPV(t *testing.T) {
 				t.Errorf("kube-vip manifest present=%v, want %v", has, c.expect)
 			}
 			if c.expect {
-				// VIP-INV-2: the manifest must itself be valid YAML and a kube-vip Pod.
-				var pod map[string]any
-				if err := yaml.Unmarshal([]byte(manifest), &pod); err != nil {
-					t.Fatalf("kube-vip manifest is not valid YAML: %v\n%s", err, manifest)
+				// VIP-INV-2 + ADR 0005 § D.1: the manifest must be a valid
+				// multi-document set — ServiceAccount + ClusterRole +
+				// ClusterRoleBinding + DaemonSet (not a single bare Pod).
+				docs := decodeKubeVIPDocs(t, manifest)
+				for _, wantKind := range []string{"ServiceAccount", "ClusterRole", "ClusterRoleBinding", "DaemonSet"} {
+					if _, ok := docs[wantKind]; !ok {
+						t.Errorf("kube-vip manifest missing %s document", wantKind)
+					}
 				}
-				if pod["kind"] != "Pod" {
-					t.Errorf("kube-vip manifest kind=%v, want Pod", pod["kind"])
+				if _, ok := docs["Pod"]; ok {
+					t.Errorf("kube-vip manifest still renders a bare Pod; expected a DaemonSet (ADR 0005 § D.1)")
+				}
+				// The ClusterRole must grant the load-bearing leader-election
+				// lease verbs — the exact grant whose absence stalled the VIP in
+				// the Phase-4 lab.
+				var cr struct {
+					Rules []struct {
+						APIGroups []string `yaml:"apiGroups"`
+						Resources []string `yaml:"resources"`
+						Verbs     []string `yaml:"verbs"`
+					} `yaml:"rules"`
+				}
+				remarshalInto(t, docs["ClusterRole"], &cr)
+				leaseRule := false
+				for _, r := range cr.Rules {
+					if strSliceHas(r.APIGroups, "coordination.k8s.io") && strSliceHas(r.Resources, "leases") &&
+						strSliceHas(r.Verbs, "get") && strSliceHas(r.Verbs, "create") {
+						leaseRule = true
+					}
+				}
+				if !leaseRule {
+					t.Error("kube-vip ClusterRole missing the coordination.k8s.io/leases get+create rule (leader election)")
+				}
+				// The DaemonSet must run as the kube-vip SA, select control-plane
+				// Nodes, and tolerate the control-plane NoSchedule taint.
+				var ds struct {
+					Spec struct {
+						Template struct {
+							Spec struct {
+								ServiceAccountName string            `yaml:"serviceAccountName"`
+								NodeSelector       map[string]string `yaml:"nodeSelector"`
+								Tolerations        []struct {
+									Key    string `yaml:"key"`
+									Effect string `yaml:"effect"`
+								} `yaml:"tolerations"`
+							} `yaml:"spec"`
+						} `yaml:"template"`
+					} `yaml:"spec"`
+				}
+				remarshalInto(t, docs["DaemonSet"], &ds)
+				ps := ds.Spec.Template.Spec
+				if ps.ServiceAccountName != "kube-vip" {
+					t.Errorf("DaemonSet serviceAccountName=%q, want kube-vip", ps.ServiceAccountName)
+				}
+				if ps.NodeSelector["node-role.kubernetes.io/control-plane"] != "true" {
+					t.Errorf("DaemonSet nodeSelector missing node-role.kubernetes.io/control-plane=true; got %v", ps.NodeSelector)
+				}
+				cpTolerated := false
+				for _, tol := range ps.Tolerations {
+					if tol.Key == "node-role.kubernetes.io/control-plane" && tol.Effect == "NoSchedule" {
+						cpTolerated = true
+					}
+				}
+				if !cpTolerated {
+					t.Error("DaemonSet missing toleration for node-role.kubernetes.io/control-plane:NoSchedule")
 				}
 			}
 		})
@@ -356,31 +415,97 @@ func TestHA_KubeVIP_Mode(t *testing.T) {
 	}
 }
 
-// kubeVIPEnv parses the kube-vip Pod manifest and returns its container env as
-// a name->value map.
+// kubeVIPEnv parses the kube-vip DaemonSet document out of the multi-document
+// manifest (ADR 0005 § D.1) and returns its container env as a name->value map.
 func kubeVIPEnv(t *testing.T, manifest string) map[string]string {
 	t.Helper()
-	var pod struct {
-		Spec struct {
-			Containers []struct {
-				Env []struct {
-					Name  string `yaml:"name"`
-					Value string `yaml:"value"`
-				} `yaml:"env"`
-			} `yaml:"containers"`
-		} `yaml:"spec"`
+	dec := yaml.NewDecoder(strings.NewReader(manifest))
+	for {
+		var doc struct {
+			Kind string `yaml:"kind"`
+			Spec struct {
+				Template struct {
+					Spec struct {
+						Containers []struct {
+							Env []struct {
+								Name  string `yaml:"name"`
+								Value string `yaml:"value"`
+							} `yaml:"env"`
+						} `yaml:"containers"`
+					} `yaml:"spec"`
+				} `yaml:"template"`
+			} `yaml:"spec"`
+		}
+		err := dec.Decode(&doc)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("parse kube-vip manifest document: %v", err)
+		}
+		if doc.Kind != "DaemonSet" {
+			continue
+		}
+		if len(doc.Spec.Template.Spec.Containers) == 0 {
+			t.Fatalf("kube-vip DaemonSet has no containers")
+		}
+		m := map[string]string{}
+		for _, e := range doc.Spec.Template.Spec.Containers[0].Env {
+			m[e.Name] = e.Value
+		}
+		return m
 	}
-	if err := yaml.Unmarshal([]byte(manifest), &pod); err != nil {
-		t.Fatalf("parse kube-vip manifest: %v", err)
+	t.Fatalf("kube-vip manifest has no DaemonSet document:\n%s", manifest)
+	return nil
+}
+
+// decodeKubeVIPDocs decodes every YAML document in the multi-document kube-vip
+// manifest into a generic map, keyed by kind (ADR 0005 § D.1). Every document
+// must be valid YAML — this is the VIP-INV-2 "the whole set parses" guard.
+func decodeKubeVIPDocs(t *testing.T, manifest string) map[string]map[string]any {
+	t.Helper()
+	byKind := map[string]map[string]any{}
+	dec := yaml.NewDecoder(strings.NewReader(manifest))
+	for {
+		var m map[string]any
+		err := dec.Decode(&m)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("kube-vip manifest document is not valid YAML: %v\n%s", err, manifest)
+		}
+		if m == nil {
+			continue
+		}
+		kind, _ := m["kind"].(string)
+		byKind[kind] = m
 	}
-	if len(pod.Spec.Containers) == 0 {
-		t.Fatalf("kube-vip manifest has no containers")
+	return byKind
+}
+
+// remarshalInto re-serializes a generic decoded document and unmarshals it into
+// the typed out, so a test can make typed assertions on one document of a
+// multi-document manifest.
+func remarshalInto(t *testing.T, m map[string]any, out any) {
+	t.Helper()
+	b, err := yaml.Marshal(m)
+	if err != nil {
+		t.Fatalf("re-marshal document: %v", err)
 	}
-	m := map[string]string{}
-	for _, e := range pod.Spec.Containers[0].Env {
-		m[e.Name] = e.Value
+	if err := yaml.Unmarshal(b, out); err != nil {
+		t.Fatalf("unmarshal document into %T: %v", out, err)
 	}
-	return m
+}
+
+// strSliceHas reports whether s contains v.
+func strSliceHas(s []string, v string) bool {
+	for _, e := range s {
+		if e == v {
+			return true
+		}
+	}
+	return false
 }
 
 // vipInjectionPayloads are shell/YAML-injection strings an operator could try
@@ -500,9 +625,12 @@ func TestVIP_ManifestMarshalEnvelopeHolds(t *testing.T) {
 			if err != nil {
 				t.Fatalf("kubeVIPManifest: %v", err)
 			}
-			var pod map[string]any
-			if err := yaml.Unmarshal([]byte(out), &pod); err != nil {
-				t.Fatalf("kube-vip manifest not valid YAML with hostile value %q: %v\n%s", h, err, out)
+			// Every document in the multi-document set must be valid YAML — a
+			// hostile value must not break out of its scalar and split/inject a
+			// document. decodeKubeVIPDocs fails if any doc fails to parse.
+			docs := decodeKubeVIPDocs(t, out)
+			if _, ok := docs["DaemonSet"]; !ok {
+				t.Fatalf("kube-vip manifest missing DaemonSet document with hostile value %q:\n%s", h, out)
 			}
 			env := kubeVIPEnv(t, out)
 			if env["address"] != h {

--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
@@ -83,6 +83,17 @@ k0s:
     # Controller-join: --token-file carries the controller-role join token.
     - --token-file=/etc/k0s/controller-token
   {{- end }}
+  {{- if .RenderKubeVIP }}
+    # ADR 0005 § D.3 (HA): run the k0s controller as a schedulable worker too, so
+    # the kube-vip DaemonSet — which selects control-plane Nodes — has a Node to
+    # land on. A controller-only k0s node registers no kubelet/Node, so the
+    # DaemonSet would stay Pending and the VIP would never float (Phase-4 lab
+    # finding). k0s auto-applies the node-role.kubernetes.io/control-plane:NoSchedule
+    # taint with --enable-worker; the DaemonSet tolerates it and general workloads
+    # stay off. HA + CAPV/CAPM3 only — single-node (RenderKubeVIP=false) and CAPK
+    # (OQ-5) never reach this, so their rendering is byte-for-byte unchanged.
+    - --enable-worker
+  {{- end }}
   {{- if and .ProviderID (not .Metal3) }}
     # KD-3c: tell kubelet the providerID BEFORE the Node is registered so it
     # appears in spec.providerID from first registration. The PR-8 audit
@@ -167,12 +178,16 @@ write_files:
       {{ .JoinToken }}
   {{- end }}
   {{- if .RenderKubeVIP }}
-  # ADR 0005 (HA) kube-vip static-pod manifest (CAPV/CAPM3 only; CAPK uses its
+  # ADR 0005 § D.1 (HA) kube-vip DaemonSet + RBAC (CAPV/CAPM3 only; CAPK uses its
   # built-in LoadBalancer Service per OQ-5 and never reaches this block).
   # k0s applies manifests under /var/lib/k0s/manifests/<dir>/ via its
-  # manifest-deployer (stack applier), so kube-vip comes up to own the floating
-  # control-plane VIP. The manifest is produced by kubeVIPManifest (marshaled
-  # YAML, VIP-INV-2) — no operator string is concatenated into the YAML.
+  # manifest-deployer (stack applier). The manifest is a multi-document set
+  # (ServiceAccount + ClusterRole + ClusterRoleBinding + DaemonSet) produced by
+  # kubeVIPManifest (marshaled YAML, VIP-INV-2) — no operator string is
+  # concatenated into the YAML. The DaemonSet runs one kube-vip per control-plane
+  # Node; the instances leader-elect on the plndr-cp-lock Lease (hence the RBAC)
+  # and the leader ARPs the floating control-plane VIP, so VIP ownership fails
+  # over when the leader's Node dies.
   - path: /var/lib/k0s/manifests/kube-vip/kube-vip.yaml
     permissions: "0644"
     owner: root

--- a/internal/bootstrap/templates/k3s_kairos_cloud_config_capv.yaml.tmpl
+++ b/internal/bootstrap/templates/k3s_kairos_cloud_config_capv.yaml.tmpl
@@ -187,12 +187,17 @@ write_files:
       {{ .JoinToken }}
   {{- end }}
   {{- if .RenderKubeVIP }}
-  # ADR 0005 (HA) kube-vip static-pod manifest (CAPV/CAPM3 only; CAPK uses its
+  # ADR 0005 § D.1 (HA) kube-vip DaemonSet + RBAC (CAPV/CAPM3 only; CAPK uses its
   # built-in LoadBalancer Service per OQ-5 and never reaches this block).
   # k3s auto-applies manifests under /var/lib/rancher/k3s/server/manifests at
-  # server start, so kube-vip comes up to own the floating control-plane VIP.
-  # The manifest is produced by kubeVIPManifest (marshaled YAML, VIP-INV-2) —
-  # no operator string is concatenated into the YAML.
+  # server start. The manifest is a multi-document set (ServiceAccount +
+  # ClusterRole + ClusterRoleBinding + DaemonSet) produced by kubeVIPManifest
+  # (marshaled YAML, VIP-INV-2) — no operator string is concatenated into the
+  # YAML. The DaemonSet runs one kube-vip per control-plane Node (k3s servers are
+  # schedulable and carry node-role.kubernetes.io/control-plane, so no
+  # --enable-worker is needed as on k0s); the instances leader-elect on the
+  # plndr-cp-lock Lease (hence the RBAC) and the leader ARPs the floating
+  # control-plane VIP, so VIP ownership fails over when the leader's Node dies.
   - path: /var/lib/rancher/k3s/server/manifests/kube-vip.yaml
     permissions: "0644"
     owner: root

--- a/internal/bootstrap/testdata/golden/k0s_capv_init.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capv_init.yaml
@@ -19,6 +19,15 @@ k0s:
   enabled: true
   args:
     - --config /etc/k0s/k0s.yaml
+    # ADR 0005 § D.3 (HA): run the k0s controller as a schedulable worker too, so
+    # the kube-vip DaemonSet — which selects control-plane Nodes — has a Node to
+    # land on. A controller-only k0s node registers no kubelet/Node, so the
+    # DaemonSet would stay Pending and the VIP would never float (Phase-4 lab
+    # finding). k0s auto-applies the node-role.kubernetes.io/control-plane:NoSchedule
+    # taint with --enable-worker; the DaemonSet tolerates it and general workloads
+    # stay off. HA + CAPV/CAPM3 only — single-node (RenderKubeVIP=false) and CAPK
+    # (OQ-5) never reach this, so their rendering is byte-for-byte unchanged.
+    - --enable-worker
 
 write_files:
   - path: /system/oem/12_kairos-capi-persistency.yaml
@@ -43,65 +52,138 @@ write_files:
         api:
           sans:
             - 192.168.1.240
-  # ADR 0005 (HA) kube-vip static-pod manifest (CAPV/CAPM3 only; CAPK uses its
+  # ADR 0005 § D.1 (HA) kube-vip DaemonSet + RBAC (CAPV/CAPM3 only; CAPK uses its
   # built-in LoadBalancer Service per OQ-5 and never reaches this block).
   # k0s applies manifests under /var/lib/k0s/manifests/<dir>/ via its
-  # manifest-deployer (stack applier), so kube-vip comes up to own the floating
-  # control-plane VIP. The manifest is produced by kubeVIPManifest (marshaled
-  # YAML, VIP-INV-2) — no operator string is concatenated into the YAML.
+  # manifest-deployer (stack applier). The manifest is a multi-document set
+  # (ServiceAccount + ClusterRole + ClusterRoleBinding + DaemonSet) produced by
+  # kubeVIPManifest (marshaled YAML, VIP-INV-2) — no operator string is
+  # concatenated into the YAML. The DaemonSet runs one kube-vip per control-plane
+  # Node; the instances leader-elect on the plndr-cp-lock Lease (hence the RBAC)
+  # and the leader ARPs the floating control-plane VIP, so VIP ownership fails
+  # over when the leader's Node dies.
   - path: /var/lib/k0s/manifests/kube-vip/kube-vip.yaml
     permissions: "0644"
     owner: root
     group: root
     content: |
       apiVersion: v1
-      kind: Pod
+      kind: ServiceAccount
       metadata:
           name: kube-vip
           namespace: kube-system
+      ---
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+          name: system:kube-vip-role
+      rules:
+          - apiGroups:
+              - ""
+            resources:
+              - services
+              - services/status
+              - nodes
+              - endpoints
+            verbs:
+              - get
+              - list
+              - watch
+              - update
+          - apiGroups:
+              - coordination.k8s.io
+            resources:
+              - leases
+            verbs:
+              - get
+              - list
+              - watch
+              - update
+              - create
+      ---
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+          name: system:kube-vip-binding
+      roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: system:kube-vip-role
+      subjects:
+          - kind: ServiceAccount
+            name: kube-vip
+            namespace: kube-system
+      ---
+      apiVersion: apps/v1
+      kind: DaemonSet
+      metadata:
+          name: kube-vip
+          namespace: kube-system
+          labels:
+              app.kubernetes.io/name: kube-vip
       spec:
-          containers:
-              - name: kube-vip
-                image: ghcr.io/kube-vip/kube-vip:v0.8.7
-                imagePullPolicy: IfNotPresent
-                args:
-                  - manager
-                env:
-                  - name: vip_arp
-                    value: "true"
-                  - name: vip_interface
-                    value: eth0
-                  - name: address
-                    value: 192.168.1.240
-                  - name: port
-                    value: "6443"
-                  - name: cp_enable
-                    value: "true"
-                  - name: svc_enable
-                    value: "false"
-                  - name: vip_leaderelection
-                    value: "true"
-                  - name: vip_leaseduration
-                    value: "5"
-                  - name: vip_renewdeadline
-                    value: "3"
-                  - name: vip_retryperiod
-                    value: "1"
-                  - name: bgp_enable
-                    value: "false"
-                securityContext:
-                  capabilities:
-                      add:
-                          - NET_ADMIN
-                          - NET_RAW
-                volumeMounts:
-                  - mountPath: /etc/kubernetes/admin.conf
-                    name: kubeconfig
-          hostNetwork: true
-          volumes:
-              - name: kubeconfig
-                hostPath:
-                  path: /etc/kubernetes/admin.conf
+          selector:
+              matchLabels:
+                  app.kubernetes.io/name: kube-vip
+          template:
+              metadata:
+                  labels:
+                      app.kubernetes.io/name: kube-vip
+              spec:
+                  serviceAccountName: kube-vip
+                  hostNetwork: true
+                  nodeSelector:
+                      node-role.kubernetes.io/control-plane: "true"
+                  tolerations:
+                      - key: node-role.kubernetes.io/control-plane
+                        operator: Exists
+                        effect: NoSchedule
+                      - key: node-role.kubernetes.io/master
+                        operator: Exists
+                        effect: NoSchedule
+                  containers:
+                      - name: kube-vip
+                        image: ghcr.io/kube-vip/kube-vip:v0.8.7
+                        imagePullPolicy: IfNotPresent
+                        args:
+                          - manager
+                        env:
+                          - name: vip_arp
+                            value: "true"
+                          - name: vip_interface
+                            value: eth0
+                          - name: address
+                            value: 192.168.1.240
+                          - name: port
+                            value: "6443"
+                          - name: cp_enable
+                            value: "true"
+                          - name: svc_enable
+                            value: "false"
+                          - name: vip_leaderelection
+                            value: "true"
+                          - name: vip_leaseduration
+                            value: "5"
+                          - name: vip_renewdeadline
+                            value: "3"
+                          - name: vip_retryperiod
+                            value: "1"
+                          - name: bgp_enable
+                            value: "false"
+                        securityContext:
+                          capabilities:
+                              add:
+                                  - NET_ADMIN
+                                  - NET_RAW
+                        volumeMounts:
+                          - mountPath: /etc/kubernetes/admin.conf
+                            name: kubeconfig
+                  volumes:
+                      - name: kubeconfig
+                        hostPath:
+                          path: /etc/kubernetes/admin.conf
+          updateStrategy:
+              type: RollingUpdate
   - path: /usr/local/etc/hostname
     permissions: "0644"
     owner: root

--- a/internal/bootstrap/testdata/golden/k0s_capv_join.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capv_join.yaml
@@ -22,6 +22,15 @@ k0s:
   args:
     # Controller-join: --token-file carries the controller-role join token.
     - --token-file=/etc/k0s/controller-token
+    # ADR 0005 § D.3 (HA): run the k0s controller as a schedulable worker too, so
+    # the kube-vip DaemonSet — which selects control-plane Nodes — has a Node to
+    # land on. A controller-only k0s node registers no kubelet/Node, so the
+    # DaemonSet would stay Pending and the VIP would never float (Phase-4 lab
+    # finding). k0s auto-applies the node-role.kubernetes.io/control-plane:NoSchedule
+    # taint with --enable-worker; the DaemonSet tolerates it and general workloads
+    # stay off. HA + CAPV/CAPM3 only — single-node (RenderKubeVIP=false) and CAPK
+    # (OQ-5) never reach this, so their rendering is byte-for-byte unchanged.
+    - --enable-worker
 
 write_files:
   - path: /system/oem/12_kairos-capi-persistency.yaml
@@ -46,65 +55,138 @@ write_files:
     group: root
     content: |
       K10aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa::server:bbbbbbbbbbbbbbbbbbbbbbbb
-  # ADR 0005 (HA) kube-vip static-pod manifest (CAPV/CAPM3 only; CAPK uses its
+  # ADR 0005 § D.1 (HA) kube-vip DaemonSet + RBAC (CAPV/CAPM3 only; CAPK uses its
   # built-in LoadBalancer Service per OQ-5 and never reaches this block).
   # k0s applies manifests under /var/lib/k0s/manifests/<dir>/ via its
-  # manifest-deployer (stack applier), so kube-vip comes up to own the floating
-  # control-plane VIP. The manifest is produced by kubeVIPManifest (marshaled
-  # YAML, VIP-INV-2) — no operator string is concatenated into the YAML.
+  # manifest-deployer (stack applier). The manifest is a multi-document set
+  # (ServiceAccount + ClusterRole + ClusterRoleBinding + DaemonSet) produced by
+  # kubeVIPManifest (marshaled YAML, VIP-INV-2) — no operator string is
+  # concatenated into the YAML. The DaemonSet runs one kube-vip per control-plane
+  # Node; the instances leader-elect on the plndr-cp-lock Lease (hence the RBAC)
+  # and the leader ARPs the floating control-plane VIP, so VIP ownership fails
+  # over when the leader's Node dies.
   - path: /var/lib/k0s/manifests/kube-vip/kube-vip.yaml
     permissions: "0644"
     owner: root
     group: root
     content: |
       apiVersion: v1
-      kind: Pod
+      kind: ServiceAccount
       metadata:
           name: kube-vip
           namespace: kube-system
+      ---
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+          name: system:kube-vip-role
+      rules:
+          - apiGroups:
+              - ""
+            resources:
+              - services
+              - services/status
+              - nodes
+              - endpoints
+            verbs:
+              - get
+              - list
+              - watch
+              - update
+          - apiGroups:
+              - coordination.k8s.io
+            resources:
+              - leases
+            verbs:
+              - get
+              - list
+              - watch
+              - update
+              - create
+      ---
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+          name: system:kube-vip-binding
+      roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: system:kube-vip-role
+      subjects:
+          - kind: ServiceAccount
+            name: kube-vip
+            namespace: kube-system
+      ---
+      apiVersion: apps/v1
+      kind: DaemonSet
+      metadata:
+          name: kube-vip
+          namespace: kube-system
+          labels:
+              app.kubernetes.io/name: kube-vip
       spec:
-          containers:
-              - name: kube-vip
-                image: ghcr.io/kube-vip/kube-vip:v0.8.7
-                imagePullPolicy: IfNotPresent
-                args:
-                  - manager
-                env:
-                  - name: vip_arp
-                    value: "true"
-                  - name: vip_interface
-                    value: eth0
-                  - name: address
-                    value: 192.168.1.240
-                  - name: port
-                    value: "6443"
-                  - name: cp_enable
-                    value: "true"
-                  - name: svc_enable
-                    value: "false"
-                  - name: vip_leaderelection
-                    value: "true"
-                  - name: vip_leaseduration
-                    value: "5"
-                  - name: vip_renewdeadline
-                    value: "3"
-                  - name: vip_retryperiod
-                    value: "1"
-                  - name: bgp_enable
-                    value: "false"
-                securityContext:
-                  capabilities:
-                      add:
-                          - NET_ADMIN
-                          - NET_RAW
-                volumeMounts:
-                  - mountPath: /etc/kubernetes/admin.conf
-                    name: kubeconfig
-          hostNetwork: true
-          volumes:
-              - name: kubeconfig
-                hostPath:
-                  path: /etc/kubernetes/admin.conf
+          selector:
+              matchLabels:
+                  app.kubernetes.io/name: kube-vip
+          template:
+              metadata:
+                  labels:
+                      app.kubernetes.io/name: kube-vip
+              spec:
+                  serviceAccountName: kube-vip
+                  hostNetwork: true
+                  nodeSelector:
+                      node-role.kubernetes.io/control-plane: "true"
+                  tolerations:
+                      - key: node-role.kubernetes.io/control-plane
+                        operator: Exists
+                        effect: NoSchedule
+                      - key: node-role.kubernetes.io/master
+                        operator: Exists
+                        effect: NoSchedule
+                  containers:
+                      - name: kube-vip
+                        image: ghcr.io/kube-vip/kube-vip:v0.8.7
+                        imagePullPolicy: IfNotPresent
+                        args:
+                          - manager
+                        env:
+                          - name: vip_arp
+                            value: "true"
+                          - name: vip_interface
+                            value: eth0
+                          - name: address
+                            value: 192.168.1.240
+                          - name: port
+                            value: "6443"
+                          - name: cp_enable
+                            value: "true"
+                          - name: svc_enable
+                            value: "false"
+                          - name: vip_leaderelection
+                            value: "true"
+                          - name: vip_leaseduration
+                            value: "5"
+                          - name: vip_renewdeadline
+                            value: "3"
+                          - name: vip_retryperiod
+                            value: "1"
+                          - name: bgp_enable
+                            value: "false"
+                        securityContext:
+                          capabilities:
+                              add:
+                                  - NET_ADMIN
+                                  - NET_RAW
+                        volumeMounts:
+                          - mountPath: /etc/kubernetes/admin.conf
+                            name: kubeconfig
+                  volumes:
+                      - name: kubeconfig
+                        hostPath:
+                          path: /etc/kubernetes/admin.conf
+          updateStrategy:
+              type: RollingUpdate
   - path: /usr/local/etc/hostname
     permissions: "0644"
     owner: root

--- a/internal/bootstrap/testdata/golden/k3s_capv_init.yaml
+++ b/internal/bootstrap/testdata/golden/k3s_capv_init.yaml
@@ -85,65 +85,139 @@ write_files:
     group: root
     content: |
       
-  # ADR 0005 (HA) kube-vip static-pod manifest (CAPV/CAPM3 only; CAPK uses its
+  # ADR 0005 § D.1 (HA) kube-vip DaemonSet + RBAC (CAPV/CAPM3 only; CAPK uses its
   # built-in LoadBalancer Service per OQ-5 and never reaches this block).
   # k3s auto-applies manifests under /var/lib/rancher/k3s/server/manifests at
-  # server start, so kube-vip comes up to own the floating control-plane VIP.
-  # The manifest is produced by kubeVIPManifest (marshaled YAML, VIP-INV-2) —
-  # no operator string is concatenated into the YAML.
+  # server start. The manifest is a multi-document set (ServiceAccount +
+  # ClusterRole + ClusterRoleBinding + DaemonSet) produced by kubeVIPManifest
+  # (marshaled YAML, VIP-INV-2) — no operator string is concatenated into the
+  # YAML. The DaemonSet runs one kube-vip per control-plane Node (k3s servers are
+  # schedulable and carry node-role.kubernetes.io/control-plane, so no
+  # --enable-worker is needed as on k0s); the instances leader-elect on the
+  # plndr-cp-lock Lease (hence the RBAC) and the leader ARPs the floating
+  # control-plane VIP, so VIP ownership fails over when the leader's Node dies.
   - path: /var/lib/rancher/k3s/server/manifests/kube-vip.yaml
     permissions: "0644"
     owner: root
     group: root
     content: |
       apiVersion: v1
-      kind: Pod
+      kind: ServiceAccount
       metadata:
           name: kube-vip
           namespace: kube-system
+      ---
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+          name: system:kube-vip-role
+      rules:
+          - apiGroups:
+              - ""
+            resources:
+              - services
+              - services/status
+              - nodes
+              - endpoints
+            verbs:
+              - get
+              - list
+              - watch
+              - update
+          - apiGroups:
+              - coordination.k8s.io
+            resources:
+              - leases
+            verbs:
+              - get
+              - list
+              - watch
+              - update
+              - create
+      ---
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+          name: system:kube-vip-binding
+      roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: system:kube-vip-role
+      subjects:
+          - kind: ServiceAccount
+            name: kube-vip
+            namespace: kube-system
+      ---
+      apiVersion: apps/v1
+      kind: DaemonSet
+      metadata:
+          name: kube-vip
+          namespace: kube-system
+          labels:
+              app.kubernetes.io/name: kube-vip
       spec:
-          containers:
-              - name: kube-vip
-                image: ghcr.io/kube-vip/kube-vip:v0.8.7
-                imagePullPolicy: IfNotPresent
-                args:
-                  - manager
-                env:
-                  - name: vip_arp
-                    value: "true"
-                  - name: vip_interface
-                    value: eth0
-                  - name: address
-                    value: 192.168.1.240
-                  - name: port
-                    value: "6443"
-                  - name: cp_enable
-                    value: "true"
-                  - name: svc_enable
-                    value: "false"
-                  - name: vip_leaderelection
-                    value: "true"
-                  - name: vip_leaseduration
-                    value: "5"
-                  - name: vip_renewdeadline
-                    value: "3"
-                  - name: vip_retryperiod
-                    value: "1"
-                  - name: bgp_enable
-                    value: "false"
-                securityContext:
-                  capabilities:
-                      add:
-                          - NET_ADMIN
-                          - NET_RAW
-                volumeMounts:
-                  - mountPath: /etc/kubernetes/admin.conf
-                    name: kubeconfig
-          hostNetwork: true
-          volumes:
-              - name: kubeconfig
-                hostPath:
-                  path: /etc/kubernetes/admin.conf
+          selector:
+              matchLabels:
+                  app.kubernetes.io/name: kube-vip
+          template:
+              metadata:
+                  labels:
+                      app.kubernetes.io/name: kube-vip
+              spec:
+                  serviceAccountName: kube-vip
+                  hostNetwork: true
+                  nodeSelector:
+                      node-role.kubernetes.io/control-plane: "true"
+                  tolerations:
+                      - key: node-role.kubernetes.io/control-plane
+                        operator: Exists
+                        effect: NoSchedule
+                      - key: node-role.kubernetes.io/master
+                        operator: Exists
+                        effect: NoSchedule
+                  containers:
+                      - name: kube-vip
+                        image: ghcr.io/kube-vip/kube-vip:v0.8.7
+                        imagePullPolicy: IfNotPresent
+                        args:
+                          - manager
+                        env:
+                          - name: vip_arp
+                            value: "true"
+                          - name: vip_interface
+                            value: eth0
+                          - name: address
+                            value: 192.168.1.240
+                          - name: port
+                            value: "6443"
+                          - name: cp_enable
+                            value: "true"
+                          - name: svc_enable
+                            value: "false"
+                          - name: vip_leaderelection
+                            value: "true"
+                          - name: vip_leaseduration
+                            value: "5"
+                          - name: vip_renewdeadline
+                            value: "3"
+                          - name: vip_retryperiod
+                            value: "1"
+                          - name: bgp_enable
+                            value: "false"
+                        securityContext:
+                          capabilities:
+                              add:
+                                  - NET_ADMIN
+                                  - NET_RAW
+                        volumeMounts:
+                          - mountPath: /etc/kubernetes/admin.conf
+                            name: kubeconfig
+                  volumes:
+                      - name: kubeconfig
+                        hostPath:
+                          path: /etc/kubernetes/admin.conf
+          updateStrategy:
+              type: RollingUpdate
   - path: /usr/local/etc/hostname
     permissions: "0644"
     owner: root

--- a/internal/bootstrap/testdata/golden/k3s_capv_join.yaml
+++ b/internal/bootstrap/testdata/golden/k3s_capv_join.yaml
@@ -78,65 +78,139 @@ write_files:
     group: root
     content: |
       K10aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa::server:bbbbbbbbbbbbbbbbbbbbbbbb
-  # ADR 0005 (HA) kube-vip static-pod manifest (CAPV/CAPM3 only; CAPK uses its
+  # ADR 0005 § D.1 (HA) kube-vip DaemonSet + RBAC (CAPV/CAPM3 only; CAPK uses its
   # built-in LoadBalancer Service per OQ-5 and never reaches this block).
   # k3s auto-applies manifests under /var/lib/rancher/k3s/server/manifests at
-  # server start, so kube-vip comes up to own the floating control-plane VIP.
-  # The manifest is produced by kubeVIPManifest (marshaled YAML, VIP-INV-2) —
-  # no operator string is concatenated into the YAML.
+  # server start. The manifest is a multi-document set (ServiceAccount +
+  # ClusterRole + ClusterRoleBinding + DaemonSet) produced by kubeVIPManifest
+  # (marshaled YAML, VIP-INV-2) — no operator string is concatenated into the
+  # YAML. The DaemonSet runs one kube-vip per control-plane Node (k3s servers are
+  # schedulable and carry node-role.kubernetes.io/control-plane, so no
+  # --enable-worker is needed as on k0s); the instances leader-elect on the
+  # plndr-cp-lock Lease (hence the RBAC) and the leader ARPs the floating
+  # control-plane VIP, so VIP ownership fails over when the leader's Node dies.
   - path: /var/lib/rancher/k3s/server/manifests/kube-vip.yaml
     permissions: "0644"
     owner: root
     group: root
     content: |
       apiVersion: v1
-      kind: Pod
+      kind: ServiceAccount
       metadata:
           name: kube-vip
           namespace: kube-system
+      ---
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+          name: system:kube-vip-role
+      rules:
+          - apiGroups:
+              - ""
+            resources:
+              - services
+              - services/status
+              - nodes
+              - endpoints
+            verbs:
+              - get
+              - list
+              - watch
+              - update
+          - apiGroups:
+              - coordination.k8s.io
+            resources:
+              - leases
+            verbs:
+              - get
+              - list
+              - watch
+              - update
+              - create
+      ---
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+          name: system:kube-vip-binding
+      roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: system:kube-vip-role
+      subjects:
+          - kind: ServiceAccount
+            name: kube-vip
+            namespace: kube-system
+      ---
+      apiVersion: apps/v1
+      kind: DaemonSet
+      metadata:
+          name: kube-vip
+          namespace: kube-system
+          labels:
+              app.kubernetes.io/name: kube-vip
       spec:
-          containers:
-              - name: kube-vip
-                image: ghcr.io/kube-vip/kube-vip:v0.8.7
-                imagePullPolicy: IfNotPresent
-                args:
-                  - manager
-                env:
-                  - name: vip_arp
-                    value: "true"
-                  - name: vip_interface
-                    value: eth0
-                  - name: address
-                    value: 192.168.1.240
-                  - name: port
-                    value: "6443"
-                  - name: cp_enable
-                    value: "true"
-                  - name: svc_enable
-                    value: "false"
-                  - name: vip_leaderelection
-                    value: "true"
-                  - name: vip_leaseduration
-                    value: "5"
-                  - name: vip_renewdeadline
-                    value: "3"
-                  - name: vip_retryperiod
-                    value: "1"
-                  - name: bgp_enable
-                    value: "false"
-                securityContext:
-                  capabilities:
-                      add:
-                          - NET_ADMIN
-                          - NET_RAW
-                volumeMounts:
-                  - mountPath: /etc/kubernetes/admin.conf
-                    name: kubeconfig
-          hostNetwork: true
-          volumes:
-              - name: kubeconfig
-                hostPath:
-                  path: /etc/kubernetes/admin.conf
+          selector:
+              matchLabels:
+                  app.kubernetes.io/name: kube-vip
+          template:
+              metadata:
+                  labels:
+                      app.kubernetes.io/name: kube-vip
+              spec:
+                  serviceAccountName: kube-vip
+                  hostNetwork: true
+                  nodeSelector:
+                      node-role.kubernetes.io/control-plane: "true"
+                  tolerations:
+                      - key: node-role.kubernetes.io/control-plane
+                        operator: Exists
+                        effect: NoSchedule
+                      - key: node-role.kubernetes.io/master
+                        operator: Exists
+                        effect: NoSchedule
+                  containers:
+                      - name: kube-vip
+                        image: ghcr.io/kube-vip/kube-vip:v0.8.7
+                        imagePullPolicy: IfNotPresent
+                        args:
+                          - manager
+                        env:
+                          - name: vip_arp
+                            value: "true"
+                          - name: vip_interface
+                            value: eth0
+                          - name: address
+                            value: 192.168.1.240
+                          - name: port
+                            value: "6443"
+                          - name: cp_enable
+                            value: "true"
+                          - name: svc_enable
+                            value: "false"
+                          - name: vip_leaderelection
+                            value: "true"
+                          - name: vip_leaseduration
+                            value: "5"
+                          - name: vip_renewdeadline
+                            value: "3"
+                          - name: vip_retryperiod
+                            value: "1"
+                          - name: bgp_enable
+                            value: "false"
+                        securityContext:
+                          capabilities:
+                              add:
+                                  - NET_ADMIN
+                                  - NET_RAW
+                        volumeMounts:
+                          - mountPath: /etc/kubernetes/admin.conf
+                            name: kubeconfig
+                  volumes:
+                      - name: kubeconfig
+                        hostPath:
+                          path: /etc/kubernetes/admin.conf
+          updateStrategy:
+              type: RollingUpdate
   - path: /usr/local/etc/hostname
     permissions: "0644"
     owner: root

--- a/internal/controllers/bootstrap/management_endpoint_resolver.go
+++ b/internal/controllers/bootstrap/management_endpoint_resolver.go
@@ -59,7 +59,9 @@ type kubeVirtTokenResolver struct {
 	SubResource func(string) client.SubResourceClient
 
 	// Scheme is needed by controllerutil.SetControllerReference on the SA /
-	// Role / RoleBinding. Must include core/v1 and rbac/v1.
+	// Role / RoleBinding. Must include core/v1, rbac/v1, and
+	// cluster.x-k8s.io/v1beta1 (the shared objects are owned by the Cluster —
+	// see the ownership note in Resolve).
 	Scheme *runtime.Scheme
 
 	// ManagementAPIServer is the URL nodes will dial back to. Production
@@ -92,6 +94,19 @@ func (r *kubeVirtTokenResolver) Resolve(ctx context.Context, kc *bootstrapv1beta
 	secretName := fmt.Sprintf("%s-kubeconfig", cluster.Name)
 	saName := kubeconfigWriterName(cluster.Name)
 
+	// OWNERSHIP (ADR 0005 § D.2): the SA/Role/RoleBinding are a single
+	// per-CLUSTER object set (named by cluster.Name) shared by every
+	// control-plane Machine's KairosConfig. They are owned by the *Cluster*,
+	// not by the per-Machine KairosConfig `kc`. An object gets exactly one
+	// controller owner, so owning by kc made the first config (the init node)
+	// the controller owner and every joiner's Resolve fail with
+	// "already owned by another controller" — the multi-node bring-up blocker
+	// found in the Phase-4 lab. Owning by the Cluster is idempotent across all
+	// KairosConfigs (they set the same owner) and GCs the RBAC when the Cluster
+	// is deleted. NOTE (migration): a cluster provisioned before this change
+	// has these objects controller-owned by the init KairosConfig; delete the
+	// three `kairos-kubeconfig-writer-<cluster>` objects once so they are
+	// recreated Cluster-owned. Pre-1.0; not otherwise handled.
 	serviceAccount := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      saName,
@@ -103,7 +118,7 @@ func (r *kubeVirtTokenResolver) Resolve(ctx context.Context, kc *bootstrapv1beta
 			serviceAccount.Labels = map[string]string{}
 		}
 		serviceAccount.Labels[clusterv1.ClusterNameLabel] = cluster.Name
-		return controllerutil.SetControllerReference(kc, serviceAccount, r.Scheme)
+		return controllerutil.SetControllerReference(cluster, serviceAccount, r.Scheme)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to ensure kubeconfig writer serviceaccount: %w", err)
@@ -194,7 +209,7 @@ func (r *kubeVirtTokenResolver) Resolve(ctx context.Context, kc *bootstrapv1beta
 			role.Labels = map[string]string{}
 		}
 		role.Labels[clusterv1.ClusterNameLabel] = cluster.Name
-		return controllerutil.SetControllerReference(kc, role, r.Scheme)
+		return controllerutil.SetControllerReference(cluster, role, r.Scheme)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to ensure kubeconfig writer role: %w", err)
@@ -223,7 +238,7 @@ func (r *kubeVirtTokenResolver) Resolve(ctx context.Context, kc *bootstrapv1beta
 			roleBinding.Labels = map[string]string{}
 		}
 		roleBinding.Labels[clusterv1.ClusterNameLabel] = cluster.Name
-		return controllerutil.SetControllerReference(kc, roleBinding, r.Scheme)
+		return controllerutil.SetControllerReference(cluster, roleBinding, r.Scheme)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to ensure kubeconfig writer rolebinding: %w", err)

--- a/internal/controllers/bootstrap/management_endpoint_resolver_test.go
+++ b/internal/controllers/bootstrap/management_endpoint_resolver_test.go
@@ -373,3 +373,61 @@ func TestResolve_PreExistingServiceAccount_StillSucceeds(t *testing.T) {
 	g.Expect(r.Client.Get(context.Background(), types.NamespacedName{Name: saName, Namespace: "default"}, sa)).To(Succeed())
 	g.Expect(sa.Labels).To(HaveKeyWithValue(clusterv1.ClusterNameLabel, "test-cluster"))
 }
+
+// TestResolve_MultipleConfigsSameCluster_OwnedByCluster is the regression guard
+// for the Phase-4 multi-node bring-up blocker (ADR 0005 § D.2). The per-cluster
+// SA/Role/RoleBinding are a single object set shared by every control-plane
+// Machine's KairosConfig. When they were controller-owned by the per-Machine
+// KairosConfig, the first config (the init node) became the sole controller
+// owner and every subsequent config's Resolve failed with a
+// controllerutil.AlreadyOwnedError ("already owned by another controller"), so
+// joiners never rendered bootstrap and the cluster stalled at one node. Owning
+// by the Cluster makes Resolve idempotent across configs.
+//
+// The test drives two DISTINCT KairosConfigs (different name + UID) in the same
+// cluster: both must succeed and the three shared objects must be
+// controller-owned by the Cluster. It fails against the pre-fix kc-owned code
+// (the second Resolve returns AlreadyOwnedError on the ServiceAccount).
+func TestResolve_MultipleConfigsSameCluster_OwnedByCluster(t *testing.T) {
+	g := NewWithT(t)
+	scheme := newResolverScheme(t)
+	sub := &fakeSubResourceClient{token: "tok"}
+	r, kc1, cluster := newResolverFixture(scheme, sub, "https://mgmt:6443")
+	kc1.Spec.Role = "control-plane"
+	kc1.Spec.Distribution = "k3s"
+
+	// Init node.
+	_, err := r.Resolve(context.Background(), kc1, cluster)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	// A second, distinct KairosConfig in the SAME cluster (a joiner). Different
+	// name + UID so a controller-ref owned by kc1 would conflict.
+	kc2 := &bootstrapv1beta2.KairosConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-config-2",
+			Namespace: "default",
+			UID:       "00000000-0000-0000-0000-000000000002",
+		},
+		Spec: bootstrapv1beta2.KairosConfigSpec{Role: "control-plane", Distribution: "k3s"},
+	}
+	_, err = r.Resolve(context.Background(), kc2, cluster)
+	g.Expect(err).NotTo(HaveOccurred(), "a second KairosConfig in the same cluster must not conflict on the shared RBAC objects")
+
+	// All three shared objects must be controller-owned by the Cluster, not by
+	// either KairosConfig.
+	saName := kubeconfigWriterName("test-cluster")
+	nn := types.NamespacedName{Name: saName, Namespace: "default"}
+	sa := &corev1.ServiceAccount{}
+	g.Expect(r.Client.Get(context.Background(), nn, sa)).To(Succeed())
+	role := &rbacv1.Role{}
+	g.Expect(r.Client.Get(context.Background(), nn, role)).To(Succeed())
+	rb := &rbacv1.RoleBinding{}
+	g.Expect(r.Client.Get(context.Background(), nn, rb)).To(Succeed())
+
+	for _, obj := range []client.Object{sa, role, rb} {
+		owner := metav1.GetControllerOf(obj)
+		g.Expect(owner).NotTo(BeNil(), "shared object must have a controller owner")
+		g.Expect(owner.Kind).To(Equal("Cluster"))
+		g.Expect(owner.Name).To(Equal("test-cluster"))
+	}
+}


### PR DESCRIPTION
## Summary

Phase-4 fixes for **multi-node** HA control planes (ADR 0005 § D). A live 3-node HA bring-up on real hardware (CAPV + Hadron) surfaced four defects in the merged Phase 1–3 code that unit/envtest/golden tests all passed over — every one is invisible at `replicas: 1`. This PR fixes them and they are validated end-to-end on both distributions.

Two logically-separate commits:

1. **`fix(bootstrap): own kubeconfig-writer RBAC by the Cluster` (§ D.2) — the multi-node blocker.**
   The per-cluster kubeconfig-writer `ServiceAccount`/`Role`/`RoleBinding` (`kairos-kubeconfig-writer-<cluster>`) were controller-owned by the per-Machine `KairosConfig`. A Kubernetes object has exactly one controller owner, so the init node's config won ownership and every joiner's `Resolve` failed with `already owned by another controller` → joiners never rendered bootstrap data → the control plane stalled at one node. Now owned by the **Cluster** (idempotent across all configs; GC'd on cluster delete). The SA's namespaced `Role` rules are unchanged.

2. **`feat(bootstrap): render kube-vip as a DaemonSet with RBAC` (§ D.1, § D.3).**
   - kube-vip was a single bare `Pod` running as the `default` ServiceAccount, which cannot `get` the `coordination.k8s.io/leases` `plndr-cp-lock` Lease → leader election failed → the VIP never bound. Now rendered as **ServiceAccount + ClusterRole + ClusterRoleBinding + DaemonSet**.
   - A single bare Pod is also a SPOF that never reschedules on node death. The **DaemonSet** runs one kube-vip per control-plane Node; they leader-elect on the lease and the leader ARPs the VIP, so VIP ownership **fails over** when a node dies.
   - k0s control-plane nodes are controller-only (not schedulable Nodes), so the DaemonSet would stay `Pending`. Added `--enable-worker` to the k0s HA control-plane args (gated on `RenderKubeVIP`; CAPV/CAPM3 only). k3s servers are already schedulable and need no change.
   - The manifest is still built from typed structs + `yaml.v3` (VIP-INV-2 — no string concatenation of `VIP.*`); the container spec is byte-identical to the previous Pod. Single-node and CAPK renders are byte-for-byte unchanged (8 of 12 goldens untouched; only the 4 CAPV init/join goldens change).

## Lab validation (controller image built from this branch)

- **k3s 3-node:** formed in ~5 min — VIP floated via the DaemonSet leader, all joiners rendered + joined, `readyReplicas=3`. **Failover proven:** powered off the VIP-leader node → the lease and VIP moved to another node in ~15s, apiserver stayed reachable via the VIP.
- **k0s 3-node:** formed in ~5.5 min — controller-join token round-trip (0 → 2320 B via the node-push channel), VIP up, `readyReplicas=3`. Confirmed empirically that k0s `--enable-worker` nodes carry `node-role.kubernetes.io/control-plane=true` (the DaemonSet nodeSelector matches) **and** the `:NoSchedule` taint (the DaemonSet toleration clears it; general workloads stay off).

## Security review

security-architect verdict: **SHIP-WITH-NOTES**, no must-fix items. NET_ADMIN/hostNetwork DaemonSet on every CP Node and the cluster-wide kube-vip ClusterRole were both accepted (the container spec is unchanged from the reviewed Pod; the RBAC matches kube-vip's published ClusterRole).

## ⚠️ Upgrade / migration note

A cluster provisioned **before** this change has the three `kairos-kubeconfig-writer-<cluster>` objects (`ServiceAccount`/`Role`/`RoleBinding`) controller-owned by the init node's `KairosConfig`. After upgrading the provider, **delete those three objects once** so they are recreated Cluster-owned:

```
kubectl -n <cluster-namespace> delete serviceaccount,role,rolebinding kairos-kubeconfig-writer-<cluster-name>
```

Otherwise a stuck multi-node cluster keeps failing joiner bootstrap with `already owned by another controller` even after the upgrade.

## Deferred follow-up

The kube-vip `ClusterRole` ships the validated-working rule set (`leases` + `services`/`services/status`/`nodes`/`endpoints`). With `svc_enable=false` a least-privilege trim to `leases` + `nodes` is plausible; deferred to a follow-up that empirically confirms kube-vip v0.8.7's CP-only startup behavior rather than risking a regression here.
