### PR TITLE
feat(ha): quorum-safe control-plane replacement + etcd health + clean k0s etcd-leave (ADR 0005 Phase 4 day-2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ This project provides two Cluster API (CAPI) providers for managing Kubernetes c
 
 ## Status
 
-**Latest release**: [`v0.1.0-alpha.2`](https://github.com/kairos-io/cluster-api-provider-kairos/releases/tag/v0.1.0-alpha.2) — pre-release; API surface may change before v0.1.0.
+**Latest release**: [`v0.1.0-alpha.2`](https://github.com/kairos-io/cluster-api-provider-kairos/releases/tag/v0.1.0-alpha.2) — pre-release; API surface may change before v0.1.0. Highly-available control planes (below) ship in the next release, `v0.1.0-alpha.3` (provisional, unreleased at time of writing) — see [its release notes](docs/release-notes/v0.1.0-alpha.3.md) for status.
 
-Supports single-node k0s and k3s clusters with CAPD, CAPV, CAPK, and CAPM3 (Metal3 bare metal). The alpha-2 e2e matrix is GREEN on all four CAPV/CAPM3 × k0s/k3s combinations with Kairos Hadron. `spec.replicas > 1` is currently webhook-rejected; HA control planes are on the roadmap (KD-5b / KD-25).
+Supports single-node and highly-available k0s and k3s clusters with CAPD, CAPV, CAPK, and CAPM3 (Metal3 bare metal). The alpha-2 e2e matrix is GREEN on all four CAPV/CAPM3 × k0s/k3s combinations with Kairos Hadron. `KairosControlPlane.spec.replicas` accepts `1` (single-node), `3`, or `5` (HA); even counts and values above `5` are webhook-rejected. See [High-Availability control planes](#high-availability-control-planes) below. k0s is the fully-supported HA distribution; k3s HA has a known day-2 limitation (KD-5d).
 
 Read the [v0.1.0-alpha.2 release notes](docs/release-notes/v0.1.0-alpha.2.md) before installing — there are breaking changes, security hardening requirements, and known limitations that affect all operators upgrading from alpha.1. Additional infrastructure providers (Tinkerbell, hyperscalers) are on the roadmap.
 
@@ -32,6 +32,40 @@ The provider is distributed as a flat manifest installable via `kubectl apply -f
 ## Credentials
 
 Provide node credentials via `userPasswordSecretRef` (recommended) or `sshPublicKey` / `githubUser`. The validating webhook rejects any `KairosConfig` that specifies no credential. Inline `userPassword` is accepted but discouraged — the value is stored in the resource spec and readable by anyone with access to KairosConfig objects.
+
+## High-Availability control planes
+
+`KairosControlPlane.spec.replicas` accepts `1`, `3`, or `5`. `1` is single-node. `3` or `5` configure a multi-node control plane with etcd quorum (the webhook rejects even counts and values above `5`, since they add quorum cost without additional fault tolerance).
+
+HA control planes need a stable endpoint that survives the loss of any one node. For CAPV, CAPM3, and CAPD, configure a kube-vip virtual IP:
+
+```yaml
+spec:
+  replicas: 3
+  ha:
+    vip:
+      address: "192.168.1.50"   # must equal Cluster.spec.controlPlaneEndpoint.host
+      interface: "ens192"       # NIC name present on the control-plane nodes
+      mode: ARP                 # ARP (default, flat L2 subnet) or BGP (routed fabric)
+```
+
+The controller renders a kube-vip DaemonSet into each control-plane node's bootstrap cloud-config; one Pod holds leader election and advertises the VIP, and it fails over to a surviving node if the leader is lost. `Cluster.spec.controlPlaneEndpoint.host` must equal `spec.ha.vip.address` — CAPI core copies the InfraCluster's endpoint into `Cluster.spec.controlPlaneEndpoint`, and every node and kubeconfig targets that value.
+
+**CAPK is the exception:** do not set `spec.ha.vip` for CAPK clusters. CAPK provisions its own LoadBalancer Service and reflects its IP into the control-plane endpoint; a kube-vip VIP alongside it produces a conflicting ARP announcement.
+
+See the worked sample: [`config/samples/capv/kairos_cluster_k0s_ha.yaml`](config/samples/capv/kairos_cluster_k0s_ha.yaml) and the [CAPV HA quickstart walkthrough](docs/QUICKSTART_CAPV.md#high-availability-3-node-k0s-control-plane).
+
+### Day-2: etcd health and quorum-safe replacement
+
+Each control-plane node reports its own etcd member health; the controller surfaces this as the `EtcdHealthy` condition on `KairosControlPlane` (`True` when every desired voting member is healthy, `False(Info)` when quorum holds but a member is degraded, `False(Warning)` at or below the `(N/2)+1` quorum minimum).
+
+Rollouts and scale-downs are quorum-safe: the controller refuses to delete a control-plane Machine if doing so would drop etcd below `(N/2)+1` healthy voting members.
+
+On a k0s control-plane removal, the node runs `k0s etcd leave` cleanly before the Machine is deleted — a CAPI pre-terminate hook pauses termination until the node acks the leave, so no etcd member is left orphaned. **k3s has no supported clean member-remove for its embedded etcd (KD-5d):** replacing a k3s control-plane node leaves an orphaned etcd member that requires manual `etcdctl member remove`; the controller emits an `EtcdMemberRemoveUnsupportedForK3s` warning event when this happens. **k0s is the fully-supported HA distribution; k3s HA works for bring-up but needs manual cleanup on every control-plane replacement.**
+
+A stuck or unreachable k0s node that never acknowledges its leave request within roughly 5 minutes is deleted anyway (the quorum-safety check already proved the delete is safe); its etcd member may remain registered. Watch for the `EtcdMemberLeaveTimedOut` warning event and remove the member manually if it fires.
+
+**Known limitation (KD-51):** node-reported etcd health and leave acknowledgements are written by control-plane nodes using vanilla RBAC on objects shared across the control plane, so a compromised control-plane node can forge them. This is not a privilege escalation — a compromised control-plane node already holds cluster-admin-equivalent access — and it cannot force an unsafe deletion, since the quorum-safety decision is made independently before any node signal is consulted. A forged signal can only self-downgrade the clean-leave/health guarantee (e.g., cause an early or missed clean-leave). Per-member-scoped signals are tracked as future hardening.
 
 ## Target Versions
 

--- a/api/bootstrap/v1beta2/kairosconfig_types.go
+++ b/api/bootstrap/v1beta2/kairosconfig_types.go
@@ -42,12 +42,31 @@ const (
 
 	// ControlPlaneJoinTokenSecretDataKey is the data key holding the join token.
 	ControlPlaneJoinTokenSecretDataKey = "token"
+
+	// EtcdStatusSecretSuffix is appended to the cluster name to form the
+	// per-cluster HA etcd-health Secret name (ADR 0005 §E.1). Every control-plane
+	// node PATCHes its own member key over the node-push channel; the controlplane
+	// controller pre-creates the (empty) Secret. Unlike the KCP-owned single-writer
+	// join-token Secret above, the etcd-status Secret is owned by the CLUSTER
+	// (multi-writer — one data key per etcd member).
+	EtcdStatusSecretSuffix = "etcd-status"
+
+	// EtcdStatusSecretTypeLabel + Value mark the etcd-status Secret so controllers'
+	// Secret-watch predicates match it by label (KD-15), never by name suffix.
+	EtcdStatusSecretTypeLabel = "controlplane.cluster.x-k8s.io/secret-type"
+	EtcdStatusSecretTypeValue = "etcd-status"
 )
 
 // ControlPlaneJoinTokenSecretName returns the per-cluster HA join-token Secret
 // name for the given cluster.
 func ControlPlaneJoinTokenSecretName(clusterName string) string {
 	return clusterName + "-" + ControlPlaneJoinTokenSecretSuffix
+}
+
+// EtcdStatusSecretName returns the per-cluster HA etcd-status Secret name for the
+// given cluster.
+func EtcdStatusSecretName(clusterName string) string {
+	return clusterName + "-" + EtcdStatusSecretSuffix
 }
 
 // ControlPlaneRole is the per-machine role discriminator for control-plane

--- a/api/controlplane/v1beta2/conditions.go
+++ b/api/controlplane/v1beta2/conditions.go
@@ -43,6 +43,13 @@ const (
 	// joined and registered a Node). False(Info) with an "n/N joined" message
 	// while scaling up. Not surfaced for single-node control planes.
 	ControlPlaneJoinedCondition = "ControlPlaneJoined"
+
+	// EtcdHealthyCondition reports control-plane etcd membership health for an HA
+	// control plane (ADR 0005 §E.4), derived from the node-reported etcd-status
+	// Secret. True when all desired members report healthy + voting; False(Info)
+	// when quorum holds but a member is degraded; False(Warning) at or below the
+	// (N/2)+1 quorum minimum. Not surfaced for single-node control planes.
+	EtcdHealthyCondition = "EtcdHealthy"
 )
 
 // Condition reasons
@@ -67,6 +74,26 @@ const (
 	// ControlPlaneJoinedReason is the True reason on ControlPlaneJoinedCondition
 	// once all configured HA members have joined.
 	ControlPlaneJoinedReason = "ControlPlaneJoined"
+
+	// EtcdHealthyReason is the True reason on EtcdHealthyCondition when all
+	// desired etcd members report healthy and voting (ADR 0005 §E.4).
+	EtcdHealthyReason = "EtcdHealthy"
+
+	// EtcdQuorumDegradedReason is the False(Info) reason on EtcdHealthyCondition
+	// when etcd quorum still holds but fewer than all desired members are
+	// healthy+voting.
+	EtcdQuorumDegradedReason = "EtcdQuorumDegraded"
+
+	// EtcdQuorumAtRiskReason is the False(Warning) reason on EtcdHealthyCondition
+	// when the healthy+voting member count is at or below the (N/2)+1 quorum
+	// minimum — one more loss breaks quorum. Also covers the not-yet-formed
+	// bring-up window (before members have reported).
+	EtcdQuorumAtRiskReason = "EtcdQuorumAtRisk"
+
+	// WaitingForEtcdMemberReason is the False(Info) reason surfaced while the
+	// init node has not yet reported a healthy voting etcd member (ADR 0005 §E.1,
+	// k0s joiner gate).
+	WaitingForEtcdMemberReason = "WaitingForEtcdMember"
 
 	// WaitingForMachinesReadyReason indicates that the control plane is waiting for machines to be ready
 	WaitingForMachinesReadyReason = "WaitingForMachinesReady"

--- a/config/samples/capv/kairos_cluster_k0s_ha.yaml
+++ b/config/samples/capv/kairos_cluster_k0s_ha.yaml
@@ -1,0 +1,207 @@
+# ============================================================================
+# CAPV Sample: 3-Node HA k0s Control Plane on Kairos OS (ADR 0005 Phase 4)
+# ============================================================================
+#
+# This provisions a highly-available, 3-node k0s control plane fronted by a
+# kube-vip virtual IP (VIP). For the single-node variant see
+# kairos_cluster_k0s_single_node.yaml.
+#
+# HOW HA DIFFERS FROM SINGLE-NODE:
+#   - spec.replicas is 3 (or 5) on the KairosControlPlane — never 2 or 4; etcd
+#     quorum needs an odd member count.
+#   - spec.ha.vip on the KairosControlPlane declares the kube-vip VIP. The
+#     controller renders a kube-vip DaemonSet (one Pod per control-plane node,
+#     leader-elected) into the bootstrap cloud-config so the VIP floats to a
+#     surviving node if the leader fails.
+#   - Cluster.spec.controlPlaneEndpoint.host MUST equal spec.ha.vip.address:
+#     the VIP is the stable API endpoint every node and kubeconfig targets.
+#   - The VIP address must be a free IP on the nodes' subnet (not in any DHCP
+#     pool), and spec.ha.vip.interface must be the NIC name that exists on the
+#     nodes (e.g. "ens192" on vSphere Hadron images — verify with `ip link`).
+#
+# DAY-2 BEHAVIOUR (ADR 0005 §E):
+#   - Each control-plane node reports its etcd member health into a per-cluster
+#     Secret; the controller surfaces it as the EtcdHealthy condition on the
+#     KairosControlPlane (kubectl get kairoscontrolplane -o yaml).
+#   - Replacement/scale-down is quorum-safe: the controller refuses a delete
+#     that would drop etcd below (N/2)+1 healthy voting members.
+#   - On a k0s control-plane removal the departing node runs `k0s etcd leave`
+#     cleanly before the VM is destroyed (no orphaned etcd member).
+#   - LIMITATIONS: see the security/limitations note at the bottom of this file
+#     (forgeable node-self-reported health — KD-51; k3s orphaned member — KD-5d).
+#
+# SETUP INSTRUCTIONS (same three-step flow as kairos_cluster_k0s_single_node.yaml):
+#
+# 1. FIRST, apply the VSphereClusterIdentity and Secret (at the bottom of this
+#    file). Edit the Secret with your actual vSphere credentials.
+#      kubectl apply -f config/samples/capv/kairos_cluster_k0s_ha.yaml
+#
+# 2. THEN, customize the VSphereCluster, VSphereMachineTemplate, and the VIP
+#    fields below (see TODO comments): server, datacenter, datastore, network,
+#    template names, VIP address, and NIC name.
+#
+# 3. FINALLY, apply the entire manifest again (or apply just the cluster parts):
+#      kubectl apply -f config/samples/capv/kairos_cluster_k0s_ha.yaml
+#
+# See docs/QUICKSTART_CAPV.md#high-availability-3-node-k0s-control-plane for
+# the full walkthrough, HA prerequisites, and verification steps.
+# ============================================================================
+
+# IMPORTANT: replace `password:` below with a strong value before applying.
+# `openssl rand -base64 32` is fine. Inline UserPassword in KairosConfig is
+# deprecated; this Secret pattern is the recommended way to provide it.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kairos-user-password
+  namespace: default
+type: Opaque
+stringData:
+  password: REPLACE_WITH_A_STRONG_PASSWORD
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  name: kairos-cluster
+  namespace: default
+spec:
+  infrastructureRef:
+    apiGroup: infrastructure.cluster.x-k8s.io
+    kind: VSphereCluster
+    name: kairos-cluster
+  controlPlaneRef:
+    apiGroup: controlplane.cluster.x-k8s.io
+    kind: KairosControlPlane
+    name: kairos-control-plane
+  # HA: this MUST be the kube-vip VIP declared in spec.ha.vip.address below.
+  # Pre-allocate a free IP on the nodes' subnet (outside any DHCP range).
+  controlPlaneEndpoint:
+    host: "TODO-REPLACE-WITH-VIP-ADDRESS"   # e.g. 172.16.56.95 — MUST match spec.ha.vip.address
+    port: 6443
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereCluster
+metadata:
+  name: kairos-cluster
+  namespace: default
+spec:
+  # vCenter FQDN or IP — hostname/IP ONLY, no protocol/path.
+  server: "TODO-YOUR-VCENTER-HOSTNAME"
+  identityRef:
+    kind: VSphereClusterIdentity
+    name: vsphere-credentials
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: KairosControlPlane
+metadata:
+  name: kairos-control-plane
+  namespace: default
+spec:
+  # HA control plane: 3 or 5 only (odd count for etcd quorum). The webhook
+  # rejects even counts > 1.
+  replicas: 3
+  # Pin a version your Kairos image bundles (informational; see KD-24).
+  version: "v1.34.1+k0s.1"
+  # HA: the kube-vip virtual IP that fronts the control plane. Rendered as a
+  # kube-vip DaemonSet into every control-plane node's cloud-config.
+  ha:
+    vip:
+      # MUST equal Cluster.spec.controlPlaneEndpoint.host above.
+      address: "TODO-REPLACE-WITH-VIP-ADDRESS"   # e.g. 172.16.56.95
+      # NIC name present on the nodes (verify with `ip link` on the image).
+      interface: "TODO-NODE-NIC"                 # e.g. ens192
+      # ARP (L2, default) suits a flat lab subnet; BGP needs a peering fabric.
+      mode: ARP
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: VSphereMachineTemplate
+      name: kairos-control-plane-template
+      namespace: default
+  kairosConfigTemplate:
+    name: kairos-config-template-control-plane
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereMachineTemplate
+metadata:
+  name: kairos-control-plane-template
+  namespace: default
+spec:
+  template:
+    spec:
+      # TODO: Configure vSphere VM settings (datacenter, datastore, network,
+      # template, sizing). See the single-node sample for the full field list.
+      # datacenter: "Datacenter"
+      # datastore: "Datastore"
+      # network:
+      #   devices:
+      #     - networkName: "VM Network"
+      # numCPUs: 2
+      # memoryMiB: 4096
+      # diskGiB: 50
+      # template: "kairos-template"
+      # cloneMode: "fullClone"
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+kind: KairosConfigTemplate
+metadata:
+  name: kairos-config-template-control-plane
+  namespace: default
+spec:
+  template:
+    spec:
+      role: control-plane
+      distribution: k0s
+      # Pin a version your Kairos image bundles (informational; see KD-24).
+      kubernetesVersion: "v1.34.1+k0s.1"
+      userName: kairos
+      # Password comes from a Secret (defined at the top of this file).
+      userPasswordSecretRef:
+        name: kairos-user-password
+      userGroups:
+        - admin
+      # Optional: sshPublicKey / githubUser for SSH access.
+---
+# ============================================================================
+# VSphere Credentials Setup (REQUIRED — apply BEFORE the cluster manifest)
+# Identical to the single-node sample; see its comments for details.
+# ============================================================================
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsphere-credentials-secret
+  namespace: capv-system   # MUST be in capv-system (where CAPV runs)
+type: Opaque
+stringData:
+  username: "administrator@vsphere.local"   # TODO: your vSphere username
+  password: "your-vsphere-password"         # TODO: your vSphere password
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereClusterIdentity
+metadata:
+  name: vsphere-credentials
+spec:
+  secretName: vsphere-credentials-secret
+  allowedNamespaces:
+    selector:
+      matchLabels: {}
+# ============================================================================
+# SECURITY / LIMITATIONS (read before running HA in production)
+# ============================================================================
+# - Node-self-reported etcd health is FORGEABLE (KD-51). Each control-plane
+#   node writes its own etcd member health with vanilla RBAC on a shared Secret,
+#   and acks its etcd-leave on a shared workload ConfigMap. A COMPROMISED
+#   control-plane node could forge another member's health (to trick the
+#   quorum-safety guard) or forge its own leave ack (to drop the deletion hook
+#   early). This is NOT privilege escalation — a compromised control-plane node
+#   already holds cluster-admin-equivalent — and the quorum-safety decision is
+#   made independently, BEFORE any node signal, so a forged signal can only make
+#   an already-authorized removal cleaner/earlier, never authorize an unsafe
+#   one. Per-member-scoped signals are tracked future hardening.
+# - A stuck/unreachable k0s node that never acks its leave within ~5 minutes is
+#   deleted anyway (quorum was already proven safe); the etcd member may remain
+#   registered. Watch for the EtcdMemberLeaveTimedOut warning event and, if it
+#   fires, remove the member manually (`k0s etcdctl member remove`).
+# - k3s HA: embedded etcd has no supported clean member-remove, so replacing a
+#   k3s control-plane node leaves an orphaned etcd member requiring manual
+#   cleanup (KD-5d). k0s is the fully-supported HA distribution.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # API Reference
 
-Last verified against: Kairos v3.6.0+, CAPI v1.9+ required (go.mod imports v1.8 types; see Notes §API Version Compatibility), provider v0.1.0-alpha.2.
+Last verified against: Kairos v3.6.0+, CAPI v1.9+ required (go.mod imports v1.8 types; see Notes §API Version Compatibility), provider v0.1.0-alpha.3 (provisional — HA control-plane support, unreleased at time of writing).
 
 This document provides a reference for all Custom Resource Definitions (CRDs) provided by the Kairos CAPI Provider. See [Install guide](INSTALL.md) for development install. Quickstarts: [CAPD](QUICKSTART_CAPD.md), [CAPV](QUICKSTART_CAPV.md), [CAPK](QUICKSTART_CAPK.md), [CAPM3](QUICKSTART_CAPM3.md).
 
@@ -222,12 +222,13 @@ spec:
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `replicas` | `*int32` | No | `1` | Number of control plane machines. Must be exactly `1`. The validating webhook rejects values greater than 1 — the current bootstrap logic would otherwise produce N independent single-node clusters. HA control planes are tracked for a future release (KD-5b / KD-25). |
+| `replicas` | `*int32` | No | `1` | Number of control plane machines. One of `1`, `3`, or `5` — the validating webhook rejects even counts (they provide the same etcd fault tolerance as the next-lower odd count while raising the quorum requirement) and values above `5` (beyond 5 members the quorum cost outweighs the added fault tolerance). `1` configures a single-node control plane. `3` or `5` configure a highly-available control plane; set `ha.vip` for infrastructure providers that do not supply a load-balanced endpoint (CAPV, CAPM3, CAPD). |
 | `version` | `string` | Yes | — | Kubernetes version string (e.g., `"v1.34.1+k0s.1"`). Informational; the actual k8s version is pinned in the Kairos image. |
-| `distribution` | `string` | No | `"k0s"` | Kubernetes distribution for this control plane: `"k0s"` or `"k3s"`. |
+| `distribution` | `string` | No | `"k0s"` | Kubernetes distribution for this control plane: `"k0s"` or `"k3s"`. k0s is the fully-supported HA distribution; k3s HA bring-up is supported but replacing a k3s control-plane node afterward leaves an orphaned etcd member requiring manual cleanup (KD-5d — see [Multi-Node Control Planes](#multi-node-control-planes)). |
 | `machineTemplate` | `KairosControlPlaneMachineTemplate` | Yes | — | Template for creating control plane Machines. |
 | `kairosConfigTemplate` | `KairosConfigTemplateReference` | Yes | — | Reference to a `KairosConfigTemplate` that provides the bootstrap configuration for each Machine. |
 | `rolloutStrategy` | `RolloutStrategy` | No | — | Strategy for rolling out updates. |
+| `ha` | `HAConfig` | No | — | High-availability configuration, used when `replicas` is `3` or `5`. Ignored when `replicas` is `1`; setting it on a single-node control plane produces a non-blocking admission warning. See [HAConfig](#haconfig). |
 
 #### KairosControlPlaneMachineTemplate
 
@@ -260,6 +261,20 @@ The `namespace` field is not part of this reference. The namespace defaults to t
 |-------|------|----------|-------------|
 | `maxSurge` | `*int32` | No | Maximum number of machines that can be created above the desired count during a rollout. |
 
+#### HAConfig
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `vip` | `KubeVIPConfig` | No | The virtual IP (kube-vip) used as the stable control-plane endpoint across HA nodes. Required on CAPV, CAPM3, and CAPD when the infrastructure provider does not supply a load-balanced endpoint automatically. **Do not set on CAPK** — CAPK provisions its own LoadBalancer Service and reflects its IP into the control-plane endpoint; a VIP alongside it produces a conflicting ARP announcement. |
+
+#### KubeVIPConfig
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `address` | `string` | Yes | — | The virtual IP address or DNS hostname for the control-plane endpoint. Must be a valid IPv4 address, IPv6 address, or RFC-1123 hostname (max 253 characters). For `mode: ARP`, must be an IP address reachable on the same L2 segment as the control-plane nodes. Must equal the host portion of the InfraCluster's `controlPlaneEndpoint` (e.g., `VSphereCluster.spec.controlPlaneEndpoint.host`) so that CAPI core copies the correct address into `Cluster.spec.controlPlaneEndpoint`. This cross-object match is not enforced at admission — a mismatch will not be rejected, but the cluster endpoint will point at the wrong address. |
+| `interface` | `string` | Yes | — | The Linux network interface name on which kube-vip advertises the VIP (e.g., `"eth0"`, `"ens192"`, `"bond0"`). Must be 1-15 characters, starting with a letter, followed by letters, digits, dots, underscores, or hyphens. Verify the interface name against your Kairos image with `ip link` before setting this field. |
+| `mode` | `string` | No | `"ARP"` | VIP advertisement mode: `"ARP"` (L2, requires the control-plane nodes to share an L2 segment) or `"BGP"` (L3, requires a BGP peer; intended for routed bare-metal fabrics). |
+
 ### Status Fields
 
 | Field | Type | Description |
@@ -270,7 +285,7 @@ The `namespace` field is not part of this reference. The namespace defaults to t
 | `replicas` | `int32` | Total number of control plane Machines across all states. |
 | `updatedReplicas` | `int32` | Number of Machines running the desired version. |
 | `unavailableReplicas` | `int32` | Number of Machines that are unavailable (not ready or being deleted). |
-| `conditions` | `[]Condition` | Standard CAPI conditions: `Ready`, `Available`, `Initialized`, `KubeconfigReady`. |
+| `conditions` | `[]Condition` | Standard CAPI conditions: `Ready`, `Available`, `Initialized`, `KubeconfigReady`, `ControlPlaneJoined` (HA only), `EtcdHealthy` (HA only). See [EtcdHealthy condition](#etcdhealthy-condition) below. |
 | `observedGeneration` | `int64` | Most recent generation observed by the controller. |
 | `failureReason` | `string` | Short machine-readable failure indicator. Cleared automatically when the next reconcile succeeds — a non-empty value indicates an ongoing failure, not a terminal one. |
 | `failureMessage` | `string` | Human-readable failure description. Cleared automatically on the next successful reconcile. If non-empty, check KairosControlPlane events and owned Machine events for context. |
@@ -296,6 +311,46 @@ spec:
   kairosConfigTemplate:
     name: kairos-config-template-control-plane
 ```
+
+A 3-node HA example with a kube-vip VIP:
+
+```yaml
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: KairosControlPlane
+metadata:
+  name: kairos-control-plane
+  namespace: default
+spec:
+  replicas: 3
+  version: "v1.34.1+k0s.1"
+  ha:
+    vip:
+      address: "192.168.1.50"   # must equal Cluster.spec.controlPlaneEndpoint.host
+      interface: "ens192"
+      mode: ARP
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: VSphereMachineTemplate
+      name: control-plane-template
+  kairosConfigTemplate:
+    name: kairos-config-template-control-plane
+```
+
+See the full worked sample at `config/samples/capv/kairos_cluster_k0s_ha.yaml` and the [CAPV HA quickstart](QUICKSTART_CAPV.md#high-availability-3-node-k0s-control-plane).
+
+### EtcdHealthy condition
+
+Surfaced on `KairosControlPlane.status.conditions` for HA control planes only (`replicas` is `3` or `5`); absent for single-node control planes.
+
+| Status | Reason | Meaning |
+|--------|--------|---------|
+| `True` | `EtcdHealthy` | All desired etcd members report healthy and voting. |
+| `False` (Info) | `EtcdQuorumDegraded` | Quorum still holds, but fewer than all desired members are healthy and voting. |
+| `False` (Warning) | `EtcdQuorumAtRisk` | The healthy+voting member count is at or below the `(N/2)+1` quorum minimum — one more member loss breaks quorum. Also covers the bring-up window before any member has reported. |
+| `False` (Info) | `WaitingForEtcdMember` | The init node has not yet reported a healthy voting etcd member. |
+
+The condition is derived from a per-cluster, node-reported etcd-status Secret (see [Security Considerations](#security-considerations) for the trust model of this signal). The controller uses this condition, together with the desired replica count, to refuse control-plane Machine deletions that would drop etcd below the quorum minimum — this quorum-safety decision is made independently of, and before, any single node's self-reported signal.
 
 ---
 
@@ -446,10 +501,13 @@ When `KairosControlPlane.spec.replicas == 1`, the controller automatically sets 
 
 ### Multi-Node Control Planes
 
-`KairosControlPlane.spec.replicas > 1` is currently rejected by the validating webhook. HA control planes are tracked for a future release (KD-5b / KD-25). Do not attempt to work around the webhook — setting replicas to 1 is the correct configuration for all current deployments.
+`KairosControlPlane.spec.replicas` accepts `1`, `3`, or `5`. The validating webhook rejects even counts (they give the same etcd fault tolerance as the next-lower odd count while raising the quorum requirement — always use the next-higher odd number instead) and values above `5` (beyond 5 members the quorum cost outweighs the added fault tolerance for a control plane).
+
+`3` and `5` configure a highly-available control plane. Set `spec.ha.vip` on CAPV, CAPM3, and CAPD clusters so kube-vip provides a stable, failover-capable endpoint — do not set it on CAPK, which supplies its own LoadBalancer-backed endpoint. See [HAConfig](#haconfig) and [EtcdHealthy condition](#etcdhealthy-condition) above, and [README.md § High-Availability control planes](../README.md#high-availability-control-planes) for the full day-2 behavior (quorum-safe replacement, k0s clean etcd-leave, and the k3s orphaned-member limitation tracked as KD-5d).
 
 ### Security Considerations
 
 - Provide credentials via `userPasswordSecretRef` (recommended) or `sshPublicKey` / `githubUser`. Inline `userPassword` is stored in the KairosConfig spec and readable by anyone who can `kubectl get kairosconfig`.
 - Worker tokens should use the `*SecretRef` variants. Inline tokens in specs are readable without Secret RBAC.
+- **HA etcd health/leave signals are node-self-reported and forgeable (KD-51).** Both day-2 HA signal channels — the per-cluster etcd-status Secret and the workload `kube-system/kairos-etcd-leave` ConfigMap leave acknowledgement — are written by control-plane nodes with vanilla RBAC on objects shared across the control plane, so a compromised control-plane node can forge them. This is not a privilege escalation (a compromised control-plane node already holds cluster-admin-equivalent access) and cannot force an unsafe deletion, because the quorum-safety decision is made independently of, and before, any node signal is consulted. A forged signal can only self-downgrade the clean-leave/health guarantee. Per-member-scoped signals are tracked as future hardening.
 - All Secrets referenced by `*SecretRef` fields must exist in the management cluster before the KairosConfig is reconciled. Missing Secrets cause a transient failure that clears automatically when the Secret is created.

--- a/docs/QUICKSTART_CAPD.md
+++ b/docs/QUICKSTART_CAPD.md
@@ -60,7 +60,7 @@ Key components:
 - `Secret` — user password (referenced by `userPasswordSecretRef` in KairosConfigTemplate).
 - `Cluster` — references `DockerCluster` and `KairosControlPlane`.
 - `DockerCluster` — Docker infrastructure cluster.
-- `KairosControlPlane` — control plane with `replicas: 1` (single-node only; HA is not yet supported).
+- `KairosControlPlane` — control plane with `replicas: 1` (this guide is single-node; HA with `replicas: 3`/`5` via `spec.ha.vip` is supported — see the [README HA section](../README.md#high-availability-control-planes). CAPV k0s is the lab-validated HA path; CAPD HA is not yet lab-validated).
 - `DockerMachineTemplate` — template for Docker machines.
 - `KairosConfigTemplate` — bootstrap configuration with `userPasswordSecretRef`.
 
@@ -150,7 +150,7 @@ This adds a `MachineDeployment` for worker nodes referencing a separate `KairosC
 
 - Configure additional Kubernetes manifests via `spec.manifests` in `KairosConfigTemplate`.
 - Scale worker nodes by updating `MachineDeployment.spec.replicas`.
-- Multi-node control planes are tracked for a future release (KD-5b / KD-25).
+- HA control planes (`replicas: 3`/`5` with a kube-vip VIP via `spec.ha.vip`) are supported; CAPV k0s is the lab-validated path (see the [README HA section](../README.md#high-availability-control-planes)). CAPD reuses the same `spec.ha.vip` surface but its HA path is not yet lab-validated.
 
 ## Cleanup
 

--- a/docs/QUICKSTART_CAPM3.md
+++ b/docs/QUICKSTART_CAPM3.md
@@ -6,7 +6,7 @@ This guide walks you through creating a single-node k3s or k0s cluster on Kairos
 
 **Scope of this release:**
 
-- Single-node control plane only (`replicas: 1`). The webhook rejects `replicas > 1` (KD-5b).
+- This guide provisions a single-node control plane (`replicas: 1`). HA (`replicas: 3`/`5`) is now supported — the webhook accepts odd counts 1/3/5. CAPV k0s is the lab-validated HA path (see the [README HA section](../README.md#high-availability-control-planes)); CAPM3 reuses the same `spec.ha.vip` surface but its HA path is not yet lab-validated.
 - DHCP-only networking. Static IPAM via Metal3DataTemplate / Metal3IPPool is a future phase.
 - No cloud controller manager (`cloudProviderEnabled: false`). Node providerID is set by the Kairos cloud-config at first boot — no manual patching required.
 
@@ -527,7 +527,7 @@ If the node's IP changes after provisioning (DHCP lease reassignment), the `cont
 
 - Configure worker nodes via `MachineDeployment` with a `Metal3MachineTemplate` and a worker-role `KairosConfigTemplate`.
 - Add custom Kubernetes manifests via `spec.template.spec.manifests` in `KairosConfigTemplate`.
-- Multi-node control planes are tracked for a future release (KD-5b / KD-25).
+- HA control planes (`replicas: 3`/`5` with a kube-vip VIP via `spec.ha.vip`) are supported; CAPV k0s is the lab-validated path (see the [README HA section](../README.md#high-availability-control-planes)). CAPM3 reuses the same `spec.ha.vip` surface but its HA path is not yet lab-validated.
 - Static IPAM via Metal3DataTemplate / Metal3IPPool is a future phase.
 
 ---

--- a/docs/QUICKSTART_CAPV.md
+++ b/docs/QUICKSTART_CAPV.md
@@ -1,8 +1,8 @@
 # Quick Start Guide - CAPV (vSphere)
 
-Last verified against: Kairos v3.6.0+, CAPI v1.9+ (lab-validated v1.12.x), CAPV v1.11.x, provider v0.1.0-alpha.2.
+Last verified against: Kairos v3.6.0+, CAPI v1.9+ (lab-validated v1.12.x), CAPV v1.11.x, provider v0.1.0-alpha.3 (provisional — HA control-plane support, unreleased at time of writing).
 
-This guide walks you through creating a single-node k0s or k3s cluster on Kairos using Cluster API with the vSphere provider (CAPV).
+This guide walks you through creating a single-node k0s or k3s cluster on Kairos using Cluster API with the vSphere provider (CAPV). For a 3-node highly-available k0s control plane, see [High-Availability: 3-node k0s control plane](#high-availability-3-node-k0s-control-plane) below.
 
 **Note on `controlPlaneEndpoint`**: both the k0s and k3s flavors require `Cluster.spec.controlPlaneEndpoint` (or `VSphereCluster.spec.controlPlaneEndpoint`) to be set to a stable LoadBalancer IP or VIP before applying the manifest. The provider does not auto-discover the endpoint. Standard CAPV practice is to pre-allocate an IP via your load-balancer solution and reference it in the sample before applying. If you apply without a valid endpoint, `KairosControlPlane` will stall with `Available=False(WaitingForInfrastructureControlPlaneEndpoint)` until the endpoint is set.
 
@@ -313,6 +313,97 @@ enable the opt-in
 [Air-gapped fallback (SSHFallback)](#air-gapped-fallback-sshfallback)
 on the `KairosControlPlane`.
 
+## High-Availability: 3-node k0s control plane
+
+This section walks through a 3-node HA k0s control plane fronted by a kube-vip virtual IP (VIP), using [`config/samples/capv/kairos_cluster_k0s_ha.yaml`](../config/samples/capv/kairos_cluster_k0s_ha.yaml). Read the [single-node walkthrough](#creating-a-cluster) above first — the vSphere template, credentials Secret, and `userPasswordSecretRef` steps are identical. This section covers only what's different for HA.
+
+k0s is the fully-supported HA distribution. k3s HA bring-up works the same way, but replacing a k3s control-plane node afterward leaves an orphaned etcd member requiring manual cleanup — see [README.md § High-Availability control planes](../README.md#high-availability-control-planes) for the full day-2 explanation (KD-5d).
+
+### HA prerequisites
+
+In addition to the [single-node prerequisites](#prerequisites):
+
+1. **A free VIP address.** Reserve an IP on the control-plane nodes' subnet that is outside any DHCP range and not otherwise in use. This is the kube-vip virtual IP — the stable API endpoint the cluster (and every kubeconfig) will target.
+2. **The NIC name on your Kairos template.** kube-vip advertises the VIP on a specific interface (ARP mode broadcasts on that NIC). Boot a VM from your Hadron/Kairos template and run `ip link` to confirm the interface name (commonly `ens192` on vSphere with the `e1000`/`vmxnet3` adapter types used in this guide).
+3. **A flat L2 subnet for the default `ARP` mode.** All three control-plane nodes and the VIP must share an L2 segment so ARP-based failover works. If your fabric is routed instead, use `mode: BGP` and configure BGP peering separately — this guide covers ARP only.
+
+### Customizing the HA sample
+
+Open `config/samples/capv/kairos_cluster_k0s_ha.yaml` and fill in the `TODO` placeholders, same pattern as the single-node sample (see [Step 3](#step-3-customize-the-manifest) above), plus these HA-specific fields:
+
+```yaml
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+spec:
+  controlPlaneEndpoint:
+    host: "192.168.1.50"   # the VIP address; MUST equal spec.ha.vip.address below
+    port: 6443
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: KairosControlPlane
+spec:
+  replicas: 3               # 3 or 5 only — odd counts for etcd quorum
+  ha:
+    vip:
+      address: "192.168.1.50"   # must equal Cluster.spec.controlPlaneEndpoint.host
+      interface: "ens192"       # NIC name from `ip link` on your template
+      mode: ARP                 # ARP for a flat L2 subnet (default)
+```
+
+`Cluster.spec.controlPlaneEndpoint.host` and `KairosControlPlane.spec.ha.vip.address` must match exactly. The webhook does not enforce this cross-object constraint — a mismatch will not be rejected, but the cluster endpoint will point at the wrong address and the workload kubeconfig will not reach a floating VIP.
+
+### Apply and verify
+
+```bash
+kubectl apply -f config/samples/capv/kairos_cluster_k0s_ha.yaml
+```
+
+Watch the control plane come up:
+
+```bash
+kubectl get kairoscontrolplane kairos-control-plane -w
+```
+
+HA comes up successfully when:
+
+```bash
+kubectl get kairoscontrolplane kairos-control-plane \
+  -o jsonpath='{.status.readyReplicas}/{.status.replicas}'
+# expect: 3/3
+```
+
+Check the `EtcdHealthy` condition — it should be `True` once all three etcd members are healthy and voting:
+
+```bash
+kubectl get kairoscontrolplane kairos-control-plane -o yaml | grep -A4 "type: EtcdHealthy"
+```
+
+Confirm the VIP is reachable and answers the Kubernetes API:
+
+```bash
+curl -k https://192.168.1.50:6443/livez
+```
+
+Retrieve the kubeconfig (same node-push path as single-node) and confirm all three nodes registered:
+
+```bash
+kubectl get secret kairos-cluster-kubeconfig \
+  -o jsonpath='{.data.value}' | base64 -d > kairos-kubeconfig.yaml
+kubectl --kubeconfig=kairos-kubeconfig.yaml get nodes
+```
+
+### HA troubleshooting
+
+| Symptom | Cause | Action |
+|---|---|---|
+| `KairosControlPlane` create is rejected with a message about `spec.replicas` | Even replica count or a value above 5 | Use `1`, `3`, or `5`. Even counts give the same etcd fault tolerance as the next-lower odd count while raising the quorum requirement — always round up to the next odd number. |
+| Admission succeeds but returns a warning about `spec.ha.vip` | `spec.ha.vip` is set while `spec.replicas` is `1` | kube-vip is not rendered for single-node control planes. Either remove `spec.ha.vip` or set `replicas` to `3`/`5`. |
+| `EtcdHealthy` condition is `False(Info)` with an "at risk" or degraded reason | One or more control-plane nodes have not yet reported healthy etcd membership, or a member is down | Check `kubectl describe kairoscontrolplane` Events and confirm all three Machines are `Running`. Transient during bring-up; investigate if it persists past a few minutes once all Machines are `Ready`. |
+| VIP does not respond, but all three nodes are `Ready` | `spec.ha.vip.interface` does not match the node's actual NIC name, or the nodes are not on a shared L2 segment (ARP mode) | Re-verify the interface name with `ip link` on a live node. For routed fabrics, use `mode: BGP` with correct peering instead of `ARP`. |
+| Deleting/replacing a control-plane Machine is refused or stalls | The quorum-safe delete guard is blocking a delete that would drop etcd below `(N/2)+1` healthy members | Do not force it. Wait for a degraded member to recover, or scale up before scaling down. Check the `EtcdHealthy` condition and Events for the specific blocking reason. |
+| A k3s control-plane replacement leaves an extra etcd member registered | Expected k3s limitation (KD-5d) — k3s embedded etcd has no supported clean member-remove | Run `etcdctl member remove` manually against the embedded etcd. Watch for the `EtcdMemberRemoveUnsupportedForK3s` warning event. Prefer k0s for HA if you need automatic clean removal. |
+| A k0s node is deleted but its etcd member is still registered | The node never acknowledged its `k0s etcd leave` request within the ~5-minute timeout | Watch for the `EtcdMemberLeaveTimedOut` warning event; remove the member manually with `k0s etcdctl member remove` if it fires. The delete itself was already quorum-safe. |
+
 ## Field Reference
 
 ### Required Fields to Customize
@@ -383,7 +474,7 @@ If `KairosConfig.status.failureMessage` is set, the issue is transient — it cl
 
 - Configure additional worker nodes via `MachineDeployment`.
 - Add custom Kubernetes manifests via `spec.manifests` in `KairosConfigTemplate`.
-- Multi-node control planes are tracked for a future release (KD-5b / KD-25).
+- For a highly-available control plane, see [High-Availability: 3-node k0s control plane](#high-availability-3-node-k0s-control-plane) above.
 
 ## Air-gapped fallback (SSHFallback)
 
@@ -491,3 +582,5 @@ kubectl get events -n <cluster-namespace> \
 kubectl delete -f config/samples/capv/kairos_cluster_k0s_single_node.yaml
 # Note: This deletes VMs in vSphere.
 ```
+
+For the HA sample: `kubectl delete -f config/samples/capv/kairos_cluster_k0s_ha.yaml`. Deletion is quorum-safe — the controller drains control-plane Machines one at a time and will not proceed past the point where etcd quorum would break; expect cluster teardown to take longer than the single-node case.

--- a/docs/release-notes/v0.1.0-alpha.3.md
+++ b/docs/release-notes/v0.1.0-alpha.3.md
@@ -1,0 +1,151 @@
+# v0.1.0-alpha.3 — Release Notes
+
+> **Version number is provisional.** This entry is written ahead of tagging;
+> confirm the actual release tag matches `v0.1.0-alpha.3` before publishing,
+> and update this header if the tag differs.
+
+This is a pre-release. The API surface, defaults, and on-disk layout may
+change before v0.1.0 ships.
+
+Read the [upgrade guide](../UPGRADING.md) before installing. If you are
+upgrading from v0.1.0-alpha.2, review the breaking-changes section below.
+
+---
+
+## Breaking Changes
+
+### `KairosControlPlane.spec.replicas` validation changed
+
+`spec.replicas` now accepts `1`, `3`, or `5` (previously only `1` was
+accepted; any value greater than 1 was rejected outright). The validating
+webhook now rejects:
+
+- Even counts (`2`, `4`, ...) — an even count gives the same etcd fault
+  tolerance as the next-lower odd count while raising the quorum
+  requirement, so it is always worse than the corresponding odd count.
+- Values above `5` — beyond 5 etcd members the quorum cost outweighs the
+  additional fault tolerance for a control plane.
+
+This is not expected to break existing `replicas: 1` deployments. It does
+change the shape of the admission error for anyone who was already
+attempting `replicas: 2` or higher and depending on the previous
+"rejected outright above 1" behavior in tooling.
+
+---
+
+## New Features
+
+### Highly-available control planes (ADR 0005, Phases 1-4)
+
+`KairosControlPlane.spec.replicas: 3` or `5` now provisions a multi-node k0s
+or k3s control plane with etcd quorum, instead of the single-node-only
+support in prior releases.
+
+**VIP-backed endpoint.** `KairosControlPlane.spec.ha.vip` configures a
+kube-vip virtual IP for CAPV, CAPM3, and CAPD clusters:
+
+```yaml
+spec:
+  replicas: 3
+  ha:
+    vip:
+      address: "192.168.1.50"   # must equal Cluster.spec.controlPlaneEndpoint.host
+      interface: "ens192"
+      mode: ARP                 # ARP (default) or BGP
+```
+
+The controller renders a kube-vip DaemonSet (one leader-elected Pod per
+control-plane node) into each node's bootstrap cloud-config, so the VIP
+fails over to a surviving node. **Do not set `spec.ha.vip` for CAPK** — CAPK
+provisions its own LoadBalancer Service and reflects its IP into the
+control-plane endpoint; a VIP alongside it produces a conflicting ARP
+announcement.
+
+**Etcd health surfaced as a condition.** Each control-plane node reports its
+own etcd member health; the controller surfaces this as the new
+`EtcdHealthy` condition on `KairosControlPlane` (`True` when all desired
+voting members are healthy; `False(Info)` when quorum holds but a member is
+degraded; `False(Warning)` at or below the `(N/2)+1` quorum minimum).
+
+**Quorum-safe replacement.** The controller refuses a rollout or scale-down
+delete that would drop etcd below `(N/2)+1` healthy voting members.
+
+**Clean etcd member eviction (k0s).** On a k0s control-plane removal, a CAPI
+pre-terminate hook pauses termination after drain; the departing node runs
+`k0s etcd leave` in response to a controller-written sentinel, and
+acknowledges once it has left. Only then does the controller let the delete
+finish — no orphaned etcd member on k0s.
+
+New sample: [`config/samples/capv/kairos_cluster_k0s_ha.yaml`](../../config/samples/capv/kairos_cluster_k0s_ha.yaml).
+New quickstart section: [QUICKSTART_CAPV.md § High-Availability](../QUICKSTART_CAPV.md#high-availability-3-node-k0s-control-plane).
+
+---
+
+## Known Limitations
+
+### k3s HA control-plane replacement leaves an orphaned etcd member (KD-5d)
+
+k3s embedded etcd has no supported clean member-remove operation. Replacing
+or scaling down a k3s HA control-plane node leaves an orphaned etcd member
+after the Machine is deleted, requiring a manual `etcdctl member remove`
+against the embedded etcd. The controller emits an
+`EtcdMemberRemoveUnsupportedForK3s` warning event when this happens. The
+quorum-safety guard still protects k3s deletes — it just cannot clean up the
+member afterward. **k0s is the fully-supported HA distribution;** k3s HA
+bring-up works, but plan for manual etcd cleanup on every control-plane
+replacement.
+
+### Etcd-leave timeout can leave a k0s member registered
+
+A stuck or unreachable k0s node that never acknowledges its leave request
+within roughly 5 minutes is deleted anyway — the quorum-safety check already
+proved the delete was safe before the timeout started. Its etcd member may
+remain registered. Watch for the `EtcdMemberLeaveTimedOut` warning event and
+remove the member manually if it fires.
+
+### HA etcd health/leave signals are node-self-reported and forgeable (KD-51)
+
+Both day-2 HA signal channels — the per-cluster etcd-status Secret and the
+workload `kube-system/kairos-etcd-leave` ConfigMap leave acknowledgement —
+are written by control-plane nodes using vanilla RBAC on objects shared
+across the control plane. A compromised control-plane node can forge either
+signal.
+
+This is **not** a privilege escalation: a compromised control-plane node
+already holds cluster-admin-equivalent access. It also **cannot force an
+unsafe deletion** — the quorum-safety decision is made independently of, and
+before, any node signal is consulted. A forged signal can only self-downgrade
+the clean-leave/health guarantee (for example, an early or missed clean
+leave). Per-member-scoped signals are tracked as future hardening; no PR is
+scheduled yet.
+
+---
+
+## Security
+
+- See **KD-51** above — node-self-reported HA signals are forgeable by a
+  compromised control-plane node, bounded to a self-downgrade of the
+  clean-leave/health guarantee (no privilege escalation, no unsafe deletion).
+- `spec.ha.vip.address` and `spec.ha.vip.interface` are validated at
+  admission (IP/hostname shape, interface-name pattern) and are shell-quoted
+  at cloud-config render time before being written into the kube-vip
+  DaemonSet manifest.
+
+---
+
+## Compatibility
+
+No changes to the target-version table since v0.1.0-alpha.2. See
+[README.md § Target Versions](../../README.md#target-versions) for the
+current matrix.
+
+---
+
+## Upgrade Notes
+
+Existing `replicas: 1` control planes are unaffected — no action required.
+Operators who want to move an existing single-node cluster to HA should
+treat it as a new HA cluster (create `spec.ha.vip`, change `replicas` to `3`
+or `5`, and add the additional control-plane Machines) rather than expect an
+in-place single-node-to-HA conversion; that migration path is not yet
+validated end-to-end.

--- a/internal/bootstrap/golden_test.go
+++ b/internal/bootstrap/golden_test.go
@@ -99,13 +99,13 @@ func goldenCases() []goldenCase {
 		{"k0s_capk_single", RenderK0sCloudConfig, base(bootstrapv1beta2.ControlPlaneRoleSingle, true, true, false)},
 		{"k3s_capk_single", RenderK3sCloudConfig, base(bootstrapv1beta2.ControlPlaneRoleSingle, true, true, false)},
 
-		// --- init (HA first node, CAPV: kube-vip rendered) ---
-		{"k0s_capv_init", RenderK0sCloudConfig, withJoinTokenSecretName(withEndpoint(withVIP(base(bootstrapv1beta2.ControlPlaneRoleInit, false, false, false)), "192.168.1.240"), "ha-cluster-control-plane-join-token")},
-		{"k3s_capv_init", RenderK3sCloudConfig, withEndpoint(withVIP(base(bootstrapv1beta2.ControlPlaneRoleInit, false, false, false)), "192.168.1.240")},
+		// --- init (HA first node, CAPV: kube-vip + etcd-health reporter rendered) ---
+		{"k0s_capv_init", RenderK0sCloudConfig, withEtcdStatusSecretName(withJoinTokenSecretName(withEndpoint(withVIP(base(bootstrapv1beta2.ControlPlaneRoleInit, false, false, false)), "192.168.1.240"), "ha-cluster-control-plane-join-token"), "ha-cluster-etcd-status")},
+		{"k3s_capv_init", RenderK3sCloudConfig, withEtcdStatusSecretName(withEndpoint(withVIP(base(bootstrapv1beta2.ControlPlaneRoleInit, false, false, false)), "192.168.1.240"), "ha-cluster-etcd-status")},
 
-		// --- join (HA subsequent node, CAPV: kube-vip rendered) ---
-		{"k0s_capv_join", RenderK0sCloudConfig, withJoinToken(withEndpoint(withVIP(base(bootstrapv1beta2.ControlPlaneRoleJoin, false, false, false)), "192.168.1.240"))},
-		{"k3s_capv_join", RenderK3sCloudConfig, withJoinToken(withEndpoint(withVIP(base(bootstrapv1beta2.ControlPlaneRoleJoin, false, false, false)), "192.168.1.240"))},
+		// --- join (HA subsequent node, CAPV: kube-vip + etcd-health reporter rendered) ---
+		{"k0s_capv_join", RenderK0sCloudConfig, withEtcdStatusSecretName(withJoinToken(withEndpoint(withVIP(base(bootstrapv1beta2.ControlPlaneRoleJoin, false, false, false)), "192.168.1.240")), "ha-cluster-etcd-status")},
+		{"k3s_capv_join", RenderK3sCloudConfig, withEtcdStatusSecretName(withJoinToken(withEndpoint(withVIP(base(bootstrapv1beta2.ControlPlaneRoleJoin, false, false, false)), "192.168.1.240")), "ha-cluster-etcd-status")},
 
 		// --- CAPK HA (NO kube-vip; OQ-5): init/join still branch, LB Service is the endpoint ---
 		{"k0s_capk_init", RenderK0sCloudConfig, withJoinTokenSecretName(capkHA(base(bootstrapv1beta2.ControlPlaneRoleInit, false, true, false)), "ha-cluster-control-plane-join-token")},
@@ -126,6 +126,16 @@ func withJoinToken(d TemplateData) TemplateData {
 // exercise that highest-blast-radius block. Requires ManagementEndpoint set.
 func withJoinTokenSecretName(d TemplateData, name string) TemplateData {
 	d.ManagementEndpoint.JoinTokenSecretName = name
+	return d
+}
+
+// withEtcdStatusSecretName stamps the HA etcd-health reporter gate
+// (ManagementEndpoint.EtcdStatusSecretName, ADR 0005 §E.1). Set for every HA
+// control-plane node (init AND join, both distros) on the CAPV path so the
+// golden snapshots exercise the node-push reporter block. Requires
+// ManagementEndpoint set.
+func withEtcdStatusSecretName(d TemplateData, name string) TemplateData {
+	d.ManagementEndpoint.EtcdStatusSecretName = name
 	return d
 }
 

--- a/internal/bootstrap/ha_test.go
+++ b/internal/bootstrap/ha_test.go
@@ -668,13 +668,24 @@ func TestHA_RenderedScriptsValidBash(t *testing.T) {
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			out, err := tc.render(haCPData(tc.role, tc.kv))
+			d := haCPData(tc.role, tc.kv)
+			// CAPV HA nodes render the etcd-health reporter (ADR 0005 §E.1); set
+			// the gate so its shell body is included in the bash -n syntax check.
+			// CAPK (kubevirt) does not render it.
+			if !tc.kv && d.ManagementEndpoint != nil {
+				d.ManagementEndpoint.EtcdStatusSecretName = "ha-cluster-etcd-status"
+			}
+			out, err := tc.render(d)
 			if err != nil {
 				t.Fatalf("render: %v", err)
 			}
 			script := extractWriteFile(t, out, tc.script)
 			if script == "" {
 				t.Fatalf("post-bootstrap script %q not found", tc.script)
+			}
+			// The etcd-health reporter must render on the CAPV path (and only there).
+			if hasReporter := strings.Contains(script, "push_etcd_status"); hasReporter != !tc.kv {
+				t.Errorf("etcd-health reporter present=%v, want %v (CAPV renders it, CAPK does not)", hasReporter, !tc.kv)
 			}
 			f := filepathJoinTemp(t, strings.ReplaceAll(tc.name, "/", "_")+".sh")
 			if err := os.WriteFile(f, []byte(script), 0o600); err != nil {

--- a/internal/bootstrap/ha_test.go
+++ b/internal/bootstrap/ha_test.go
@@ -697,3 +697,59 @@ func TestHA_RenderedScriptsValidBash(t *testing.T) {
 		})
 	}
 }
+
+// TestHA_EtcdLeaveResponder_k0sOnly asserts the ADR 0005 §E.3 etcd-leave
+// responder renders on k0s CAPV HA nodes (valid bash; gates on the fixed
+// leave-requested sentinel via string equality; runs `k0s etcd leave` with NO
+// externally-supplied argument), and does NOT render for k0s single-node or for
+// k3s (no clean member-remove, KD-5d).
+func TestHA_EtcdLeaveResponder_k0sOnly(t *testing.T) {
+	bashPath, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not available; skipping rendered-script syntax check")
+	}
+	out, err := RenderK0sCloudConfig(haCPData("init", false))
+	if err != nil {
+		t.Fatalf("render k0s init: %v", err)
+	}
+	script := extractWriteFile(t, out, "kairos-etcd-leave.sh")
+	if script == "" {
+		t.Fatal("k0s HA control-plane must render the etcd-leave responder script")
+	}
+	if !strings.Contains(script, `[ "${val}" = "leave-requested" ]`) {
+		t.Error("leave script must gate on the fixed sentinel via string equality (security constraint #4)")
+	}
+	if !strings.Contains(script, "k0s etcd leave") {
+		t.Error("leave script must run `k0s etcd leave`")
+	}
+	if strings.Contains(script, "etcd leave --peer-address") {
+		t.Error("leave script must NOT pass --peer-address (node leaves itself; no external arg — security constraint #5)")
+	}
+	f := filepathJoinTemp(t, "k0s-etcd-leave.sh")
+	if werr := os.WriteFile(f, []byte(script), 0o600); werr != nil {
+		t.Fatalf("write temp script: %v", werr)
+	}
+	if b, berr := exec.Command(bashPath, "-n", f).CombinedOutput(); berr != nil {
+		t.Fatalf("etcd-leave script is not valid bash: %v\n%s", berr, b)
+	}
+
+	// k0s single-node must NOT render it (no etcd quorum).
+	single := haCPData("single", false)
+	single.SingleNode = true
+	sout, err := RenderK0sCloudConfig(single)
+	if err != nil {
+		t.Fatalf("render k0s single: %v", err)
+	}
+	if extractWriteFile(t, sout, "kairos-etcd-leave.sh") != "" {
+		t.Error("k0s single-node must NOT render the etcd-leave responder")
+	}
+
+	// k3s HA must NOT render it (KD-5d: no clean member-remove).
+	kout, err := RenderK3sCloudConfig(haCPData("init", false))
+	if err != nil {
+		t.Fatalf("render k3s init: %v", err)
+	}
+	if extractWriteFile(t, kout, "kairos-etcd-leave.sh") != "" {
+		t.Error("k3s must NOT render the etcd-leave responder (KD-5d)")
+	}
+}

--- a/internal/bootstrap/template.go
+++ b/internal/bootstrap/template.go
@@ -161,6 +161,16 @@ type ManagementEndpoint struct {
 	// through text/template. Only meaningful for k0s init; k3s uses a
 	// controller-generated token and never runs this block.
 	JoinTokenSecretName string
+	// EtcdStatusSecretName, when non-empty, enables the etcd-health reporter
+	// block (ADR 0005 §E.1): every HA control-plane node (init AND join) reports
+	// its own etcd member health into this per-cluster Secret over the same
+	// node-push channel as the kubeconfig/join-token. The Secret lives in
+	// KubeconfigSecretNamespace, is pre-created empty + Cluster-owned by the KCP
+	// controller, and each node PATCHes only its own member key. etcd membership
+	// is non-sensitive cluster metadata (no secret material) but is still never
+	// interpolated through text/template — the reporter builds the JSON on-node.
+	// Set for init+join (both distros); empty for single-node and workers.
+	EtcdStatusSecretName string
 }
 
 // InstallConfig holds installation configuration for the template

--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
@@ -273,9 +273,84 @@ write_files:
       # this helper runs once multi-user.target is set up and triggers
       # both enablement and immediate start of the post-bootstrap service.
       ExecStart=/bin/systemctl enable --now kairos-k0s-post-bootstrap.service
+      {{- if .IsHAControlPlane }}
+      # ADR 0005 §E.3: on HA control-plane nodes, also enable the etcd-leave
+      # responder timer so the node can cleanly `k0s etcd leave` when the
+      # controller requests it during a quorum-safe replacement/scale-down.
+      ExecStart=/bin/systemctl enable --now kairos-etcd-leave.timer
+      {{- end }}
 
       [Install]
       WantedBy=multi-user.target
+  {{- if .IsHAControlPlane }}
+  # ADR 0005 §E.3 (HA) k0s etcd-leave responder. During a quorum-safe
+  # replacement/scale-down the controller (a) sets a CAPI pre-terminate hook on
+  # this Machine and (b) writes a `leave-requested` sentinel for this member into
+  # the workload-cluster kube-system/kairos-etcd-leave ConfigMap. This node-local
+  # timer polls that ConfigMap via the LOCAL admin.conf (no mgmt token — the
+  # node's mgmt bearer token is only valid ~24h, but replacement happens much
+  # later; the local kubeconfig never expires), and on the exact sentinel runs
+  # `k0s etcd leave` (which leaves THIS node — no operator/ConfigMap value is
+  # ever passed as a command argument), then acks `left`. The controller then
+  # clears the pre-terminate hook and CAPI terminates the VM.
+  - path: /usr/local/bin/kairos-etcd-leave.sh
+    permissions: "0755"
+    owner: root
+    group: root
+    content: |
+      #!/bin/bash
+      set -euo pipefail
+      # This member's key == the sanitized hostname, identical to the reporter's
+      # key so it matches what the controller writes.
+      member_key=$(hostname | tr -c 'a-zA-Z0-9._-' '-')
+      # Read our own leave signal from the workload ConfigMap via the LOCAL admin
+      # kubeconfig (k0s kubectl). Absent ConfigMap/key => empty => no-op exit.
+      val=$(k0s kubectl -n kube-system get configmap kairos-etcd-leave -o "jsonpath={.data.${member_key}}" 2>/dev/null || true)
+      # Fixed sentinel, string-equality only — never eval'd, never a command arg.
+      [ "${val}" = "leave-requested" ] || exit 0
+      echo "etcd-leave: leave requested for ${member_key}; leaving etcd cluster"
+      # `k0s etcd leave` (no --peer-address) leaves THIS node using its own
+      # configured peer address — no ConfigMap/operator-derived value reaches the
+      # command (security constraint: peer-address is never externally supplied).
+      if k0s etcd leave 2>/dev/null; then
+        echo "etcd-leave: left etcd cluster"
+      else
+        echo "etcd-leave: k0s etcd leave returned non-zero (already left?); acking anyway"
+      fi
+      # Ack by patching our own key to `left`. Only member_key (locally
+      # sanitized) is interpolated; the read-back value is never reused.
+      k0s kubectl -n kube-system patch configmap kairos-etcd-leave --type merge \
+        -p "{\"data\":{\"${member_key}\":\"left\"}}" 2>/dev/null || true
+  - path: /etc/systemd/system/kairos-etcd-leave.service
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      [Unit]
+      Description=Kairos k0s etcd-leave responder (ADR 0005 §E.3)
+      ConditionKernelCommandLine=!cdroot
+      After=k0s.service
+      Wants=k0s.service
+
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/local/bin/kairos-etcd-leave.sh
+  - path: /etc/systemd/system/kairos-etcd-leave.timer
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      [Unit]
+      Description=Poll for Kairos k0s etcd-leave requests (ADR 0005 §E.3)
+      ConditionKernelCommandLine=!cdroot
+
+      [Timer]
+      OnBootSec=60
+      OnUnitActiveSec=30
+
+      [Install]
+      WantedBy=timers.target
+  {{- end }}
   - path: /usr/local/bin/kairos-k0s-post-bootstrap.sh
     permissions: "0755"
     owner: root

--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
@@ -682,6 +682,80 @@ MANIFEST_EOF
       fi
       {{- end }}
 
+      {{- if and .IsHAControlPlane .ManagementEndpoint .ManagementEndpoint.EtcdStatusSecretName }}
+      # ADR 0005 §E.1 (HA) etcd-health reporter: every control-plane node (init
+      # AND join) reports its own etcd member health into the per-cluster
+      # etcd-status Secret over the SAME node-push channel as the kubeconfig/join
+      # token (NOT SSH, NOT a controller etcd dial — KD-10). The controller reads
+      # it for the joiner gate (init must be a healthy voting member),
+      # EtcdHealthyCondition, and the quorum-safe-replacement guard.
+      #
+      # SECURITY: etcd membership (name/count) is non-sensitive cluster metadata —
+      # NO secret material is written into this Secret. The status JSON is built
+      # ON-NODE (never interpolated through text/template); every
+      # management-endpoint value is shquote'd; the bearer token is never logged.
+      # The node PATCHes ONLY its own member key (keyed by hostname).
+      push_etcd_status() {
+        if ! command -v curl >/dev/null 2>&1; then
+          echo "WARN: curl not available; cannot report etcd status"
+          return 1
+        fi
+        if ! command -v base64 >/dev/null 2>&1; then
+          echo "WARN: base64 not available; cannot report etcd status"
+          return 1
+        fi
+        # This member's Secret data key = the node hostname, sanitized to the
+        # allowed Secret-key charset [a-zA-Z0-9._-] so it is safe both as a
+        # Secret key and inside the strategic-merge patch JSON.
+        local member_key
+        member_key=$(hostname | tr -c 'a-zA-Z0-9._-' '-')
+        # Query k0s etcd membership. k0s controllers join as full voting members
+        # (no learners), so "present in member-list" == "healthy voting member".
+        local ml healthy=false voting=false members=0
+        ml=$(k0s etcd member-list 2>/dev/null || true)
+        if [ -n "${ml}" ]; then
+          healthy=true
+          voting=true
+          members=$(printf '%s' "${ml}" | grep -oE 'https?://' | wc -l | tr -d ' ')
+        fi
+        local reported_at
+        reported_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+        # Compact, non-secret status JSON for THIS member, built on-node.
+        local status_json
+        status_json=$(printf '{"name":"%s","healthy":%s,"voting":%s,"members":%s,"reportedAt":"%s"}' \
+          "${member_key}" "${healthy}" "${voting}" "${members}" "${reported_at}")
+        local status_b64
+        status_b64=$(printf '%s' "${status_json}" | base64 -w 0 2>/dev/null || printf '%s' "${status_json}" | base64 | tr -d '\n')
+        local api={{ .ManagementEndpoint.APIServer | shquote }}
+        local ns={{ .ManagementEndpoint.KubeconfigSecretNamespace | shquote }}
+        local es_name={{ .ManagementEndpoint.EtcdStatusSecretName | shquote }}
+        local token={{ .ManagementEndpoint.Token | shquote }}
+        # Strategic-merge PATCH only this member's own data key in the pre-created,
+        # Cluster-owned etcd-status Secret. update/patch on the named Secret is
+        # exactly the node SA's RBAC (no create).
+        local patch
+        patch="{\"data\":{\"${member_key}\":\"${status_b64}\"}}"
+        local url="${api}/api/v1/namespaces/${ns}/secrets/${es_name}"
+        local status
+        status=$(curl -k -sS -o /tmp/kairos-etcdstatus-push.log -w "%{http_code}" \
+          -H "Authorization: Bearer ${token}" \
+          -H "Content-Type: application/strategic-merge-patch+json" \
+          -X PATCH \
+          --data "${patch}" \
+          "${url}" || true)
+        unset token
+        if [ "${status}" -ge 200 ] && [ "${status}" -lt 300 ]; then
+          echo "Reported etcd status to management secret ${ns}/${es_name} (member ${member_key})"
+          return 0
+        fi
+        echo "WARN: failed to report etcd status (status ${status})"
+        return 1
+      }
+      if ! push_etcd_status; then
+        echo "WARN: etcd-status report failed; will retry on next boot"
+      fi
+      {{- end }}
+
       # Mark bootstrap success for CAPI/CAPK consumers
       # This file is used by Cluster API to determine bootstrap completion
       mkdir -p /run/cluster-api

--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
@@ -306,9 +306,22 @@ write_files:
       # complement-translate, or it becomes a spurious trailing '-' that no
       # longer matches NodeRef.Name.
       member_key=$(hostname | tr -d '\n' | tr -c 'a-zA-Z0-9._-' '-')
-      # Read our own leave signal from the workload ConfigMap via the LOCAL admin
-      # kubeconfig (k0s kubectl). Absent ConfigMap/key => empty => no-op exit.
-      val=$(k0s kubectl -n kube-system get configmap kairos-etcd-leave -o "jsonpath={.data.${member_key}}" 2>/dev/null || true)
+      # Target the control-plane VIP, NOT this node's local apiserver: `k0s etcd
+      # leave` (below) drops THIS node's local apiserver (it loses its etcd
+      # backend), so a localhost read/ack would fail post-leave and never retry.
+      # The VIP is always fronted by a surviving node, so both the sentinel read
+      # and the `left` ack keep working across the timer's poll cycles until the
+      # ack lands. VIP.Address is render-validated (VIP-INV-3) + shquoted
+      # (VIP-INV-1); it is a --server flag value, never eval'd.
+      {{- if .VIP }}
+      vip_addr={{ .VIP.Address | shquote }}
+      srv=(--server="https://${vip_addr}:6443")
+      {{- else }}
+      srv=()
+      {{- end }}
+      # Read our own leave signal from the workload ConfigMap via the VIP.
+      # Absent ConfigMap/key => empty => no-op exit.
+      val=$(k0s kubectl "${srv[@]}" -n kube-system get configmap kairos-etcd-leave -o "jsonpath={.data.${member_key}}" 2>/dev/null || true)
       # Fixed sentinel, string-equality only — never eval'd, never a command arg.
       [ "${val}" = "leave-requested" ] || exit 0
       echo "etcd-leave: leave requested for ${member_key}; leaving etcd cluster"
@@ -320,9 +333,10 @@ write_files:
       else
         echo "etcd-leave: k0s etcd leave returned non-zero (already left?); acking anyway"
       fi
-      # Ack by patching our own key to `left`. Only member_key (locally
-      # sanitized) is interpolated; the read-back value is never reused.
-      k0s kubectl -n kube-system patch configmap kairos-etcd-leave --type merge \
+      # Ack by patching our own key to `left` via the VIP (the local apiserver is
+      # gone now). Only member_key (locally sanitized) is interpolated; the
+      # read-back value is never reused.
+      k0s kubectl "${srv[@]}" -n kube-system patch configmap kairos-etcd-leave --type merge \
         -p "{\"data\":{\"${member_key}\":\"left\"}}" 2>/dev/null || true
   - path: /etc/systemd/system/kairos-etcd-leave.service
     permissions: "0644"

--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
@@ -301,8 +301,11 @@ write_files:
       #!/bin/bash
       set -euo pipefail
       # This member's key == the sanitized hostname, identical to the reporter's
-      # key so it matches what the controller writes.
-      member_key=$(hostname | tr -c 'a-zA-Z0-9._-' '-')
+      # key so it matches what the controller writes (the node's Kubernetes Node
+      # name == NodeRef.Name). Strip hostname's trailing newline BEFORE the
+      # complement-translate, or it becomes a spurious trailing '-' that no
+      # longer matches NodeRef.Name.
+      member_key=$(hostname | tr -d '\n' | tr -c 'a-zA-Z0-9._-' '-')
       # Read our own leave signal from the workload ConfigMap via the LOCAL admin
       # kubeconfig (k0s kubectl). Absent ConfigMap/key => empty => no-op exit.
       val=$(k0s kubectl -n kube-system get configmap kairos-etcd-leave -o "jsonpath={.data.${member_key}}" 2>/dev/null || true)
@@ -783,7 +786,10 @@ MANIFEST_EOF
         # allowed Secret-key charset [a-zA-Z0-9._-] so it is safe both as a
         # Secret key and inside the strategic-merge patch JSON.
         local member_key
-        member_key=$(hostname | tr -c 'a-zA-Z0-9._-' '-')
+        # Strip hostname's trailing newline BEFORE the complement-translate, or
+        # it becomes a spurious trailing '-'; the key must equal the node's
+        # Kubernetes Node name (NodeRef.Name) that the controller looks up.
+        member_key=$(hostname | tr -d '\n' | tr -c 'a-zA-Z0-9._-' '-')
         # Query k0s etcd membership. k0s controllers join as full voting members
         # (no learners), so "present in member-list" == "healthy voting member".
         local ml healthy=false voting=false members=0

--- a/internal/bootstrap/templates/k3s_kairos_cloud_config_capv.yaml.tmpl
+++ b/internal/bootstrap/templates/k3s_kairos_cloud_config_capv.yaml.tmpl
@@ -559,6 +559,80 @@ MANIFEST_EOF
       fi
       {{- end }}
 
+      {{- if and .IsHAControlPlane .ManagementEndpoint .ManagementEndpoint.EtcdStatusSecretName }}
+      # ADR 0005 §E.1 (HA) etcd-health reporter — k3s HEALTH-ONLY variant (KD-5d).
+      # Every k3s server reports its own membership into the per-cluster
+      # etcd-status Secret over the node-push channel, feeding the joiner gate,
+      # EtcdHealthyCondition, and the quorum guard. k3s embedded etcd has no clean
+      # member-remove CLI, so member REMOVAL is unsupported (documented KD-5d);
+      # this reporter is read-only + best-effort. Member count is queried via
+      # etcdctl against the local embedded etcd IF etcdctl + the server certs are
+      # present; otherwise it reports healthy from server readiness (the
+      # post-bootstrap script only reaches here after k3s is up) with members=0.
+      #
+      # SECURITY: identical discipline to the k0s reporter — non-secret metadata,
+      # JSON built on-node, all management-endpoint values shquote'd, bearer token
+      # never logged, PATCHes only this node's own member key.
+      push_etcd_status() {
+        if ! command -v curl >/dev/null 2>&1; then
+          echo "WARN: curl not available; cannot report etcd status"
+          return 1
+        fi
+        if ! command -v base64 >/dev/null 2>&1; then
+          echo "WARN: base64 not available; cannot report etcd status"
+          return 1
+        fi
+        local member_key
+        member_key=$(hostname | tr -c 'a-zA-Z0-9._-' '-')
+        # Best-effort member count via etcdctl against the local embedded etcd.
+        local healthy=true voting=true members=0
+        local etcd_dir=/var/lib/rancher/k3s/server/tls/etcd
+        if command -v etcdctl >/dev/null 2>&1 && [ -f "${etcd_dir}/server-client.crt" ]; then
+          local ml
+          ml=$(ETCDCTL_API=3 etcdctl \
+            --endpoints=https://127.0.0.1:2379 \
+            --cacert="${etcd_dir}/server-ca.crt" \
+            --cert="${etcd_dir}/server-client.crt" \
+            --key="${etcd_dir}/server-client.key" \
+            member list 2>/dev/null || true)
+          if [ -n "${ml}" ]; then
+            members=$(printf '%s\n' "${ml}" | grep -c 'started' | tr -d ' ')
+          fi
+        fi
+        local reported_at
+        reported_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+        local status_json
+        status_json=$(printf '{"name":"%s","healthy":%s,"voting":%s,"members":%s,"reportedAt":"%s"}' \
+          "${member_key}" "${healthy}" "${voting}" "${members}" "${reported_at}")
+        local status_b64
+        status_b64=$(printf '%s' "${status_json}" | base64 -w 0 2>/dev/null || printf '%s' "${status_json}" | base64 | tr -d '\n')
+        local api={{ .ManagementEndpoint.APIServer | shquote }}
+        local ns={{ .ManagementEndpoint.KubeconfigSecretNamespace | shquote }}
+        local es_name={{ .ManagementEndpoint.EtcdStatusSecretName | shquote }}
+        local token={{ .ManagementEndpoint.Token | shquote }}
+        local patch
+        patch="{\"data\":{\"${member_key}\":\"${status_b64}\"}}"
+        local url="${api}/api/v1/namespaces/${ns}/secrets/${es_name}"
+        local status
+        status=$(curl -k -sS -o /tmp/kairos-etcdstatus-push.log -w "%{http_code}" \
+          -H "Authorization: Bearer ${token}" \
+          -H "Content-Type: application/strategic-merge-patch+json" \
+          -X PATCH \
+          --data "${patch}" \
+          "${url}" || true)
+        unset token
+        if [ "${status}" -ge 200 ] && [ "${status}" -lt 300 ]; then
+          echo "Reported etcd status to management secret ${ns}/${es_name} (member ${member_key})"
+          return 0
+        fi
+        echo "WARN: failed to report etcd status (status ${status})"
+        return 1
+      }
+      if ! push_etcd_status; then
+        echo "WARN: etcd-status report failed; will retry on next boot"
+      fi
+      {{- end }}
+
       # Mark bootstrap success for CAPI/CAPK consumers
       mkdir -p /run/cluster-api
       echo "success" > /run/cluster-api/bootstrap-success.complete

--- a/internal/bootstrap/testdata/golden/k0s_capv_init.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capv_init.yaml
@@ -261,8 +261,11 @@ write_files:
       #!/bin/bash
       set -euo pipefail
       # This member's key == the sanitized hostname, identical to the reporter's
-      # key so it matches what the controller writes.
-      member_key=$(hostname | tr -c 'a-zA-Z0-9._-' '-')
+      # key so it matches what the controller writes (the node's Kubernetes Node
+      # name == NodeRef.Name). Strip hostname's trailing newline BEFORE the
+      # complement-translate, or it becomes a spurious trailing '-' that no
+      # longer matches NodeRef.Name.
+      member_key=$(hostname | tr -d '\n' | tr -c 'a-zA-Z0-9._-' '-')
       # Read our own leave signal from the workload ConfigMap via the LOCAL admin
       # kubeconfig (k0s kubectl). Absent ConfigMap/key => empty => no-op exit.
       val=$(k0s kubectl -n kube-system get configmap kairos-etcd-leave -o "jsonpath={.data.${member_key}}" 2>/dev/null || true)
@@ -548,7 +551,10 @@ write_files:
         # allowed Secret-key charset [a-zA-Z0-9._-] so it is safe both as a
         # Secret key and inside the strategic-merge patch JSON.
         local member_key
-        member_key=$(hostname | tr -c 'a-zA-Z0-9._-' '-')
+        # Strip hostname's trailing newline BEFORE the complement-translate, or
+        # it becomes a spurious trailing '-'; the key must equal the node's
+        # Kubernetes Node name (NodeRef.Name) that the controller looks up.
+        member_key=$(hostname | tr -d '\n' | tr -c 'a-zA-Z0-9._-' '-')
         # Query k0s etcd membership. k0s controllers join as full voting members
         # (no learners), so "present in member-list" == "healthy voting member".
         local ml healthy=false voting=false members=0

--- a/internal/bootstrap/testdata/golden/k0s_capv_init.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capv_init.yaml
@@ -452,6 +452,77 @@ write_files:
       if ! push_join_token; then
         echo "WARN: controller-join token push failed; joiners will wait until it succeeds"
       fi
+      # ADR 0005 §E.1 (HA) etcd-health reporter: every control-plane node (init
+      # AND join) reports its own etcd member health into the per-cluster
+      # etcd-status Secret over the SAME node-push channel as the kubeconfig/join
+      # token (NOT SSH, NOT a controller etcd dial — KD-10). The controller reads
+      # it for the joiner gate (init must be a healthy voting member),
+      # EtcdHealthyCondition, and the quorum-safe-replacement guard.
+      #
+      # SECURITY: etcd membership (name/count) is non-sensitive cluster metadata —
+      # NO secret material is written into this Secret. The status JSON is built
+      # ON-NODE (never interpolated through text/template); every
+      # management-endpoint value is shquote'd; the bearer token is never logged.
+      # The node PATCHes ONLY its own member key (keyed by hostname).
+      push_etcd_status() {
+        if ! command -v curl >/dev/null 2>&1; then
+          echo "WARN: curl not available; cannot report etcd status"
+          return 1
+        fi
+        if ! command -v base64 >/dev/null 2>&1; then
+          echo "WARN: base64 not available; cannot report etcd status"
+          return 1
+        fi
+        # This member's Secret data key = the node hostname, sanitized to the
+        # allowed Secret-key charset [a-zA-Z0-9._-] so it is safe both as a
+        # Secret key and inside the strategic-merge patch JSON.
+        local member_key
+        member_key=$(hostname | tr -c 'a-zA-Z0-9._-' '-')
+        # Query k0s etcd membership. k0s controllers join as full voting members
+        # (no learners), so "present in member-list" == "healthy voting member".
+        local ml healthy=false voting=false members=0
+        ml=$(k0s etcd member-list 2>/dev/null || true)
+        if [ -n "${ml}" ]; then
+          healthy=true
+          voting=true
+          members=$(printf '%s' "${ml}" | grep -oE 'https?://' | wc -l | tr -d ' ')
+        fi
+        local reported_at
+        reported_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+        # Compact, non-secret status JSON for THIS member, built on-node.
+        local status_json
+        status_json=$(printf '{"name":"%s","healthy":%s,"voting":%s,"members":%s,"reportedAt":"%s"}' \
+          "${member_key}" "${healthy}" "${voting}" "${members}" "${reported_at}")
+        local status_b64
+        status_b64=$(printf '%s' "${status_json}" | base64 -w 0 2>/dev/null || printf '%s' "${status_json}" | base64 | tr -d '\n')
+        local api='https://mgmt.example.com:6443'
+        local ns='default'
+        local es_name='ha-cluster-etcd-status'
+        local token='mgmt-token'
+        # Strategic-merge PATCH only this member's own data key in the pre-created,
+        # Cluster-owned etcd-status Secret. update/patch on the named Secret is
+        # exactly the node SA's RBAC (no create).
+        local patch
+        patch="{\"data\":{\"${member_key}\":\"${status_b64}\"}}"
+        local url="${api}/api/v1/namespaces/${ns}/secrets/${es_name}"
+        local status
+        status=$(curl -k -sS -o /tmp/kairos-etcdstatus-push.log -w "%{http_code}" \
+          -H "Authorization: Bearer ${token}" \
+          -H "Content-Type: application/strategic-merge-patch+json" \
+          -X PATCH \
+          --data "${patch}" \
+          "${url}" || true)
+        unset token
+        if [ "${status}" -ge 200 ] && [ "${status}" -lt 300 ]; then
+          echo "Reported etcd status to management secret ${ns}/${es_name} (member ${member_key})"
+          return 0
+        fi
+        echo "WARN: failed to report etcd status (status ${status})"
+        return 1
+      }
+      if ! push_etcd_status; then
+        echo "WARN: etcd-status report failed; will retry on next boot"
+      fi
 
       # Mark bootstrap success for CAPI/CAPK consumers
       # This file is used by Cluster API to determine bootstrap completion

--- a/internal/bootstrap/testdata/golden/k0s_capv_init.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capv_init.yaml
@@ -236,9 +236,80 @@ write_files:
       # this helper runs once multi-user.target is set up and triggers
       # both enablement and immediate start of the post-bootstrap service.
       ExecStart=/bin/systemctl enable --now kairos-k0s-post-bootstrap.service
+      # ADR 0005 §E.3: on HA control-plane nodes, also enable the etcd-leave
+      # responder timer so the node can cleanly `k0s etcd leave` when the
+      # controller requests it during a quorum-safe replacement/scale-down.
+      ExecStart=/bin/systemctl enable --now kairos-etcd-leave.timer
 
       [Install]
       WantedBy=multi-user.target
+  # ADR 0005 §E.3 (HA) k0s etcd-leave responder. During a quorum-safe
+  # replacement/scale-down the controller (a) sets a CAPI pre-terminate hook on
+  # this Machine and (b) writes a `leave-requested` sentinel for this member into
+  # the workload-cluster kube-system/kairos-etcd-leave ConfigMap. This node-local
+  # timer polls that ConfigMap via the LOCAL admin.conf (no mgmt token — the
+  # node's mgmt bearer token is only valid ~24h, but replacement happens much
+  # later; the local kubeconfig never expires), and on the exact sentinel runs
+  # `k0s etcd leave` (which leaves THIS node — no operator/ConfigMap value is
+  # ever passed as a command argument), then acks `left`. The controller then
+  # clears the pre-terminate hook and CAPI terminates the VM.
+  - path: /usr/local/bin/kairos-etcd-leave.sh
+    permissions: "0755"
+    owner: root
+    group: root
+    content: |
+      #!/bin/bash
+      set -euo pipefail
+      # This member's key == the sanitized hostname, identical to the reporter's
+      # key so it matches what the controller writes.
+      member_key=$(hostname | tr -c 'a-zA-Z0-9._-' '-')
+      # Read our own leave signal from the workload ConfigMap via the LOCAL admin
+      # kubeconfig (k0s kubectl). Absent ConfigMap/key => empty => no-op exit.
+      val=$(k0s kubectl -n kube-system get configmap kairos-etcd-leave -o "jsonpath={.data.${member_key}}" 2>/dev/null || true)
+      # Fixed sentinel, string-equality only — never eval'd, never a command arg.
+      [ "${val}" = "leave-requested" ] || exit 0
+      echo "etcd-leave: leave requested for ${member_key}; leaving etcd cluster"
+      # `k0s etcd leave` (no --peer-address) leaves THIS node using its own
+      # configured peer address — no ConfigMap/operator-derived value reaches the
+      # command (security constraint: peer-address is never externally supplied).
+      if k0s etcd leave 2>/dev/null; then
+        echo "etcd-leave: left etcd cluster"
+      else
+        echo "etcd-leave: k0s etcd leave returned non-zero (already left?); acking anyway"
+      fi
+      # Ack by patching our own key to `left`. Only member_key (locally
+      # sanitized) is interpolated; the read-back value is never reused.
+      k0s kubectl -n kube-system patch configmap kairos-etcd-leave --type merge \
+        -p "{\"data\":{\"${member_key}\":\"left\"}}" 2>/dev/null || true
+  - path: /etc/systemd/system/kairos-etcd-leave.service
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      [Unit]
+      Description=Kairos k0s etcd-leave responder (ADR 0005 §E.3)
+      ConditionKernelCommandLine=!cdroot
+      After=k0s.service
+      Wants=k0s.service
+
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/local/bin/kairos-etcd-leave.sh
+  - path: /etc/systemd/system/kairos-etcd-leave.timer
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      [Unit]
+      Description=Poll for Kairos k0s etcd-leave requests (ADR 0005 §E.3)
+      ConditionKernelCommandLine=!cdroot
+
+      [Timer]
+      OnBootSec=60
+      OnUnitActiveSec=30
+
+      [Install]
+      WantedBy=timers.target
   - path: /usr/local/bin/kairos-k0s-post-bootstrap.sh
     permissions: "0755"
     owner: root

--- a/internal/bootstrap/testdata/golden/k0s_capv_init.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capv_init.yaml
@@ -266,9 +266,18 @@ write_files:
       # complement-translate, or it becomes a spurious trailing '-' that no
       # longer matches NodeRef.Name.
       member_key=$(hostname | tr -d '\n' | tr -c 'a-zA-Z0-9._-' '-')
-      # Read our own leave signal from the workload ConfigMap via the LOCAL admin
-      # kubeconfig (k0s kubectl). Absent ConfigMap/key => empty => no-op exit.
-      val=$(k0s kubectl -n kube-system get configmap kairos-etcd-leave -o "jsonpath={.data.${member_key}}" 2>/dev/null || true)
+      # Target the control-plane VIP, NOT this node's local apiserver: `k0s etcd
+      # leave` (below) drops THIS node's local apiserver (it loses its etcd
+      # backend), so a localhost read/ack would fail post-leave and never retry.
+      # The VIP is always fronted by a surviving node, so both the sentinel read
+      # and the `left` ack keep working across the timer's poll cycles until the
+      # ack lands. VIP.Address is render-validated (VIP-INV-3) + shquoted
+      # (VIP-INV-1); it is a --server flag value, never eval'd.
+      vip_addr='192.168.1.240'
+      srv=(--server="https://${vip_addr}:6443")
+      # Read our own leave signal from the workload ConfigMap via the VIP.
+      # Absent ConfigMap/key => empty => no-op exit.
+      val=$(k0s kubectl "${srv[@]}" -n kube-system get configmap kairos-etcd-leave -o "jsonpath={.data.${member_key}}" 2>/dev/null || true)
       # Fixed sentinel, string-equality only — never eval'd, never a command arg.
       [ "${val}" = "leave-requested" ] || exit 0
       echo "etcd-leave: leave requested for ${member_key}; leaving etcd cluster"
@@ -280,9 +289,10 @@ write_files:
       else
         echo "etcd-leave: k0s etcd leave returned non-zero (already left?); acking anyway"
       fi
-      # Ack by patching our own key to `left`. Only member_key (locally
-      # sanitized) is interpolated; the read-back value is never reused.
-      k0s kubectl -n kube-system patch configmap kairos-etcd-leave --type merge \
+      # Ack by patching our own key to `left` via the VIP (the local apiserver is
+      # gone now). Only member_key (locally sanitized) is interpolated; the
+      # read-back value is never reused.
+      k0s kubectl "${srv[@]}" -n kube-system patch configmap kairos-etcd-leave --type merge \
         -p "{\"data\":{\"${member_key}\":\"left\"}}" 2>/dev/null || true
   - path: /etc/systemd/system/kairos-etcd-leave.service
     permissions: "0644"

--- a/internal/bootstrap/testdata/golden/k0s_capv_join.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capv_join.yaml
@@ -264,8 +264,11 @@ write_files:
       #!/bin/bash
       set -euo pipefail
       # This member's key == the sanitized hostname, identical to the reporter's
-      # key so it matches what the controller writes.
-      member_key=$(hostname | tr -c 'a-zA-Z0-9._-' '-')
+      # key so it matches what the controller writes (the node's Kubernetes Node
+      # name == NodeRef.Name). Strip hostname's trailing newline BEFORE the
+      # complement-translate, or it becomes a spurious trailing '-' that no
+      # longer matches NodeRef.Name.
+      member_key=$(hostname | tr -d '\n' | tr -c 'a-zA-Z0-9._-' '-')
       # Read our own leave signal from the workload ConfigMap via the LOCAL admin
       # kubeconfig (k0s kubectl). Absent ConfigMap/key => empty => no-op exit.
       val=$(k0s kubectl -n kube-system get configmap kairos-etcd-leave -o "jsonpath={.data.${member_key}}" 2>/dev/null || true)
@@ -486,7 +489,10 @@ write_files:
         # allowed Secret-key charset [a-zA-Z0-9._-] so it is safe both as a
         # Secret key and inside the strategic-merge patch JSON.
         local member_key
-        member_key=$(hostname | tr -c 'a-zA-Z0-9._-' '-')
+        # Strip hostname's trailing newline BEFORE the complement-translate, or
+        # it becomes a spurious trailing '-'; the key must equal the node's
+        # Kubernetes Node name (NodeRef.Name) that the controller looks up.
+        member_key=$(hostname | tr -d '\n' | tr -c 'a-zA-Z0-9._-' '-')
         # Query k0s etcd membership. k0s controllers join as full voting members
         # (no learners), so "present in member-list" == "healthy voting member".
         local ml healthy=false voting=false members=0

--- a/internal/bootstrap/testdata/golden/k0s_capv_join.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capv_join.yaml
@@ -390,6 +390,77 @@ write_files:
       if ! push_kubeconfig; then
         echo "WARN: kubeconfig push failed; proceeding without blocking bootstrap"
       fi
+      # ADR 0005 §E.1 (HA) etcd-health reporter: every control-plane node (init
+      # AND join) reports its own etcd member health into the per-cluster
+      # etcd-status Secret over the SAME node-push channel as the kubeconfig/join
+      # token (NOT SSH, NOT a controller etcd dial — KD-10). The controller reads
+      # it for the joiner gate (init must be a healthy voting member),
+      # EtcdHealthyCondition, and the quorum-safe-replacement guard.
+      #
+      # SECURITY: etcd membership (name/count) is non-sensitive cluster metadata —
+      # NO secret material is written into this Secret. The status JSON is built
+      # ON-NODE (never interpolated through text/template); every
+      # management-endpoint value is shquote'd; the bearer token is never logged.
+      # The node PATCHes ONLY its own member key (keyed by hostname).
+      push_etcd_status() {
+        if ! command -v curl >/dev/null 2>&1; then
+          echo "WARN: curl not available; cannot report etcd status"
+          return 1
+        fi
+        if ! command -v base64 >/dev/null 2>&1; then
+          echo "WARN: base64 not available; cannot report etcd status"
+          return 1
+        fi
+        # This member's Secret data key = the node hostname, sanitized to the
+        # allowed Secret-key charset [a-zA-Z0-9._-] so it is safe both as a
+        # Secret key and inside the strategic-merge patch JSON.
+        local member_key
+        member_key=$(hostname | tr -c 'a-zA-Z0-9._-' '-')
+        # Query k0s etcd membership. k0s controllers join as full voting members
+        # (no learners), so "present in member-list" == "healthy voting member".
+        local ml healthy=false voting=false members=0
+        ml=$(k0s etcd member-list 2>/dev/null || true)
+        if [ -n "${ml}" ]; then
+          healthy=true
+          voting=true
+          members=$(printf '%s' "${ml}" | grep -oE 'https?://' | wc -l | tr -d ' ')
+        fi
+        local reported_at
+        reported_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+        # Compact, non-secret status JSON for THIS member, built on-node.
+        local status_json
+        status_json=$(printf '{"name":"%s","healthy":%s,"voting":%s,"members":%s,"reportedAt":"%s"}' \
+          "${member_key}" "${healthy}" "${voting}" "${members}" "${reported_at}")
+        local status_b64
+        status_b64=$(printf '%s' "${status_json}" | base64 -w 0 2>/dev/null || printf '%s' "${status_json}" | base64 | tr -d '\n')
+        local api='https://mgmt.example.com:6443'
+        local ns='default'
+        local es_name='ha-cluster-etcd-status'
+        local token='mgmt-token'
+        # Strategic-merge PATCH only this member's own data key in the pre-created,
+        # Cluster-owned etcd-status Secret. update/patch on the named Secret is
+        # exactly the node SA's RBAC (no create).
+        local patch
+        patch="{\"data\":{\"${member_key}\":\"${status_b64}\"}}"
+        local url="${api}/api/v1/namespaces/${ns}/secrets/${es_name}"
+        local status
+        status=$(curl -k -sS -o /tmp/kairos-etcdstatus-push.log -w "%{http_code}" \
+          -H "Authorization: Bearer ${token}" \
+          -H "Content-Type: application/strategic-merge-patch+json" \
+          -X PATCH \
+          --data "${patch}" \
+          "${url}" || true)
+        unset token
+        if [ "${status}" -ge 200 ] && [ "${status}" -lt 300 ]; then
+          echo "Reported etcd status to management secret ${ns}/${es_name} (member ${member_key})"
+          return 0
+        fi
+        echo "WARN: failed to report etcd status (status ${status})"
+        return 1
+      }
+      if ! push_etcd_status; then
+        echo "WARN: etcd-status report failed; will retry on next boot"
+      fi
 
       # Mark bootstrap success for CAPI/CAPK consumers
       # This file is used by Cluster API to determine bootstrap completion

--- a/internal/bootstrap/testdata/golden/k0s_capv_join.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capv_join.yaml
@@ -269,9 +269,18 @@ write_files:
       # complement-translate, or it becomes a spurious trailing '-' that no
       # longer matches NodeRef.Name.
       member_key=$(hostname | tr -d '\n' | tr -c 'a-zA-Z0-9._-' '-')
-      # Read our own leave signal from the workload ConfigMap via the LOCAL admin
-      # kubeconfig (k0s kubectl). Absent ConfigMap/key => empty => no-op exit.
-      val=$(k0s kubectl -n kube-system get configmap kairos-etcd-leave -o "jsonpath={.data.${member_key}}" 2>/dev/null || true)
+      # Target the control-plane VIP, NOT this node's local apiserver: `k0s etcd
+      # leave` (below) drops THIS node's local apiserver (it loses its etcd
+      # backend), so a localhost read/ack would fail post-leave and never retry.
+      # The VIP is always fronted by a surviving node, so both the sentinel read
+      # and the `left` ack keep working across the timer's poll cycles until the
+      # ack lands. VIP.Address is render-validated (VIP-INV-3) + shquoted
+      # (VIP-INV-1); it is a --server flag value, never eval'd.
+      vip_addr='192.168.1.240'
+      srv=(--server="https://${vip_addr}:6443")
+      # Read our own leave signal from the workload ConfigMap via the VIP.
+      # Absent ConfigMap/key => empty => no-op exit.
+      val=$(k0s kubectl "${srv[@]}" -n kube-system get configmap kairos-etcd-leave -o "jsonpath={.data.${member_key}}" 2>/dev/null || true)
       # Fixed sentinel, string-equality only — never eval'd, never a command arg.
       [ "${val}" = "leave-requested" ] || exit 0
       echo "etcd-leave: leave requested for ${member_key}; leaving etcd cluster"
@@ -283,9 +292,10 @@ write_files:
       else
         echo "etcd-leave: k0s etcd leave returned non-zero (already left?); acking anyway"
       fi
-      # Ack by patching our own key to `left`. Only member_key (locally
-      # sanitized) is interpolated; the read-back value is never reused.
-      k0s kubectl -n kube-system patch configmap kairos-etcd-leave --type merge \
+      # Ack by patching our own key to `left` via the VIP (the local apiserver is
+      # gone now). Only member_key (locally sanitized) is interpolated; the
+      # read-back value is never reused.
+      k0s kubectl "${srv[@]}" -n kube-system patch configmap kairos-etcd-leave --type merge \
         -p "{\"data\":{\"${member_key}\":\"left\"}}" 2>/dev/null || true
   - path: /etc/systemd/system/kairos-etcd-leave.service
     permissions: "0644"

--- a/internal/bootstrap/testdata/golden/k0s_capv_join.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capv_join.yaml
@@ -239,9 +239,80 @@ write_files:
       # this helper runs once multi-user.target is set up and triggers
       # both enablement and immediate start of the post-bootstrap service.
       ExecStart=/bin/systemctl enable --now kairos-k0s-post-bootstrap.service
+      # ADR 0005 §E.3: on HA control-plane nodes, also enable the etcd-leave
+      # responder timer so the node can cleanly `k0s etcd leave` when the
+      # controller requests it during a quorum-safe replacement/scale-down.
+      ExecStart=/bin/systemctl enable --now kairos-etcd-leave.timer
 
       [Install]
       WantedBy=multi-user.target
+  # ADR 0005 §E.3 (HA) k0s etcd-leave responder. During a quorum-safe
+  # replacement/scale-down the controller (a) sets a CAPI pre-terminate hook on
+  # this Machine and (b) writes a `leave-requested` sentinel for this member into
+  # the workload-cluster kube-system/kairos-etcd-leave ConfigMap. This node-local
+  # timer polls that ConfigMap via the LOCAL admin.conf (no mgmt token — the
+  # node's mgmt bearer token is only valid ~24h, but replacement happens much
+  # later; the local kubeconfig never expires), and on the exact sentinel runs
+  # `k0s etcd leave` (which leaves THIS node — no operator/ConfigMap value is
+  # ever passed as a command argument), then acks `left`. The controller then
+  # clears the pre-terminate hook and CAPI terminates the VM.
+  - path: /usr/local/bin/kairos-etcd-leave.sh
+    permissions: "0755"
+    owner: root
+    group: root
+    content: |
+      #!/bin/bash
+      set -euo pipefail
+      # This member's key == the sanitized hostname, identical to the reporter's
+      # key so it matches what the controller writes.
+      member_key=$(hostname | tr -c 'a-zA-Z0-9._-' '-')
+      # Read our own leave signal from the workload ConfigMap via the LOCAL admin
+      # kubeconfig (k0s kubectl). Absent ConfigMap/key => empty => no-op exit.
+      val=$(k0s kubectl -n kube-system get configmap kairos-etcd-leave -o "jsonpath={.data.${member_key}}" 2>/dev/null || true)
+      # Fixed sentinel, string-equality only — never eval'd, never a command arg.
+      [ "${val}" = "leave-requested" ] || exit 0
+      echo "etcd-leave: leave requested for ${member_key}; leaving etcd cluster"
+      # `k0s etcd leave` (no --peer-address) leaves THIS node using its own
+      # configured peer address — no ConfigMap/operator-derived value reaches the
+      # command (security constraint: peer-address is never externally supplied).
+      if k0s etcd leave 2>/dev/null; then
+        echo "etcd-leave: left etcd cluster"
+      else
+        echo "etcd-leave: k0s etcd leave returned non-zero (already left?); acking anyway"
+      fi
+      # Ack by patching our own key to `left`. Only member_key (locally
+      # sanitized) is interpolated; the read-back value is never reused.
+      k0s kubectl -n kube-system patch configmap kairos-etcd-leave --type merge \
+        -p "{\"data\":{\"${member_key}\":\"left\"}}" 2>/dev/null || true
+  - path: /etc/systemd/system/kairos-etcd-leave.service
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      [Unit]
+      Description=Kairos k0s etcd-leave responder (ADR 0005 §E.3)
+      ConditionKernelCommandLine=!cdroot
+      After=k0s.service
+      Wants=k0s.service
+
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/local/bin/kairos-etcd-leave.sh
+  - path: /etc/systemd/system/kairos-etcd-leave.timer
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      [Unit]
+      Description=Poll for Kairos k0s etcd-leave requests (ADR 0005 §E.3)
+      ConditionKernelCommandLine=!cdroot
+
+      [Timer]
+      OnBootSec=60
+      OnUnitActiveSec=30
+
+      [Install]
+      WantedBy=timers.target
   - path: /usr/local/bin/kairos-k0s-post-bootstrap.sh
     permissions: "0755"
     owner: root

--- a/internal/bootstrap/testdata/golden/k3s_capv_init.yaml
+++ b/internal/bootstrap/testdata/golden/k3s_capv_init.yaml
@@ -361,6 +361,77 @@ write_files:
       if ! push_kubeconfig; then
         echo "WARN: kubeconfig push failed; proceeding without blocking bootstrap"
       fi
+      # ADR 0005 §E.1 (HA) etcd-health reporter — k3s HEALTH-ONLY variant (KD-5d).
+      # Every k3s server reports its own membership into the per-cluster
+      # etcd-status Secret over the node-push channel, feeding the joiner gate,
+      # EtcdHealthyCondition, and the quorum guard. k3s embedded etcd has no clean
+      # member-remove CLI, so member REMOVAL is unsupported (documented KD-5d);
+      # this reporter is read-only + best-effort. Member count is queried via
+      # etcdctl against the local embedded etcd IF etcdctl + the server certs are
+      # present; otherwise it reports healthy from server readiness (the
+      # post-bootstrap script only reaches here after k3s is up) with members=0.
+      #
+      # SECURITY: identical discipline to the k0s reporter — non-secret metadata,
+      # JSON built on-node, all management-endpoint values shquote'd, bearer token
+      # never logged, PATCHes only this node's own member key.
+      push_etcd_status() {
+        if ! command -v curl >/dev/null 2>&1; then
+          echo "WARN: curl not available; cannot report etcd status"
+          return 1
+        fi
+        if ! command -v base64 >/dev/null 2>&1; then
+          echo "WARN: base64 not available; cannot report etcd status"
+          return 1
+        fi
+        local member_key
+        member_key=$(hostname | tr -c 'a-zA-Z0-9._-' '-')
+        # Best-effort member count via etcdctl against the local embedded etcd.
+        local healthy=true voting=true members=0
+        local etcd_dir=/var/lib/rancher/k3s/server/tls/etcd
+        if command -v etcdctl >/dev/null 2>&1 && [ -f "${etcd_dir}/server-client.crt" ]; then
+          local ml
+          ml=$(ETCDCTL_API=3 etcdctl \
+            --endpoints=https://127.0.0.1:2379 \
+            --cacert="${etcd_dir}/server-ca.crt" \
+            --cert="${etcd_dir}/server-client.crt" \
+            --key="${etcd_dir}/server-client.key" \
+            member list 2>/dev/null || true)
+          if [ -n "${ml}" ]; then
+            members=$(printf '%s\n' "${ml}" | grep -c 'started' | tr -d ' ')
+          fi
+        fi
+        local reported_at
+        reported_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+        local status_json
+        status_json=$(printf '{"name":"%s","healthy":%s,"voting":%s,"members":%s,"reportedAt":"%s"}' \
+          "${member_key}" "${healthy}" "${voting}" "${members}" "${reported_at}")
+        local status_b64
+        status_b64=$(printf '%s' "${status_json}" | base64 -w 0 2>/dev/null || printf '%s' "${status_json}" | base64 | tr -d '\n')
+        local api='https://mgmt.example.com:6443'
+        local ns='default'
+        local es_name='ha-cluster-etcd-status'
+        local token='mgmt-token'
+        local patch
+        patch="{\"data\":{\"${member_key}\":\"${status_b64}\"}}"
+        local url="${api}/api/v1/namespaces/${ns}/secrets/${es_name}"
+        local status
+        status=$(curl -k -sS -o /tmp/kairos-etcdstatus-push.log -w "%{http_code}" \
+          -H "Authorization: Bearer ${token}" \
+          -H "Content-Type: application/strategic-merge-patch+json" \
+          -X PATCH \
+          --data "${patch}" \
+          "${url}" || true)
+        unset token
+        if [ "${status}" -ge 200 ] && [ "${status}" -lt 300 ]; then
+          echo "Reported etcd status to management secret ${ns}/${es_name} (member ${member_key})"
+          return 0
+        fi
+        echo "WARN: failed to report etcd status (status ${status})"
+        return 1
+      }
+      if ! push_etcd_status; then
+        echo "WARN: etcd-status report failed; will retry on next boot"
+      fi
 
       # Mark bootstrap success for CAPI/CAPK consumers
       mkdir -p /run/cluster-api

--- a/internal/bootstrap/testdata/golden/k3s_capv_join.yaml
+++ b/internal/bootstrap/testdata/golden/k3s_capv_join.yaml
@@ -354,6 +354,77 @@ write_files:
       if ! push_kubeconfig; then
         echo "WARN: kubeconfig push failed; proceeding without blocking bootstrap"
       fi
+      # ADR 0005 §E.1 (HA) etcd-health reporter — k3s HEALTH-ONLY variant (KD-5d).
+      # Every k3s server reports its own membership into the per-cluster
+      # etcd-status Secret over the node-push channel, feeding the joiner gate,
+      # EtcdHealthyCondition, and the quorum guard. k3s embedded etcd has no clean
+      # member-remove CLI, so member REMOVAL is unsupported (documented KD-5d);
+      # this reporter is read-only + best-effort. Member count is queried via
+      # etcdctl against the local embedded etcd IF etcdctl + the server certs are
+      # present; otherwise it reports healthy from server readiness (the
+      # post-bootstrap script only reaches here after k3s is up) with members=0.
+      #
+      # SECURITY: identical discipline to the k0s reporter — non-secret metadata,
+      # JSON built on-node, all management-endpoint values shquote'd, bearer token
+      # never logged, PATCHes only this node's own member key.
+      push_etcd_status() {
+        if ! command -v curl >/dev/null 2>&1; then
+          echo "WARN: curl not available; cannot report etcd status"
+          return 1
+        fi
+        if ! command -v base64 >/dev/null 2>&1; then
+          echo "WARN: base64 not available; cannot report etcd status"
+          return 1
+        fi
+        local member_key
+        member_key=$(hostname | tr -c 'a-zA-Z0-9._-' '-')
+        # Best-effort member count via etcdctl against the local embedded etcd.
+        local healthy=true voting=true members=0
+        local etcd_dir=/var/lib/rancher/k3s/server/tls/etcd
+        if command -v etcdctl >/dev/null 2>&1 && [ -f "${etcd_dir}/server-client.crt" ]; then
+          local ml
+          ml=$(ETCDCTL_API=3 etcdctl \
+            --endpoints=https://127.0.0.1:2379 \
+            --cacert="${etcd_dir}/server-ca.crt" \
+            --cert="${etcd_dir}/server-client.crt" \
+            --key="${etcd_dir}/server-client.key" \
+            member list 2>/dev/null || true)
+          if [ -n "${ml}" ]; then
+            members=$(printf '%s\n' "${ml}" | grep -c 'started' | tr -d ' ')
+          fi
+        fi
+        local reported_at
+        reported_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+        local status_json
+        status_json=$(printf '{"name":"%s","healthy":%s,"voting":%s,"members":%s,"reportedAt":"%s"}' \
+          "${member_key}" "${healthy}" "${voting}" "${members}" "${reported_at}")
+        local status_b64
+        status_b64=$(printf '%s' "${status_json}" | base64 -w 0 2>/dev/null || printf '%s' "${status_json}" | base64 | tr -d '\n')
+        local api='https://mgmt.example.com:6443'
+        local ns='default'
+        local es_name='ha-cluster-etcd-status'
+        local token='mgmt-token'
+        local patch
+        patch="{\"data\":{\"${member_key}\":\"${status_b64}\"}}"
+        local url="${api}/api/v1/namespaces/${ns}/secrets/${es_name}"
+        local status
+        status=$(curl -k -sS -o /tmp/kairos-etcdstatus-push.log -w "%{http_code}" \
+          -H "Authorization: Bearer ${token}" \
+          -H "Content-Type: application/strategic-merge-patch+json" \
+          -X PATCH \
+          --data "${patch}" \
+          "${url}" || true)
+        unset token
+        if [ "${status}" -ge 200 ] && [ "${status}" -lt 300 ]; then
+          echo "Reported etcd status to management secret ${ns}/${es_name} (member ${member_key})"
+          return 0
+        fi
+        echo "WARN: failed to report etcd status (status ${status})"
+        return 1
+      }
+      if ! push_etcd_status; then
+        echo "WARN: etcd-status report failed; will retry on next boot"
+      fi
 
       # Mark bootstrap success for CAPI/CAPK consumers
       mkdir -p /run/cluster-api

--- a/internal/controllers/bootstrap/kairosconfig_controller.go
+++ b/internal/controllers/bootstrap/kairosconfig_controller.go
@@ -881,6 +881,17 @@ func (r *KairosConfigReconciler) applyControlPlaneRenderData(ctx context.Context
 		distribution = "k0s"
 	}
 
+	// ADR 0005 §E.1: every HA control-plane node (init AND join) reports its own
+	// etcd member health into the per-cluster etcd-status Secret over the
+	// node-push channel. The renderer needs the target Secret name to build that
+	// reporter block. Not for single-node (no quorum to report) or workers.
+	if td.ManagementEndpoint != nil && cluster != nil {
+		switch kairosConfig.Spec.ControlPlaneRole {
+		case bootstrapv1beta2.ControlPlaneRoleInit, bootstrapv1beta2.ControlPlaneRoleJoin:
+			td.ManagementEndpoint.EtcdStatusSecretName = bootstrapv1beta2.EtcdStatusSecretName(cluster.Name)
+		}
+	}
+
 	// The join token is only meaningful for init/join nodes. single needs none.
 	switch kairosConfig.Spec.ControlPlaneRole {
 	case bootstrapv1beta2.ControlPlaneRoleInit:

--- a/internal/controllers/bootstrap/management_endpoint_resolver.go
+++ b/internal/controllers/bootstrap/management_endpoint_resolver.go
@@ -178,6 +178,13 @@ func (r *kubeVirtTokenResolver) Resolve(ctx context.Context, kc *bootstrapv1beta
 		//                                            updates it. Named Secret only;
 		//                                            deliberate, bounded widening.
 		joinTokenSecretName := bootstrapv1beta2.ControlPlaneJoinTokenSecretName(cluster.Name)
+		// ADR 0005 §E.1: HA control-plane nodes also PATCH their own member key
+		// into the per-cluster etcd-status Secret over this same node-push
+		// channel. Add it to the resourceNames-scoped get/update/patch rule (no
+		// create — the controller pre-creates it, Cluster-owned). Named Secret
+		// only; deliberate, bounded widening, identical in shape to the join-token
+		// grant. Non-HA clusters never create the Secret, so the grant is inert.
+		etcdStatusSecretName := bootstrapv1beta2.EtcdStatusSecretName(cluster.Name)
 		role.Rules = []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{""},
@@ -187,7 +194,7 @@ func (r *kubeVirtTokenResolver) Resolve(ctx context.Context, kc *bootstrapv1beta
 			{
 				APIGroups:     []string{""},
 				Resources:     []string{"secrets"},
-				ResourceNames: []string{secretName, joinTokenSecretName},
+				ResourceNames: []string{secretName, joinTokenSecretName, etcdStatusSecretName},
 				Verbs:         []string{"get", "update", "patch"},
 			},
 		}

--- a/internal/controllers/bootstrap/management_endpoint_resolver_test.go
+++ b/internal/controllers/bootstrap/management_endpoint_resolver_test.go
@@ -431,3 +431,74 @@ func TestResolve_MultipleConfigsSameCluster_OwnedByCluster(t *testing.T) {
 		g.Expect(owner.Name).To(Equal("test-cluster"))
 	}
 }
+
+// TestResolve_GrantsEtcdStatusSecret asserts the node SA's Role is granted
+// get/update/patch (and NOT create) on the per-cluster etcd-status Secret
+// (ADR 0005 §E.1), on the same resourceNames-scoped rule as the kubeconfig +
+// join-token Secrets — a bounded named-Secret widening, no new rule.
+func TestResolve_GrantsEtcdStatusSecret(t *testing.T) {
+	g := NewWithT(t)
+	scheme := newResolverScheme(t)
+	sub := &fakeSubResourceClient{token: "tok"}
+	r, kc, cluster := newResolverFixture(scheme, sub, "https://mgmt:6443")
+	kc.Spec.Role = "control-plane"
+	kc.Spec.Distribution = "k0s"
+
+	_, err := r.Resolve(context.Background(), kc, cluster)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	role := &rbacv1.Role{}
+	saName := kubeconfigWriterName("test-cluster")
+	g.Expect(r.Client.Get(context.Background(), types.NamespacedName{Name: saName, Namespace: "default"}, role)).To(Succeed())
+
+	etcdName := bootstrapv1beta2.EtcdStatusSecretName("test-cluster")
+	g.Expect(roleGrantsNamedSecret(role, etcdName, "get")).To(BeTrue(), "node SA must get the etcd-status Secret")
+	g.Expect(roleGrantsNamedSecret(role, etcdName, "update")).To(BeTrue(), "node SA must update the etcd-status Secret")
+	g.Expect(roleGrantsNamedSecret(role, etcdName, "patch")).To(BeTrue(), "node SA must patch the etcd-status Secret")
+	g.Expect(roleGrantsNamedSecret(role, etcdName, "create")).To(BeFalse(), "node SA must NOT create the etcd-status Secret (controller pre-creates it)")
+}
+
+// roleGrantsNamedSecret reports whether the Role grants the given verb on the
+// named core Secret via a resourceNames-scoped rule (the create rule carries no
+// resourceNames, so a create check only matches a named-create rule — which we
+// assert is absent).
+func roleGrantsNamedSecret(role *rbacv1.Role, name, verb string) bool {
+	for _, rule := range role.Rules {
+		coreGroup := false
+		for _, gp := range rule.APIGroups {
+			if gp == "" {
+				coreGroup = true
+				break
+			}
+		}
+		if !coreGroup {
+			continue
+		}
+		hasSecret := false
+		for _, res := range rule.Resources {
+			if res == "secrets" {
+				hasSecret = true
+				break
+			}
+		}
+		if !hasSecret {
+			continue
+		}
+		hasName := false
+		for _, rn := range rule.ResourceNames {
+			if rn == name {
+				hasName = true
+				break
+			}
+		}
+		if !hasName {
+			continue
+		}
+		for _, v := range rule.Verbs {
+			if v == verb {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/controllers/controlplane/cleanup.go
+++ b/internal/controllers/controlplane/cleanup.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	controlplanev1beta2 "github.com/kairos-io/cluster-api-provider-kairos/api/controlplane/v1beta2"
@@ -94,6 +95,59 @@ func drainOwnedMachines(ctx context.Context, c client.Client, kcp *controlplanev
 		}
 	}
 	return remaining, nil
+}
+
+// stripEtcdLeaveHooks removes the etcd-leave pre-terminate lifecycle hook
+// (ADR 0005 §E.3) from every Machine owned by this KairosControlPlane. It MUST
+// run before drainOwnedMachines on the whole-cluster teardown path: the hook
+// pauses CAPI termination after drain, and nothing on the delete path drives the
+// per-member leave handshake, so leaving the hook in place would deadlock
+// teardown (load-bearing). It strips UNCONDITIONALLY — including Machines already
+// mid-deletion and paused at the hook — so a scale-down that was in flight when
+// the cluster was deleted is unblocked too. Whole-cluster teardown discards etcd
+// entirely, so a clean per-member leave is pointless here.
+//
+// Selection mirrors drainOwnedMachines (cluster-name label + controller-UID
+// ownership). Idempotent: Machines without the hook are skipped; an IsNotFound on
+// patch (reaped between List and Patch) is treated as success.
+func stripEtcdLeaveHooks(ctx context.Context, c client.Client, kcp *controlplanev1beta2.KairosControlPlane) error {
+	clusterName, ok := kcp.Labels[clusterv1.ClusterNameLabel]
+	if !ok || clusterName == "" {
+		return nil
+	}
+	selector := labels.SelectorFromSet(labels.Set{
+		clusterv1.ClusterNameLabel: clusterName,
+	})
+	machineList := &clusterv1.MachineList{}
+	if err := c.List(ctx, machineList,
+		client.InNamespace(kcp.Namespace),
+		client.MatchingLabelsSelector{Selector: selector},
+	); err != nil {
+		return err
+	}
+
+	hook := etcdLeaveHookAnnotation()
+	for i := range machineList.Items {
+		m := &machineList.Items[i]
+		if !ownedByKCP(m, kcp.UID) {
+			continue
+		}
+		if _, has := m.Annotations[hook]; !has {
+			continue
+		}
+		helper, err := patch.NewHelper(m, c)
+		if err != nil {
+			return err
+		}
+		delete(m.Annotations, hook)
+		if err := helper.Patch(ctx, m); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return err
+		}
+	}
+	return nil
 }
 
 // ownedByKCP reports whether machine is owned (controller=true) by a

--- a/internal/controllers/controlplane/ha_etcd.go
+++ b/internal/controllers/controlplane/ha_etcd.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2024 The Kairos CAPI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package controlplane
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	bootstrapv1beta2 "github.com/kairos-io/cluster-api-provider-kairos/api/bootstrap/v1beta2"
+)
+
+// etcdStatusSecretName returns the name of the per-cluster HA etcd-status Secret.
+func etcdStatusSecretName(clusterName string) string {
+	return bootstrapv1beta2.EtcdStatusSecretName(clusterName)
+}
+
+// ensureEtcdStatusSecret guarantees the per-cluster HA etcd-status Secret exists,
+// owner-ref'd to the *Cluster* (ADR 0005 §E.1) and labeled with the cluster-name
+// label (KD-15). It is idempotent and created EMPTY: every control-plane node
+// PATCHes its own member key (member id, voting, healthy, member-list count)
+// over the node-push channel — the same channel as the join token — and the
+// controller reads it to compute etcd health (EtcdHealthyCondition) and the
+// quorum-safe-replacement guard (canRemoveMember).
+//
+// OWNERSHIP — the Cluster, NOT the KairosControlPlane (contrast
+// ensureJoinTokenSecret): this is a *multi-writer* per-cluster shared object —
+// every control-plane node's SA writes its own member key. It must GC with the
+// Cluster and must present the SAME controller owner to every writer's
+// CreateOrUpdate. Owning it by a per-Machine object would re-open the multi-node
+// "already owned by another controller" bug fixed in ADR 0005 §D.2; owning it by
+// the KCP would strand it across a KCP replace. The mutate func NEVER clears
+// existing Data — that would wipe node-reported health on every reconcile.
+//
+// Gated by the caller on desiredReplicas > 1 (single-node clusters have no etcd
+// quorum to guard and no peers to report about).
+func (r *KairosControlPlaneReconciler) ensureEtcdStatusSecret(ctx context.Context, log logr.Logger, cluster *clusterv1.Cluster) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      etcdStatusSecretName(cluster.Name),
+			Namespace: cluster.Namespace,
+		},
+	}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, secret, func() error {
+		if secret.Labels == nil {
+			secret.Labels = map[string]string{}
+		}
+		secret.Labels[clusterv1.ClusterNameLabel] = cluster.Name
+		secret.Labels[bootstrapv1beta2.EtcdStatusSecretTypeLabel] = bootstrapv1beta2.EtcdStatusSecretTypeValue
+
+		// Created empty; per-node reporters populate their own member keys. Do
+		// NOT touch secret.Data here — the node-authored keys must survive every
+		// controller reconcile.
+
+		// Owner-ref to the Cluster so the Secret cascades on Cluster delete and
+		// every CP node's writer sees the same, stable controller owner.
+		return controllerutil.SetControllerReference(cluster, secret, r.Scheme)
+	})
+	if err != nil {
+		return fmt.Errorf("ensure etcd-status secret %s/%s: %w", secret.Namespace, secret.Name, err)
+	}
+	log.V(4).Info("Ensured HA etcd-status secret",
+		"secret", etcdStatusSecretName(cluster.Name), "namespace", cluster.Namespace)
+	return nil
+}

--- a/internal/controllers/controlplane/ha_etcd.go
+++ b/internal/controllers/controlplane/ha_etcd.go
@@ -18,11 +18,14 @@ package controlplane
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -82,4 +85,54 @@ func (r *KairosControlPlaneReconciler) ensureEtcdStatusSecret(ctx context.Contex
 	log.V(4).Info("Ensured HA etcd-status secret",
 		"secret", etcdStatusSecretName(cluster.Name), "namespace", cluster.Namespace)
 	return nil
+}
+
+// etcdMemberStatus is the per-member health record a control-plane node reports
+// into the etcd-status Secret (ADR 0005 §E.1). It is non-secret cluster
+// metadata. The wire form is the compact JSON the node-side reporter builds; the
+// controller only READS it (it is never authored controller-side).
+type etcdMemberStatus struct {
+	Name       string `json:"name"`
+	Healthy    bool   `json:"healthy"`
+	Voting     bool   `json:"voting"`
+	Members    int    `json:"members"`
+	ReportedAt string `json:"reportedAt"`
+}
+
+// readEtcdStatus loads the per-cluster etcd-status Secret and parses each
+// member's reported status, keyed by member key (the reporting node's sanitized
+// hostname == its Node name). A missing Secret returns an empty map (the cluster
+// is pre-HA or no node has reported yet), not an error. Malformed entries (a
+// node wrote garbage, or a future schema) are skipped rather than failing the
+// whole read — a single bad key must not blind the controller to healthy peers.
+func (r *KairosControlPlaneReconciler) readEtcdStatus(ctx context.Context, cluster *clusterv1.Cluster) (map[string]etcdMemberStatus, error) {
+	secret := &corev1.Secret{}
+	key := types.NamespacedName{Name: etcdStatusSecretName(cluster.Name), Namespace: cluster.Namespace}
+	if err := r.Client.Get(ctx, key, secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			return map[string]etcdMemberStatus{}, nil
+		}
+		return nil, fmt.Errorf("read etcd-status secret %s/%s: %w", key.Namespace, key.Name, err)
+	}
+	out := make(map[string]etcdMemberStatus, len(secret.Data))
+	for member, raw := range secret.Data {
+		var st etcdMemberStatus
+		if err := json.Unmarshal(raw, &st); err != nil {
+			continue
+		}
+		out[member] = st
+	}
+	return out, nil
+}
+
+// etcdVotingHealthyCount returns the number of members reporting BOTH healthy and
+// voting — the population that counts toward etcd quorum (ADR 0005 §E.2/§E.4).
+func etcdVotingHealthyCount(status map[string]etcdMemberStatus) int {
+	n := 0
+	for _, st := range status {
+		if st.Healthy && st.Voting {
+			n++
+		}
+	}
+	return n
 }

--- a/internal/controllers/controlplane/ha_etcd.go
+++ b/internal/controllers/controlplane/ha_etcd.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	bootstrapv1beta2 "github.com/kairos-io/cluster-api-provider-kairos/api/bootstrap/v1beta2"
+	controlplanev1beta2 "github.com/kairos-io/cluster-api-provider-kairos/api/controlplane/v1beta2"
 )
 
 // etcdStatusSecretName returns the name of the per-cluster HA etcd-status Secret.
@@ -135,4 +136,69 @@ func etcdVotingHealthyCount(status map[string]etcdMemberStatus) int {
 		}
 	}
 	return n
+}
+
+// canRemoveMember reports whether deleting `target` (a control-plane Machine) is
+// safe for etcd quorum (ADR 0005 §E.2). It guards every NON-teardown CP-Machine
+// delete site (rollout replacement, scale-down); reconcileDelete does NOT call it
+// (whole-cluster teardown is the bypass).
+//
+// SECURITY (ADR 0005 §E.5, security-architect ruling — must-honor constraints):
+//   - FAILS CLOSED: a transient read error, or a live Running target with NO
+//     etcd-status report, refuses the delete ("cannot prove quorum safety") — a
+//     missing report on a live node may be a silent voting member.
+//   - BYPASS is EXACT: only whole-cluster teardown (kcp.DeletionTimestamp set)
+//     bypasses. A per-Machine deletion timestamp, rollout, or scale-down never
+//     reaches the bypass.
+//   - The failed-node fast path (allow the delete of a presumed-dead member) is
+//     gated on the OBJECTIVE Machine phase / NodeRef — never on the
+//     attacker-influenceable etcd self-report.
+//   - The quorum population is the healthy+voting REPORTERS (etcdVotingHealthyCount),
+//     never the node-reported `members` list length (unvalidated, forgeable).
+func (r *KairosControlPlaneReconciler) canRemoveMember(ctx context.Context, kcp *controlplanev1beta2.KairosControlPlane, cluster *clusterv1.Cluster, target *clusterv1.Machine) (bool, string, error) {
+	// Whole-cluster teardown must never deadlock on quorum (the single bypass).
+	if !kcp.ObjectMeta.DeletionTimestamp.IsZero() {
+		return true, "", nil
+	}
+	desiredReplicas := int32(1)
+	if kcp.Spec.Replicas != nil {
+		desiredReplicas = *kcp.Spec.Replicas
+	}
+	// Single-node (or unset) control planes have no etcd quorum to protect.
+	if desiredReplicas <= 1 {
+		return true, "", nil
+	}
+	// Failed-node fast path — OBJECTIVE liveness only (Machine phase / NodeRef),
+	// NOT the etcd self-report: a target that never registered a Node or is not
+	// Running is presumed dead/failed, is not a healthy voting member, and cannot
+	// reduce the healthy-voting count — allow. This is the primary replacement
+	// case for an unreachable node.
+	if target.Status.NodeRef == nil || target.Status.Phase != string(clusterv1.MachinePhaseRunning) {
+		return true, "", nil
+	}
+	// The target is a live, Running control-plane node. Prove that removing it
+	// keeps etcd quorum from the node-reported etcd-status Secret.
+	status, err := r.readEtcdStatus(ctx, cluster)
+	if err != nil {
+		return false, "", err // transient read error: caller requeues, delete withheld
+	}
+	targetKey := target.Status.NodeRef.Name
+	st, reported := status[targetKey]
+	if !reported {
+		// A live CP node with no etcd report may be a silent voting member whose
+		// report is stale — cannot prove safety, fail closed.
+		return false, "target is a live control-plane node with no etcd-status report; cannot prove quorum safety", nil
+	}
+	voting := etcdVotingHealthyCount(status)
+	postRemoval := voting
+	if st.Healthy && st.Voting {
+		postRemoval = voting - 1 // removing a member currently counted toward quorum
+	}
+	quorum := int(desiredReplicas/2 + 1)
+	if postRemoval < quorum {
+		return false, fmt.Sprintf(
+			"removing this member would leave %d healthy voting etcd members, below the quorum minimum ((N/2)+1=%d)",
+			postRemoval, quorum), nil
+	}
+	return true, "", nil
 }

--- a/internal/controllers/controlplane/ha_etcd_test.go
+++ b/internal/controllers/controlplane/ha_etcd_test.go
@@ -24,11 +24,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/cluster-api/util/conditions"
 
 	bootstrapv1beta2 "github.com/kairos-io/cluster-api-provider-kairos/api/bootstrap/v1beta2"
+	controlplanev1beta2 "github.com/kairos-io/cluster-api-provider-kairos/api/controlplane/v1beta2"
 )
 
 // TestEnsureEtcdStatusSecret_ClusterOwnedEmptyIdempotent asserts the per-cluster
@@ -72,4 +75,139 @@ func TestEnsureEtcdStatusSecret_ClusterOwnedEmptyIdempotent(t *testing.T) {
 	g.Expect(c.Get(context.Background(), key, secret)).To(Succeed())
 	g.Expect(secret.Data).To(HaveKeyWithValue("member-cp-0", []byte(`{"healthy":true}`)),
 		"node-reported member data must survive controller reconcile")
+}
+
+// etcdStatusSecretWith builds a per-cluster etcd-status Secret whose data holds
+// `voting` healthy+voting members plus one unhealthy member, for the readers and
+// condition tests.
+func etcdStatusSecretWith(cluster string, voting int) *corev1.Secret {
+	data := map[string][]byte{}
+	for i := 0; i < voting; i++ {
+		name := "cp-h" + string(rune('0'+i))
+		data[name] = []byte(`{"name":"` + name + `","healthy":true,"voting":true,"members":3,"reportedAt":"t"}`)
+	}
+	data["cp-down"] = []byte(`{"name":"cp-down","healthy":false,"voting":true,"members":3,"reportedAt":"t"}`)
+	data["cp-junk"] = []byte(`this is not json`)
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: etcdStatusSecretName(cluster), Namespace: "default"},
+		Data:       data,
+	}
+}
+
+// TestReadEtcdStatus_ParsesCountsSkipsMalformed asserts the reader parses valid
+// member reports, skips malformed entries (a node wrote garbage), and that the
+// voting-healthy count excludes unhealthy members.
+func TestReadEtcdStatus_ParsesCountsSkipsMalformed(t *testing.T) {
+	g := NewWithT(t)
+	scheme := haTestScheme(g)
+	cluster := &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "default"}}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(etcdStatusSecretWith("c", 2)).Build()
+	r := &KairosControlPlaneReconciler{Client: c, Scheme: scheme}
+
+	status, err := r.readEtcdStatus(context.Background(), cluster)
+	g.Expect(err).ToNot(HaveOccurred())
+	// 2 healthy + 1 unhealthy parsed; the malformed "cp-junk" entry is skipped.
+	g.Expect(status).To(HaveLen(3))
+	g.Expect(etcdVotingHealthyCount(status)).To(Equal(2))
+}
+
+// TestReadEtcdStatus_MissingSecretEmpty asserts a missing Secret is not an error
+// (pre-HA / no node has reported yet).
+func TestReadEtcdStatus_MissingSecretEmpty(t *testing.T) {
+	g := NewWithT(t)
+	scheme := haTestScheme(g)
+	cluster := &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "default"}}
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &KairosControlPlaneReconciler{Client: c, Scheme: scheme}
+
+	status, err := r.readEtcdStatus(context.Background(), cluster)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(status).To(BeEmpty())
+}
+
+// TestSetHAConditions_EtcdHealthy pins the EtcdHealthyCondition mapping
+// (ADR 0005 §E.4): True when all desired members are healthy+voting; Info when
+// quorum holds with a margin; Warning at or below the (N/2)+1 razor's edge.
+func TestSetHAConditions_EtcdHealthy(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		desired    int32
+		voting     int
+		wantStatus corev1.ConditionStatus
+		wantReason string
+	}{
+		{"3-node all healthy", 3, 3, corev1.ConditionTrue, ""},
+		{"3-node one down (at quorum)", 3, 2, corev1.ConditionFalse, controlplanev1beta2.EtcdQuorumAtRiskReason},
+		{"5-node one down (margin)", 5, 4, corev1.ConditionFalse, controlplanev1beta2.EtcdQuorumDegradedReason},
+		{"5-node two down (at quorum)", 5, 3, corev1.ConditionFalse, controlplanev1beta2.EtcdQuorumAtRiskReason},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			scheme := haTestScheme(g)
+			cluster := &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "default"}}
+			kcp := &controlplanev1beta2.KairosControlPlane{
+				ObjectMeta: metav1.ObjectMeta{Name: "kcp", Namespace: "default"},
+				Spec: controlplanev1beta2.KairosControlPlaneSpec{
+					Replicas: ptr.To(tc.desired),
+					HA:       &controlplanev1beta2.HAConfig{VIP: &controlplanev1beta2.KubeVIPConfig{Address: "10.0.0.1", Interface: "eth0", Mode: "ARP"}},
+				},
+				Status: controlplanev1beta2.KairosControlPlaneStatus{ReadyReplicas: tc.desired},
+			}
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(etcdStatusSecretWith("c", tc.voting)).Build()
+			r := &KairosControlPlaneReconciler{Client: c, Scheme: scheme}
+
+			r.setHAConditions(context.Background(), kcp, cluster, true)
+
+			cond := conditions.Get(kcp, controlplanev1beta2.EtcdHealthyCondition)
+			g.Expect(cond).ToNot(BeNil(), "EtcdHealthyCondition must be set for HA")
+			g.Expect(cond.Status).To(Equal(tc.wantStatus))
+			// True conditions carry no reason (CAPI convention, like ControlPlaneJoined).
+			if tc.wantStatus == corev1.ConditionFalse {
+				g.Expect(cond.Reason).To(Equal(tc.wantReason))
+			}
+		})
+	}
+}
+
+// TestInitMachineJoinable_GatesOnEtcdReport asserts the ADR 0005 §E.1 joiner-gate
+// graduation: with NodeRef + KubeconfigReady + join-token all satisfied, a k0s
+// init is still NOT joinable until it reports a healthy voting etcd member, and
+// becomes joinable once it does.
+func TestInitMachineJoinable_GatesOnEtcdReport(t *testing.T) {
+	g := NewWithT(t)
+	scheme := haTestScheme(g)
+	cluster := &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "default"}}
+	kcp := &controlplanev1beta2.KairosControlPlane{
+		ObjectMeta: metav1.ObjectMeta{Name: "kcp", Namespace: "default"},
+		Spec:       controlplanev1beta2.KairosControlPlaneSpec{Distribution: "k0s", Replicas: ptr.To(int32(3))},
+	}
+	conditions.MarkTrue(kcp, controlplanev1beta2.KubeconfigReadyCondition)
+	init := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "cp-0", Namespace: "default"},
+		Status:     clusterv1.MachineStatus{NodeRef: &corev1.ObjectReference{Name: "cp-0"}},
+	}
+	jt := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: joinTokenSecretName("c"), Namespace: "default"},
+		Data:       map[string][]byte{joinTokenSecretDataKey: []byte("tok")},
+	}
+
+	// No etcd report yet: NOT joinable (k0s strict).
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(jt).Build()
+	r := &KairosControlPlaneReconciler{Client: c, Scheme: scheme}
+	joinable, reason, err := r.initMachineJoinable(context.Background(), kcp, cluster, []*clusterv1.Machine{init})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(joinable).To(BeFalse())
+	g.Expect(reason).To(ContainSubstring("etcd member"))
+
+	// Init reports healthy+voting: joinable.
+	es := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: etcdStatusSecretName("c"), Namespace: "default"},
+		Data:       map[string][]byte{"cp-0": []byte(`{"name":"cp-0","healthy":true,"voting":true,"members":1,"reportedAt":"t"}`)},
+	}
+	c2 := fake.NewClientBuilder().WithScheme(scheme).WithObjects(jt, es).Build()
+	r2 := &KairosControlPlaneReconciler{Client: c2, Scheme: scheme}
+	joinable, _, err = r2.initMachineJoinable(context.Background(), kcp, cluster, []*clusterv1.Machine{init})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(joinable).To(BeTrue())
 }

--- a/internal/controllers/controlplane/ha_etcd_test.go
+++ b/internal/controllers/controlplane/ha_etcd_test.go
@@ -18,6 +18,7 @@ package controlplane
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -26,9 +27,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/cluster-api/util/conditions"
 
 	bootstrapv1beta2 "github.com/kairos-io/cluster-api-provider-kairos/api/bootstrap/v1beta2"
 	controlplanev1beta2 "github.com/kairos-io/cluster-api-provider-kairos/api/controlplane/v1beta2"
@@ -210,4 +212,76 @@ func TestInitMachineJoinable_GatesOnEtcdReport(t *testing.T) {
 	joinable, _, err = r2.initMachineJoinable(context.Background(), kcp, cluster, []*clusterv1.Machine{init})
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(joinable).To(BeTrue())
+}
+
+// TestCanRemoveMember pins the ADR 0005 §E.2/§E.5 quorum guard: exact teardown
+// bypass, objective failed-node fast path (Machine phase, not the etcd
+// self-report), fail-closed on a live-but-unreported target, and correct quorum
+// arithmetic over healthy+voting reporters.
+func TestCanRemoveMember(t *testing.T) {
+	mkMachine := func(name, node, phase string) *clusterv1.Machine {
+		m := &clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"}}
+		m.Status.Phase = phase
+		if node != "" {
+			m.Status.NodeRef = &corev1.ObjectReference{Name: node}
+		}
+		return m
+	}
+	type member struct{ healthy, voting bool }
+	running := string(clusterv1.MachinePhaseRunning)
+	for _, tc := range []struct {
+		name        string
+		desired     int32
+		members     map[string]member
+		target      *clusterv1.Machine
+		deleting    bool
+		wantAllowed bool
+	}{
+		{"teardown bypass allows even at zero quorum", 3, nil, mkMachine("cp-0", "cp-0", running), true, true},
+		{"single-node has no quorum to guard", 1, nil, mkMachine("cp-0", "cp-0", running), false, true},
+		{"failed node (no NodeRef) fast-path allows", 3,
+			map[string]member{"cp-1": {true, true}, "cp-2": {true, true}}, mkMachine("cp-0", "", "Provisioning"), false, true},
+		{"not-Running node fast-path allows", 3,
+			map[string]member{"cp-1": {true, true}, "cp-2": {true, true}}, mkMachine("cp-0", "cp-0", "Deleting"), false, true},
+		{"3-node all healthy, remove one keeps quorum", 3,
+			map[string]member{"cp-0": {true, true}, "cp-1": {true, true}, "cp-2": {true, true}}, mkMachine("cp-0", "cp-0", running), false, true},
+		{"3-node one down, removing a healthy one breaks quorum", 3,
+			map[string]member{"cp-0": {true, true}, "cp-1": {true, true}, "cp-2": {false, true}}, mkMachine("cp-0", "cp-0", running), false, false},
+		{"live node with no etcd report fails closed", 3,
+			map[string]member{"cp-1": {true, true}, "cp-2": {true, true}}, mkMachine("cp-0", "cp-0", running), false, false},
+		{"removing an unhealthy member keeps quorum", 3,
+			map[string]member{"cp-0": {false, true}, "cp-1": {true, true}, "cp-2": {true, true}}, mkMachine("cp-0", "cp-0", running), false, true},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			scheme := haTestScheme(g)
+			cluster := &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "default"}}
+			kcp := &controlplanev1beta2.KairosControlPlane{
+				ObjectMeta: metav1.ObjectMeta{Name: "kcp", Namespace: "default"},
+				Spec:       controlplanev1beta2.KairosControlPlaneSpec{Replicas: ptr.To(tc.desired)},
+			}
+			if tc.deleting {
+				now := metav1.Now()
+				kcp.DeletionTimestamp = &now
+			}
+			objs := []client.Object{}
+			if tc.members != nil {
+				data := map[string][]byte{}
+				for name, m := range tc.members {
+					data[name] = []byte(fmt.Sprintf(`{"name":%q,"healthy":%t,"voting":%t,"members":3,"reportedAt":"t"}`, name, m.healthy, m.voting))
+				}
+				objs = append(objs, &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: etcdStatusSecretName("c"), Namespace: "default"},
+					Data:       data,
+				})
+			}
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+			r := &KairosControlPlaneReconciler{Client: c, Scheme: scheme}
+
+			allowed, reason, err := r.canRemoveMember(context.Background(), kcp, cluster, tc.target)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(allowed).To(Equal(tc.wantAllowed), "reason=%q", reason)
+		})
+	}
 }

--- a/internal/controllers/controlplane/ha_etcd_test.go
+++ b/internal/controllers/controlplane/ha_etcd_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2024 The Kairos CAPI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package controlplane
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	bootstrapv1beta2 "github.com/kairos-io/cluster-api-provider-kairos/api/bootstrap/v1beta2"
+)
+
+// TestEnsureEtcdStatusSecret_ClusterOwnedEmptyIdempotent asserts the per-cluster
+// etcd-status Secret (ADR 0005 §E.1) is:
+//   - created EMPTY (nodes populate their own member keys over node-push),
+//   - owner-ref'd to the *Cluster* — NOT the KCP: it is a multi-writer shared
+//     object, and Cluster ownership is what avoids the §D.2 "already owned by
+//     another controller" multi-node bug and GCs it with the cluster,
+//   - labeled for the KD-15 label-filtered watch, and
+//   - idempotent: a second reconcile must NOT wipe node-reported member data.
+func TestEnsureEtcdStatusSecret_ClusterOwnedEmptyIdempotent(t *testing.T) {
+	g := NewWithT(t)
+	scheme := haTestScheme(g)
+	cluster := &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "default", UID: "cluster-uid"}}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster).Build()
+	r := &KairosControlPlaneReconciler{Client: c, Scheme: scheme}
+
+	g.Expect(r.ensureEtcdStatusSecret(context.Background(), log.Log, cluster)).To(Succeed())
+
+	secret := &corev1.Secret{}
+	key := types.NamespacedName{Name: etcdStatusSecretName("c"), Namespace: "default"}
+	g.Expect(c.Get(context.Background(), key, secret)).To(Succeed())
+
+	// Empty on create.
+	g.Expect(secret.Data).To(BeEmpty(), "etcd-status Secret is filled by the CP nodes, not the controller")
+	// Labels for the label-filtered watch (KD-15).
+	g.Expect(secret.Labels).To(HaveKeyWithValue(clusterv1.ClusterNameLabel, "c"))
+	g.Expect(secret.Labels).To(HaveKeyWithValue(bootstrapv1beta2.EtcdStatusSecretTypeLabel, bootstrapv1beta2.EtcdStatusSecretTypeValue))
+	// Owned by the Cluster, NOT the KCP (contrast the join-token Secret).
+	g.Expect(secret.OwnerReferences).To(HaveLen(1))
+	g.Expect(secret.OwnerReferences[0].Kind).To(Equal("Cluster"))
+	g.Expect(secret.OwnerReferences[0].UID).To(Equal(cluster.UID))
+
+	// Simulate a node reporting its member health, then reconcile again: the
+	// controller must NOT clobber node-authored data.
+	secret.Data = map[string][]byte{"member-cp-0": []byte(`{"healthy":true}`)}
+	g.Expect(c.Update(context.Background(), secret)).To(Succeed())
+
+	g.Expect(r.ensureEtcdStatusSecret(context.Background(), log.Log, cluster)).To(Succeed())
+	g.Expect(c.Get(context.Background(), key, secret)).To(Succeed())
+	g.Expect(secret.Data).To(HaveKeyWithValue("member-cp-0", []byte(`{"healthy":true}`)),
+		"node-reported member data must survive controller reconcile")
+}

--- a/internal/controllers/controlplane/ha_leave.go
+++ b/internal/controllers/controlplane/ha_leave.go
@@ -176,6 +176,7 @@ func (r *KairosControlPlaneReconciler) reconcileMemberLeave(ctx context.Context,
 	}
 
 	nodeName := target.Status.NodeRef.Name
+	_, requested := target.Annotations[etcdLeaveRequestedAtAnnotation]
 
 	// Build the workload client on demand. Build error is fail-safe: hook retained.
 	factory := r.WorkloadClientFactory
@@ -186,70 +187,85 @@ func (r *KairosControlPlaneReconciler) reconcileMemberLeave(ctx context.Context,
 	if err != nil {
 		return false, fmt.Errorf("etcd-leave: build workload client: %w", err)
 	}
-
-	cm := &corev1.ConfigMap{}
 	cmKey := types.NamespacedName{Namespace: etcdLeaveConfigMapNamespace, Name: etcdLeaveConfigMapName}
+
+	// (3) First entry for THIS eviction cycle (no timestamp stamped yet). FORCE the
+	// leave-requested sentinel, overwriting any STALE `left` a prior eviction of a
+	// same-named Machine left behind: Machine indices/names are reused, and the
+	// workload ConfigMap key == the Node name, so a previous cycle's ack can linger
+	// and would otherwise short-circuit this eviction into removing the hook
+	// without the (new) member ever leaving etcd → orphan. The force-write MUST
+	// precede the timestamp stamp, so a stamp failure re-forces (clears the stale
+	// ack) next reconcile rather than leaving a stale `left` visible once
+	// requested==true. Terminal checks are deliberately NOT evaluated on this pass.
+	if !requested {
+		if err := r.ensureLeaveRequested(ctx, wc, cmKey, nodeName, true /*force*/); err != nil {
+			return false, err
+		}
+		if err := r.stampLeaveRequestedAt(ctx, target); err != nil {
+			return false, err
+		}
+		log.Info("etcd-leave: leave-requested written; awaiting node ack", "machine", target.Name, "node", nodeName)
+		return false, nil
+	}
+
+	// (4) This cycle has requested a leave — terminal checks below are now valid for
+	// THIS cycle (a `left` seen here was written by the node in response to our
+	// request, not a stale prior ack).
+	cm := &corev1.ConfigMap{}
 	if err := wc.Get(ctx, cmKey, cm); err != nil && !apierrors.IsNotFound(err) {
 		// Read error is fail-safe: hook retained, requeue.
 		return false, fmt.Errorf("etcd-leave: read workload ConfigMap %s: %w", cmKey, err)
 	}
-
-	// (3) Node acked the leave — unambiguous terminal, checked before anything
-	// that depends on prior state.
+	// Node acked the leave → done.
 	if cm.Data[nodeName] == etcdLeftValue {
 		log.Info("etcd-leave: node acked left; removing hook", "machine", target.Name, "node", nodeName)
 		return true, r.removeEtcdLeaveHook(ctx, target)
 	}
-
-	// (4) Terminal checks that only apply once we have actually asked the node to
-	// leave. Gating on the stamped timestamp prevents a premature skip for a member
-	// that simply has not reported etcd-status yet (the guard already fails closed
-	// pre-delete for a live unreported member, so this is belt-and-braces).
-	if _, requested := target.Annotations[etcdLeaveRequestedAtAnnotation]; requested {
-		// Member gone from node-reported etcd-status → treat as left. Best-effort:
-		// a read error leaves the member "present" so we keep waiting, never skip.
-		if status, serr := r.readEtcdStatus(ctx, cluster); serr == nil {
-			if _, present := status[nodeName]; !present {
-				log.Info("etcd-leave: member absent from etcd-status; treating as left", "machine", target.Name, "node", nodeName)
-				return true, r.removeEtcdLeaveHook(ctx, target)
-			}
+	// Member gone from node-reported etcd-status → treat as left. Best-effort: a
+	// read error leaves the member "present" so we keep waiting, never skip.
+	if status, serr := r.readEtcdStatus(ctx, cluster); serr == nil {
+		if _, present := status[nodeName]; !present {
+			log.Info("etcd-leave: member absent from etcd-status; treating as left", "machine", target.Name, "node", nodeName)
+			return true, r.removeEtcdLeaveHook(ctx, target)
 		}
-		// Timeout backstop: an unreachable/stuck node must not wedge deletion.
-		if requestedAt, perr := time.Parse(time.RFC3339, target.Annotations[etcdLeaveRequestedAtAnnotation]); perr == nil {
-			if time.Since(requestedAt) > memberLeaveTimeout {
-				log.Info("etcd-leave: timed out waiting for node ack; removing hook (etcd member may be orphaned)",
-					"machine", target.Name, "node", nodeName, "timeout", memberLeaveTimeout)
-				if r.Recorder != nil {
-					r.Recorder.Eventf(kcp, corev1.EventTypeWarning, "EtcdMemberLeaveTimedOut",
-						"Control-plane node %q did not leave etcd within %s; proceeding with deletion — the etcd member may need manual removal", nodeName, memberLeaveTimeout)
-				}
-				return true, r.removeEtcdLeaveHook(ctx, target)
+	}
+	// Timeout backstop: an unreachable/stuck node must not wedge deletion.
+	if requestedAt, perr := time.Parse(time.RFC3339, target.Annotations[etcdLeaveRequestedAtAnnotation]); perr == nil {
+		if time.Since(requestedAt) > memberLeaveTimeout {
+			log.Info("etcd-leave: timed out waiting for node ack; removing hook (etcd member may be orphaned)",
+				"machine", target.Name, "node", nodeName, "timeout", memberLeaveTimeout)
+			if r.Recorder != nil {
+				r.Recorder.Eventf(kcp, corev1.EventTypeWarning, "EtcdMemberLeaveTimedOut",
+					"Control-plane node %q did not leave etcd within %s; proceeding with deletion — the etcd member may need manual removal", nodeName, memberLeaveTimeout)
 			}
+			return true, r.removeEtcdLeaveHook(ctx, target)
 		}
 	}
 
-	// (5) Ask the node to leave and record when we first asked, then wait.
-	if err := r.ensureLeaveRequested(ctx, wc, cmKey, nodeName); err != nil {
+	// (5) Still waiting: keep the sentinel present (preserving a just-written `left`
+	// against a racy overwrite), then requeue.
+	if err := r.ensureLeaveRequested(ctx, wc, cmKey, nodeName, false); err != nil {
 		return false, err
 	}
-	if err := r.stampLeaveRequestedAt(ctx, target); err != nil {
-		return false, err
-	}
-	log.Info("etcd-leave: leave-requested written; awaiting node ack", "machine", target.Name, "node", nodeName)
+	log.Info("etcd-leave: awaiting node ack", "machine", target.Name, "node", nodeName)
 	return false, nil
 }
 
 // ensureLeaveRequested upserts the workload-cluster ConfigMap and sets this
-// member's key to the leave-requested sentinel. It never clobbers an existing
-// `left` ack (a racy reconcile must not un-ack a node that already left).
-func (r *KairosControlPlaneReconciler) ensureLeaveRequested(ctx context.Context, wc client.Client, cmKey types.NamespacedName, nodeName string) error {
+// member's key to the leave-requested sentinel. When force is false it never
+// clobbers an existing `left` ack (a racy reconcile within a cycle must not
+// un-ack a node that already left). When force is true (the first entry of an
+// eviction cycle) it overwrites any value, including a STALE `left` left behind
+// by a prior eviction of a same-named Machine.
+func (r *KairosControlPlaneReconciler) ensureLeaveRequested(ctx context.Context, wc client.Client, cmKey types.NamespacedName, nodeName string, force bool) error {
 	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: cmKey.Name, Namespace: cmKey.Namespace}}
 	_, err := controllerutil.CreateOrUpdate(ctx, wc, cm, func() error {
 		if cm.Data == nil {
 			cm.Data = map[string]string{}
 		}
-		if cm.Data[nodeName] == etcdLeftValue {
-			return nil // already left; keep the ack
+		if !force && cm.Data[nodeName] == etcdLeftValue {
+			return nil // already left this cycle; keep the ack
 		}
 		cm.Data[nodeName] = etcdLeaveRequestedValue
 		return nil

--- a/internal/controllers/controlplane/ha_leave.go
+++ b/internal/controllers/controlplane/ha_leave.go
@@ -1,0 +1,319 @@
+/*
+Copyright 2024 The Kairos CAPI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package controlplane
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/clientcmd"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	bootstrapv1beta2 "github.com/kairos-io/cluster-api-provider-kairos/api/bootstrap/v1beta2"
+	controlplanev1beta2 "github.com/kairos-io/cluster-api-provider-kairos/api/controlplane/v1beta2"
+)
+
+// The etcd-leave handshake (ADR 0005 §E.3). These identifiers are a wire
+// contract shared with the node-side responder rendered by
+// internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl — the
+// ConfigMap name/namespace, the member key, and the two sentinel values MUST
+// match byte-for-byte or the node never sees its leave request.
+const (
+	// etcdLeaveHookName is the SUFFIX of the CAPI pre-terminate lifecycle-hook
+	// annotation stamped on k0s HA control-plane Machines. CAPI pauses Machine
+	// termination *after drain, before infrastructure teardown* (node kubelet +
+	// workload API still up) for as long as any annotation with the
+	// pre-terminate prefix is present, giving the controller a window to drive a
+	// clean `k0s etcd leave`.
+	etcdLeaveHookName = "kairos-etcd-leave"
+
+	// etcdLeaveConfigMapName / -Namespace name the workload-cluster ConfigMap the
+	// controller writes the leave request into and the node acks on. Matches the
+	// node responder.
+	etcdLeaveConfigMapName      = "kairos-etcd-leave"
+	etcdLeaveConfigMapNamespace = "kube-system"
+
+	// etcdLeaveRequestedValue is the fixed sentinel the controller writes for a
+	// member; etcdLeftValue is the ack the node writes back after `k0s etcd
+	// leave`. Compared by exact string equality on both ends — never eval'd.
+	etcdLeaveRequestedValue = "leave-requested"
+	etcdLeftValue           = "left"
+
+	// etcdLeaveRequestedAtAnnotation records (RFC3339) when the controller FIRST
+	// wrote leave-requested for a member. It anchors the timeout so an
+	// unreachable/stuck node cannot wedge Machine deletion forever.
+	etcdLeaveRequestedAtAnnotation = "controlplane.cluster.x-k8s.io/etcd-leave-requested-at"
+
+	// memberLeaveTimeout bounds the wait for a node to ack its etcd leave. The
+	// node responder polls every 30s (OnUnitActiveSec), so this allows ~10
+	// attempts before the controller gives up on the clean leave, warns that the
+	// member may be orphaned, and lets the delete proceed (quorum was already
+	// proven safe by canRemoveMember before the delete).
+	memberLeaveTimeout = 5 * time.Minute
+)
+
+// etcdLeaveHookAnnotation is the full pre-terminate hook annotation key
+// (`<prefix>/<name>`) CAPI recognizes.
+func etcdLeaveHookAnnotation() string {
+	return clusterv1.PreTerminateDeleteHookAnnotationPrefix + "/" + etcdLeaveHookName
+}
+
+// hasEtcdLeaveHook reports whether the Machine carries the etcd-leave
+// pre-terminate hook.
+func hasEtcdLeaveHook(m *clusterv1.Machine) bool {
+	_, ok := m.Annotations[etcdLeaveHookAnnotation()]
+	return ok
+}
+
+// distributionOf returns the effective distribution for a KCP, defaulting the
+// empty value to k0s (mirrors createControlPlaneMachine).
+func distributionOf(kcp *controlplanev1beta2.KairosControlPlane) string {
+	if kcp.Spec.Distribution == "" {
+		return "k0s"
+	}
+	return kcp.Spec.Distribution
+}
+
+// shouldStampEtcdLeaveHook decides whether a newly-created control-plane Machine
+// gets the etcd-leave pre-terminate hook: only k0s init/join members. Single-node
+// has no etcd cluster to leave; k3s embedded etcd has no supported member-remove
+// (KD-5d), so neither is hooked.
+func shouldStampEtcdLeaveHook(kcp *controlplanev1beta2.KairosControlPlane, role bootstrapv1beta2.ControlPlaneRole) bool {
+	if distributionOf(kcp) != "k0s" {
+		return false
+	}
+	return role == bootstrapv1beta2.ControlPlaneRoleInit || role == bootstrapv1beta2.ControlPlaneRoleJoin
+}
+
+// defaultWorkloadClient builds a client for the workload cluster from its
+// `<cluster>-kubeconfig` Secret (the KD-3b node-push payload; its server URL
+// already points at the VIP, which quorum guarantees is up). Used when the
+// reconciler's WorkloadClientFactory seam is not overridden (tests inject a fake).
+func (r *KairosControlPlaneReconciler) defaultWorkloadClient(ctx context.Context, cluster *clusterv1.Cluster) (client.Client, error) {
+	secret := &corev1.Secret{}
+	key := types.NamespacedName{Namespace: cluster.Namespace, Name: fmt.Sprintf("%s-kubeconfig", cluster.Name)}
+	if err := r.Get(ctx, key, secret); err != nil {
+		return nil, fmt.Errorf("get workload kubeconfig secret %s: %w", key, err)
+	}
+	data, ok := secret.Data["value"]
+	if !ok || len(data) == 0 {
+		return nil, fmt.Errorf("workload kubeconfig secret %s has no non-empty 'value' key", key)
+	}
+	restCfg, err := clientcmd.RESTConfigFromKubeConfig(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse workload kubeconfig %s: %w", key, err)
+	}
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	wc, err := client.New(restCfg, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil, fmt.Errorf("build workload client for cluster %s/%s: %w", cluster.Namespace, cluster.Name, err)
+	}
+	return wc, nil
+}
+
+// reconcileMemberLeave drives the clean k0s etcd-leave handshake for a
+// control-plane Machine that is being removed and still carries the etcd-leave
+// pre-terminate hook (ADR 0005 §E.3). It is called from the reconcileMachines
+// sweep for any owned, terminating, hooked Machine — which covers the
+// controller's own quorum-approved rollout/scale-down deletes, operator/MHC
+// deletes, and crash recovery. It returns done=true only once it is safe for
+// CAPI to proceed (the hook has been removed); done=false requeues.
+//
+// State machine:
+//  1. NodeRef == nil → the Machine never registered a Node: no member key to
+//     signal and no live node to run the leave. Remove the hook, done. (We key
+//     ONLY on NodeRef, never Machine phase: by the time the sweep runs the
+//     Machine is already `Deleting`, so a phase check would fire for every
+//     target and skip the leave for healthy members too.)
+//  2. Non-k0s carrying the hook (should never happen) → remove hook, done.
+//  3. Node acked `left` in the workload ConfigMap → remove hook, done.
+//  4. Already-requested AND (member gone from etcd-status OR past
+//     memberLeaveTimeout) → remove hook, done (timeout warns: member may be
+//     orphaned).
+//  5. Otherwise → write the leave-requested sentinel, stamp the first-request
+//     timestamp, requeue (done=false).
+//
+// SECURITY / fail-safe (ADR 0005 §E.5): a workload-client BUILD error or a
+// ConfigMap READ error returns the error with the hook STILL SET — the delete
+// stays blocked and quorum is preserved. The hook is never removed on an error
+// path.
+func (r *KairosControlPlaneReconciler) reconcileMemberLeave(ctx context.Context, log logr.Logger, kcp *controlplanev1beta2.KairosControlPlane, cluster *clusterv1.Cluster, target *clusterv1.Machine) (bool, error) {
+	// (1) Never-registered node: nothing to leave, nothing alive to run it.
+	if target.Status.NodeRef == nil {
+		log.Info("etcd-leave: target has no NodeRef; removing hook without leave handshake", "machine", target.Name)
+		return true, r.removeEtcdLeaveHook(ctx, target)
+	}
+	// (2) Defensive: only k0s stamps the hook.
+	if distributionOf(kcp) != "k0s" {
+		return true, r.removeEtcdLeaveHook(ctx, target)
+	}
+
+	nodeName := target.Status.NodeRef.Name
+
+	// Build the workload client on demand. Build error is fail-safe: hook retained.
+	factory := r.WorkloadClientFactory
+	if factory == nil {
+		factory = r.defaultWorkloadClient
+	}
+	wc, err := factory(ctx, cluster)
+	if err != nil {
+		return false, fmt.Errorf("etcd-leave: build workload client: %w", err)
+	}
+
+	cm := &corev1.ConfigMap{}
+	cmKey := types.NamespacedName{Namespace: etcdLeaveConfigMapNamespace, Name: etcdLeaveConfigMapName}
+	if err := wc.Get(ctx, cmKey, cm); err != nil && !apierrors.IsNotFound(err) {
+		// Read error is fail-safe: hook retained, requeue.
+		return false, fmt.Errorf("etcd-leave: read workload ConfigMap %s: %w", cmKey, err)
+	}
+
+	// (3) Node acked the leave — unambiguous terminal, checked before anything
+	// that depends on prior state.
+	if cm.Data[nodeName] == etcdLeftValue {
+		log.Info("etcd-leave: node acked left; removing hook", "machine", target.Name, "node", nodeName)
+		return true, r.removeEtcdLeaveHook(ctx, target)
+	}
+
+	// (4) Terminal checks that only apply once we have actually asked the node to
+	// leave. Gating on the stamped timestamp prevents a premature skip for a member
+	// that simply has not reported etcd-status yet (the guard already fails closed
+	// pre-delete for a live unreported member, so this is belt-and-braces).
+	if _, requested := target.Annotations[etcdLeaveRequestedAtAnnotation]; requested {
+		// Member gone from node-reported etcd-status → treat as left. Best-effort:
+		// a read error leaves the member "present" so we keep waiting, never skip.
+		if status, serr := r.readEtcdStatus(ctx, cluster); serr == nil {
+			if _, present := status[nodeName]; !present {
+				log.Info("etcd-leave: member absent from etcd-status; treating as left", "machine", target.Name, "node", nodeName)
+				return true, r.removeEtcdLeaveHook(ctx, target)
+			}
+		}
+		// Timeout backstop: an unreachable/stuck node must not wedge deletion.
+		if requestedAt, perr := time.Parse(time.RFC3339, target.Annotations[etcdLeaveRequestedAtAnnotation]); perr == nil {
+			if time.Since(requestedAt) > memberLeaveTimeout {
+				log.Info("etcd-leave: timed out waiting for node ack; removing hook (etcd member may be orphaned)",
+					"machine", target.Name, "node", nodeName, "timeout", memberLeaveTimeout)
+				if r.Recorder != nil {
+					r.Recorder.Eventf(kcp, corev1.EventTypeWarning, "EtcdMemberLeaveTimedOut",
+						"Control-plane node %q did not leave etcd within %s; proceeding with deletion — the etcd member may need manual removal", nodeName, memberLeaveTimeout)
+				}
+				return true, r.removeEtcdLeaveHook(ctx, target)
+			}
+		}
+	}
+
+	// (5) Ask the node to leave and record when we first asked, then wait.
+	if err := r.ensureLeaveRequested(ctx, wc, cmKey, nodeName); err != nil {
+		return false, err
+	}
+	if err := r.stampLeaveRequestedAt(ctx, target); err != nil {
+		return false, err
+	}
+	log.Info("etcd-leave: leave-requested written; awaiting node ack", "machine", target.Name, "node", nodeName)
+	return false, nil
+}
+
+// ensureLeaveRequested upserts the workload-cluster ConfigMap and sets this
+// member's key to the leave-requested sentinel. It never clobbers an existing
+// `left` ack (a racy reconcile must not un-ack a node that already left).
+func (r *KairosControlPlaneReconciler) ensureLeaveRequested(ctx context.Context, wc client.Client, cmKey types.NamespacedName, nodeName string) error {
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: cmKey.Name, Namespace: cmKey.Namespace}}
+	_, err := controllerutil.CreateOrUpdate(ctx, wc, cm, func() error {
+		if cm.Data == nil {
+			cm.Data = map[string]string{}
+		}
+		if cm.Data[nodeName] == etcdLeftValue {
+			return nil // already left; keep the ack
+		}
+		cm.Data[nodeName] = etcdLeaveRequestedValue
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("etcd-leave: write leave-requested to %s: %w", cmKey, err)
+	}
+	return nil
+}
+
+// stampLeaveRequestedAt records the first-request timestamp on the Machine, once.
+// The ORIGINAL timestamp is preserved on subsequent calls so the timeout window
+// is anchored to when we first asked, not the latest reconcile.
+func (r *KairosControlPlaneReconciler) stampLeaveRequestedAt(ctx context.Context, m *clusterv1.Machine) error {
+	if _, ok := m.Annotations[etcdLeaveRequestedAtAnnotation]; ok {
+		return nil
+	}
+	helper, err := patch.NewHelper(m, r.Client)
+	if err != nil {
+		return err
+	}
+	if m.Annotations == nil {
+		m.Annotations = map[string]string{}
+	}
+	m.Annotations[etcdLeaveRequestedAtAnnotation] = time.Now().UTC().Format(time.RFC3339)
+	if err := helper.Patch(ctx, m); err != nil {
+		return fmt.Errorf("stamp etcd-leave-requested-at on machine %s: %w", m.Name, err)
+	}
+	return nil
+}
+
+// removeEtcdLeaveHook drops the etcd-leave pre-terminate hook from the Machine so
+// CAPI can proceed with termination. Idempotent: a no-op if the hook is absent.
+func (r *KairosControlPlaneReconciler) removeEtcdLeaveHook(ctx context.Context, m *clusterv1.Machine) error {
+	if !hasEtcdLeaveHook(m) {
+		return nil
+	}
+	helper, err := patch.NewHelper(m, r.Client)
+	if err != nil {
+		return err
+	}
+	delete(m.Annotations, etcdLeaveHookAnnotation())
+	if err := helper.Patch(ctx, m); err != nil {
+		return fmt.Errorf("remove etcd-leave pre-terminate hook from machine %s: %w", m.Name, err)
+	}
+	return nil
+}
+
+// warnIfK3sEtcdLimitation emits a Warning event when a k3s HA control-plane
+// member is removed: k3s embedded etcd has no supported member-remove, so the
+// member stays registered after the node is gone (KD-5d). No-op for k0s (which
+// removes members cleanly via the leave handshake) and for single-node (no etcd
+// cluster).
+func (r *KairosControlPlaneReconciler) warnIfK3sEtcdLimitation(kcp *controlplanev1beta2.KairosControlPlane, target *clusterv1.Machine) {
+	if r.Recorder == nil || distributionOf(kcp) == "k0s" {
+		return
+	}
+	desired := int32(1)
+	if kcp.Spec.Replicas != nil {
+		desired = *kcp.Spec.Replicas
+	}
+	if desired <= 1 {
+		return
+	}
+	r.Recorder.Eventf(kcp, corev1.EventTypeWarning, "EtcdMemberRemoveUnsupportedForK3s",
+		"Removing control-plane Machine %q: k3s embedded etcd has no supported member-remove; the etcd member remains registered after the node is gone and may require manual `etcdctl member remove` (KD-5d)", target.Name)
+}

--- a/internal/controllers/controlplane/ha_leave_test.go
+++ b/internal/controllers/controlplane/ha_leave_test.go
@@ -370,6 +370,38 @@ func TestWarnIfK3sEtcdLimitation(t *testing.T) {
 	}
 }
 
+// TestReconcileMemberLeave_StaleLeftDoesNotShortCircuit: a fresh eviction (no
+// requested-at annotation) of a Machine whose workload ConfigMap key still holds
+// a STALE `left` from a prior eviction of a same-named Machine must NOT
+// short-circuit. It must force-rewrite leave-requested (clearing the stale ack),
+// stamp the timestamp, and wait — otherwise the new member would be deleted
+// without ever leaving etcd (orphan). Regression for the lab-found bug.
+func TestReconcileMemberLeave_StaleLeftDoesNotShortCircuit(t *testing.T) {
+	g := NewWithT(t)
+	scheme := haTestScheme(g)
+	// Fresh Machine: hook present, NO requested-at annotation.
+	target := hookedMachine("cp-0", "cp-0", nil)
+	mgmt := fake.NewClientBuilder().WithScheme(scheme).WithObjects(target, etcdStatusSecretForMembers("cp-0", "cp-1", "cp-2")).Build()
+	// Workload ConfigMap carries a STALE `left` for cp-0 from a prior cycle.
+	wc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(leaveConfigMap(map[string]string{"cp-0": etcdLeftValue})).Build()
+
+	r := &KairosControlPlaneReconciler{Client: mgmt, Scheme: scheme, WorkloadClientFactory: staticWorkloadClient(wc)}
+	done, err := r.reconcileMemberLeave(context.Background(), log.Log, k0sKCP(), testCluster(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(done).To(BeFalse(), "stale `left` must not complete the leave; a real leave must be requested")
+
+	// The stale `left` must have been overwritten with leave-requested.
+	cm := &corev1.ConfigMap{}
+	g.Expect(wc.Get(context.Background(), types.NamespacedName{Name: etcdLeaveConfigMapName, Namespace: etcdLeaveConfigMapNamespace}, cm)).To(Succeed())
+	g.Expect(cm.Data).To(HaveKeyWithValue("cp-0", etcdLeaveRequestedValue), "stale left must be overwritten")
+
+	// Timestamp stamped, hook retained.
+	got := &clusterv1.Machine{}
+	g.Expect(mgmt.Get(context.Background(), types.NamespacedName{Name: "cp-0", Namespace: "default"}, got)).To(Succeed())
+	g.Expect(got.Annotations).To(HaveKey(etcdLeaveRequestedAtAnnotation))
+	g.Expect(hasEtcdLeaveHook(got)).To(BeTrue())
+}
+
 // staticWorkloadClient returns a factory that always yields the given client.
 func staticWorkloadClient(wc client.Client) func(context.Context, *clusterv1.Cluster) (client.Client, error) {
 	return func(context.Context, *clusterv1.Cluster) (client.Client, error) { return wc, nil }

--- a/internal/controllers/controlplane/ha_leave_test.go
+++ b/internal/controllers/controlplane/ha_leave_test.go
@@ -1,0 +1,383 @@
+/*
+Copyright 2024 The Kairos CAPI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package controlplane
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	bootstrapv1beta2 "github.com/kairos-io/cluster-api-provider-kairos/api/bootstrap/v1beta2"
+	controlplanev1beta2 "github.com/kairos-io/cluster-api-provider-kairos/api/controlplane/v1beta2"
+)
+
+const testClusterName = "c"
+
+// TestEtcdLeaveHookAnnotation pins the exact hook key CAPI recognizes — a
+// mismatch would silently disable the pause and orphan etcd members.
+func TestEtcdLeaveHookAnnotation(t *testing.T) {
+	g := NewWithT(t)
+	g.Expect(etcdLeaveHookAnnotation()).To(Equal("pre-terminate.delete.hook.machine.cluster.x-k8s.io/kairos-etcd-leave"))
+}
+
+// TestShouldStampEtcdLeaveHook: only k0s init/join are hooked. Single-node has no
+// etcd cluster; k3s has no supported member-remove (KD-5d).
+func TestShouldStampEtcdLeaveHook(t *testing.T) {
+	mk := func(dist string) *controlplanev1beta2.KairosControlPlane {
+		return &controlplanev1beta2.KairosControlPlane{Spec: controlplanev1beta2.KairosControlPlaneSpec{Distribution: dist}}
+	}
+	for _, tc := range []struct {
+		name string
+		kcp  *controlplanev1beta2.KairosControlPlane
+		role bootstrapv1beta2.ControlPlaneRole
+		want bool
+	}{
+		{"k0s init", mk("k0s"), bootstrapv1beta2.ControlPlaneRoleInit, true},
+		{"k0s join", mk("k0s"), bootstrapv1beta2.ControlPlaneRoleJoin, true},
+		{"k0s single", mk("k0s"), bootstrapv1beta2.ControlPlaneRoleSingle, false},
+		{"empty dist defaults k0s init", mk(""), bootstrapv1beta2.ControlPlaneRoleInit, true},
+		{"empty dist single", mk(""), bootstrapv1beta2.ControlPlaneRoleSingle, false},
+		{"k3s init", mk("k3s"), bootstrapv1beta2.ControlPlaneRoleInit, false},
+		{"k3s join", mk("k3s"), bootstrapv1beta2.ControlPlaneRoleJoin, false},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(shouldStampEtcdLeaveHook(tc.kcp, tc.role)).To(Equal(tc.want))
+		})
+	}
+}
+
+// hookedMachine builds a k0s HA control-plane Machine carrying the etcd-leave
+// hook, with the given node name (empty → no NodeRef).
+func hookedMachine(name, node string, extraAnnotations map[string]string) *clusterv1.Machine {
+	ann := map[string]string{etcdLeaveHookAnnotation(): ""}
+	for k, v := range extraAnnotations {
+		ann[k] = v
+	}
+	m := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", Annotations: ann},
+	}
+	if node != "" {
+		m.Status.NodeRef = &corev1.ObjectReference{Name: node}
+	}
+	return m
+}
+
+func k0sKCP() *controlplanev1beta2.KairosControlPlane {
+	return &controlplanev1beta2.KairosControlPlane{
+		ObjectMeta: metav1.ObjectMeta{Name: "kcp", Namespace: "default"},
+		Spec:       controlplanev1beta2.KairosControlPlaneSpec{Distribution: "k0s", Replicas: ptr.To(int32(3))},
+	}
+}
+
+func testCluster() *clusterv1.Cluster {
+	return &clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: testClusterName, Namespace: "default"}}
+}
+
+// leaveConfigMap builds the workload-cluster kube-system/kairos-etcd-leave
+// ConfigMap with the given data.
+func leaveConfigMap(data map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: etcdLeaveConfigMapName, Namespace: etcdLeaveConfigMapNamespace},
+		Data:       data,
+	}
+}
+
+// etcdStatusSecretForMembers builds the per-cluster etcd-status Secret with the
+// given member keys present (values are minimal valid JSON).
+func etcdStatusSecretForMembers(members ...string) *corev1.Secret {
+	data := map[string][]byte{}
+	for _, m := range members {
+		data[m] = []byte(`{"name":"` + m + `","healthy":true,"voting":true,"members":3,"reportedAt":"t"}`)
+	}
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: etcdStatusSecretName(testClusterName), Namespace: "default"},
+		Data:       data,
+	}
+}
+
+// TestReconcileMemberLeave_NoNodeRefFastPath: a Machine that never registered a
+// Node has no member to leave — hook removed, done, and NO workload client built.
+func TestReconcileMemberLeave_NoNodeRefFastPath(t *testing.T) {
+	g := NewWithT(t)
+	scheme := haTestScheme(g)
+	target := hookedMachine("cp-0", "", nil)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(target).Build()
+
+	factoryCalled := false
+	r := &KairosControlPlaneReconciler{
+		Client: c, Scheme: scheme,
+		WorkloadClientFactory: func(context.Context, *clusterv1.Cluster) (client.Client, error) {
+			factoryCalled = true
+			return nil, nil
+		},
+	}
+	done, err := r.reconcileMemberLeave(context.Background(), log.Log, k0sKCP(), testCluster(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(done).To(BeTrue())
+	g.Expect(factoryCalled).To(BeFalse(), "no NodeRef must not reach the workload cluster")
+	assertHookGone(g, c, "cp-0")
+}
+
+// TestReconcileMemberLeave_NonK0sRemovesHook: defensive — a non-k0s Machine that
+// somehow carries the hook is unblocked without a k0s-specific leave.
+func TestReconcileMemberLeave_NonK0sRemovesHook(t *testing.T) {
+	g := NewWithT(t)
+	scheme := haTestScheme(g)
+	target := hookedMachine("cp-0", "cp-0", nil)
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(target).Build()
+
+	factoryCalled := false
+	r := &KairosControlPlaneReconciler{
+		Client: c, Scheme: scheme,
+		WorkloadClientFactory: func(context.Context, *clusterv1.Cluster) (client.Client, error) {
+			factoryCalled = true
+			return nil, nil
+		},
+	}
+	k3s := k0sKCP()
+	k3s.Spec.Distribution = "k3s"
+	done, err := r.reconcileMemberLeave(context.Background(), log.Log, k3s, testCluster(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(done).To(BeTrue())
+	g.Expect(factoryCalled).To(BeFalse())
+	assertHookGone(g, c, "cp-0")
+}
+
+// TestReconcileMemberLeave_WritesRequestThenWaits: first entry writes the
+// leave-requested sentinel to the workload ConfigMap, stamps the request
+// timestamp, and requeues (done=false) with the hook retained.
+func TestReconcileMemberLeave_WritesRequestThenWaits(t *testing.T) {
+	g := NewWithT(t)
+	scheme := haTestScheme(g)
+	target := hookedMachine("cp-0", "cp-0", nil)
+	mgmt := fake.NewClientBuilder().WithScheme(scheme).WithObjects(target, etcdStatusSecretForMembers("cp-0", "cp-1", "cp-2")).Build()
+	wc := fake.NewClientBuilder().WithScheme(scheme).Build() // no ConfigMap yet
+
+	r := &KairosControlPlaneReconciler{
+		Client: mgmt, Scheme: scheme,
+		WorkloadClientFactory: staticWorkloadClient(wc),
+	}
+	done, err := r.reconcileMemberLeave(context.Background(), log.Log, k0sKCP(), testCluster(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(done).To(BeFalse(), "must wait for the node to ack")
+
+	// leave-requested written to the workload ConfigMap.
+	cm := &corev1.ConfigMap{}
+	g.Expect(wc.Get(context.Background(), types.NamespacedName{Name: etcdLeaveConfigMapName, Namespace: etcdLeaveConfigMapNamespace}, cm)).To(Succeed())
+	g.Expect(cm.Data).To(HaveKeyWithValue("cp-0", etcdLeaveRequestedValue))
+
+	// timestamp stamped, hook retained.
+	got := &clusterv1.Machine{}
+	g.Expect(mgmt.Get(context.Background(), types.NamespacedName{Name: "cp-0", Namespace: "default"}, got)).To(Succeed())
+	g.Expect(got.Annotations).To(HaveKey(etcdLeaveRequestedAtAnnotation))
+	_, perr := time.Parse(time.RFC3339, got.Annotations[etcdLeaveRequestedAtAnnotation])
+	g.Expect(perr).ToNot(HaveOccurred())
+	g.Expect(hasEtcdLeaveHook(got)).To(BeTrue(), "hook must stay until the node acks")
+}
+
+// TestReconcileMemberLeave_AckRemovesHook: once the node writes `left`, the hook
+// is removed and the delete may proceed.
+func TestReconcileMemberLeave_AckRemovesHook(t *testing.T) {
+	g := NewWithT(t)
+	scheme := haTestScheme(g)
+	target := hookedMachine("cp-0", "cp-0", map[string]string{etcdLeaveRequestedAtAnnotation: time.Now().UTC().Format(time.RFC3339)})
+	mgmt := fake.NewClientBuilder().WithScheme(scheme).WithObjects(target, etcdStatusSecretForMembers("cp-0", "cp-1", "cp-2")).Build()
+	wc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(leaveConfigMap(map[string]string{"cp-0": etcdLeftValue})).Build()
+
+	r := &KairosControlPlaneReconciler{Client: mgmt, Scheme: scheme, WorkloadClientFactory: staticWorkloadClient(wc)}
+	done, err := r.reconcileMemberLeave(context.Background(), log.Log, k0sKCP(), testCluster(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(done).To(BeTrue())
+	assertHookGone(g, mgmt, "cp-0")
+}
+
+// TestReconcileMemberLeave_AbsentFromEtcdStatusRemovesHook: after we have asked
+// the node to leave, its disappearance from node-reported etcd-status is treated
+// as a completed leave (cross-check terminal).
+func TestReconcileMemberLeave_AbsentFromEtcdStatusRemovesHook(t *testing.T) {
+	g := NewWithT(t)
+	scheme := haTestScheme(g)
+	target := hookedMachine("cp-0", "cp-0", map[string]string{etcdLeaveRequestedAtAnnotation: time.Now().UTC().Format(time.RFC3339)})
+	// etcd-status no longer lists cp-0.
+	mgmt := fake.NewClientBuilder().WithScheme(scheme).WithObjects(target, etcdStatusSecretForMembers("cp-1", "cp-2")).Build()
+	wc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(leaveConfigMap(map[string]string{"cp-0": etcdLeaveRequestedValue})).Build()
+
+	r := &KairosControlPlaneReconciler{Client: mgmt, Scheme: scheme, WorkloadClientFactory: staticWorkloadClient(wc)}
+	done, err := r.reconcileMemberLeave(context.Background(), log.Log, k0sKCP(), testCluster(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(done).To(BeTrue())
+	assertHookGone(g, mgmt, "cp-0")
+}
+
+// TestReconcileMemberLeave_TimeoutRemovesHook: a node that never acks within
+// memberLeaveTimeout must not wedge deletion — the hook is removed (member may be
+// orphaned) and a Warning event is emitted.
+func TestReconcileMemberLeave_TimeoutRemovesHook(t *testing.T) {
+	g := NewWithT(t)
+	scheme := haTestScheme(g)
+	old := time.Now().Add(-2 * memberLeaveTimeout).UTC().Format(time.RFC3339)
+	target := hookedMachine("cp-0", "cp-0", map[string]string{etcdLeaveRequestedAtAnnotation: old})
+	// Member still present in etcd-status (so the cross-check does NOT short-circuit)
+	// and no `left` ack — only the timeout can fire.
+	mgmt := fake.NewClientBuilder().WithScheme(scheme).WithObjects(target, etcdStatusSecretForMembers("cp-0", "cp-1", "cp-2")).Build()
+	wc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(leaveConfigMap(map[string]string{"cp-0": etcdLeaveRequestedValue})).Build()
+
+	rec := record.NewFakeRecorder(4)
+	r := &KairosControlPlaneReconciler{Client: mgmt, Scheme: scheme, Recorder: rec, WorkloadClientFactory: staticWorkloadClient(wc)}
+	done, err := r.reconcileMemberLeave(context.Background(), log.Log, k0sKCP(), testCluster(), target)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(done).To(BeTrue())
+	assertHookGone(g, mgmt, "cp-0")
+	g.Expect(rec.Events).To(Receive(ContainSubstring("EtcdMemberLeaveTimedOut")))
+}
+
+// TestReconcileMemberLeave_ClientBuildErrorRetainsHook: a workload-client build
+// failure is FAIL-SAFE — the error propagates (caller requeues) and the hook
+// stays set so the delete remains blocked and quorum is preserved.
+func TestReconcileMemberLeave_ClientBuildErrorRetainsHook(t *testing.T) {
+	g := NewWithT(t)
+	scheme := haTestScheme(g)
+	target := hookedMachine("cp-0", "cp-0", nil)
+	mgmt := fake.NewClientBuilder().WithScheme(scheme).WithObjects(target, etcdStatusSecretForMembers("cp-0", "cp-1", "cp-2")).Build()
+
+	r := &KairosControlPlaneReconciler{
+		Client: mgmt, Scheme: scheme,
+		WorkloadClientFactory: func(context.Context, *clusterv1.Cluster) (client.Client, error) {
+			return nil, context.DeadlineExceeded
+		},
+	}
+	done, err := r.reconcileMemberLeave(context.Background(), log.Log, k0sKCP(), testCluster(), target)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(done).To(BeFalse())
+	got := &clusterv1.Machine{}
+	g.Expect(mgmt.Get(context.Background(), types.NamespacedName{Name: "cp-0", Namespace: "default"}, got)).To(Succeed())
+	g.Expect(hasEtcdLeaveHook(got)).To(BeTrue(), "hook must be retained on a client-build error (fail-safe)")
+}
+
+// TestStripEtcdLeaveHooks_Teardown: the teardown strip removes the hook from
+// every owned Machine — including one already mid-deletion and paused at the
+// hook — while leaving un-owned and un-hooked Machines untouched.
+func TestStripEtcdLeaveHooks_Teardown(t *testing.T) {
+	g := NewWithT(t)
+	scheme := haTestScheme(g)
+	kcp := &controlplanev1beta2.KairosControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kcp", Namespace: "default", UID: "kcp-uid",
+			Labels: map[string]string{clusterv1.ClusterNameLabel: testClusterName},
+		},
+	}
+	ownedRef := metav1.OwnerReference{
+		APIVersion: controlplanev1beta2.GroupVersion.String(), Kind: "KairosControlPlane",
+		Name: "kcp", UID: "kcp-uid", Controller: ptr.To(true),
+	}
+
+	// Owned + hooked, live.
+	live := &clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{
+		Name: "cp-0", Namespace: "default",
+		Labels:          map[string]string{clusterv1.ClusterNameLabel: testClusterName},
+		OwnerReferences: []metav1.OwnerReference{ownedRef},
+		Annotations:     map[string]string{etcdLeaveHookAnnotation(): ""},
+	}}
+	// Owned + hooked, ALREADY DELETING and paused at the hook (needs a finalizer
+	// for the fake client to retain a deletionTimestamp).
+	now := metav1.Now()
+	deleting := &clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{
+		Name: "cp-1", Namespace: "default",
+		Labels:            map[string]string{clusterv1.ClusterNameLabel: testClusterName},
+		OwnerReferences:   []metav1.OwnerReference{ownedRef},
+		Annotations:       map[string]string{etcdLeaveHookAnnotation(): ""},
+		DeletionTimestamp: &now,
+		Finalizers:        []string{"test.kairos.io/hold"},
+	}}
+	// Foreign (different owner UID) — must NOT be touched.
+	foreignRef := ownedRef
+	foreignRef.UID = "other-uid"
+	foreign := &clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{
+		Name: "foreign", Namespace: "default",
+		Labels:          map[string]string{clusterv1.ClusterNameLabel: testClusterName},
+		OwnerReferences: []metav1.OwnerReference{foreignRef},
+		Annotations:     map[string]string{etcdLeaveHookAnnotation(): ""},
+	}}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(kcp, live, deleting, foreign).Build()
+	g.Expect(stripEtcdLeaveHooks(context.Background(), c, kcp)).To(Succeed())
+
+	assertHookGone(g, c, "cp-0")
+	assertHookGone(g, c, "cp-1")
+
+	// Foreign Machine keeps its hook.
+	gotForeign := &clusterv1.Machine{}
+	g.Expect(c.Get(context.Background(), types.NamespacedName{Name: "foreign", Namespace: "default"}, gotForeign)).To(Succeed())
+	g.Expect(hasEtcdLeaveHook(gotForeign)).To(BeTrue(), "a Machine owned by a different KCP UID must be left alone")
+}
+
+// TestWarnIfK3sEtcdLimitation: the KD-5d warning fires for multi-replica k3s and
+// stays silent for k0s and for single-node.
+func TestWarnIfK3sEtcdLimitation(t *testing.T) {
+	target := &clusterv1.Machine{ObjectMeta: metav1.ObjectMeta{Name: "cp-0", Namespace: "default"}}
+	for _, tc := range []struct {
+		name     string
+		dist     string
+		replicas int32
+		wantEvt  bool
+	}{
+		{"k3s HA warns", "k3s", 3, true},
+		{"k0s HA silent", "k0s", 3, false},
+		{"k3s single silent", "k3s", 1, false},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			rec := record.NewFakeRecorder(4)
+			r := &KairosControlPlaneReconciler{Recorder: rec}
+			kcp := &controlplanev1beta2.KairosControlPlane{Spec: controlplanev1beta2.KairosControlPlaneSpec{
+				Distribution: tc.dist, Replicas: ptr.To(tc.replicas),
+			}}
+			r.warnIfK3sEtcdLimitation(kcp, target)
+			if tc.wantEvt {
+				g.Expect(rec.Events).To(Receive(ContainSubstring("EtcdMemberRemoveUnsupportedForK3s")))
+			} else {
+				g.Expect(rec.Events).ToNot(Receive())
+			}
+		})
+	}
+}
+
+// staticWorkloadClient returns a factory that always yields the given client.
+func staticWorkloadClient(wc client.Client) func(context.Context, *clusterv1.Cluster) (client.Client, error) {
+	return func(context.Context, *clusterv1.Cluster) (client.Client, error) { return wc, nil }
+}
+
+func assertHookGone(g *WithT, c client.Client, name string) {
+	g.THelper()
+	got := &clusterv1.Machine{}
+	g.Expect(c.Get(context.Background(), types.NamespacedName{Name: name, Namespace: "default"}, got)).To(Succeed())
+	g.Expect(hasEtcdLeaveHook(got)).To(BeFalse(), "hook should have been removed from %s", name)
+}

--- a/internal/controllers/controlplane/kairoscontrolplane_controller.go
+++ b/internal/controllers/controlplane/kairoscontrolplane_controller.go
@@ -483,6 +483,13 @@ func (r *KairosControlPlaneReconciler) reconcileMachines(ctx context.Context, lo
 		if err := r.ensureJoinTokenSecret(ctx, log, kcp, cluster); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to ensure join-token secret: %w", err)
 		}
+		// HA: ensure the per-cluster etcd-status Secret exists (Cluster-owned,
+		// empty) so every control-plane node can PATCH its own member health over
+		// the node-push channel (ADR 0005 §E.1). Consumed by the joiner gate,
+		// EtcdHealthyCondition, and the quorum-safe-replacement guard.
+		if err := r.ensureEtcdStatusSecret(ctx, log, cluster); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to ensure etcd-status secret: %w", err)
+		}
 	}
 
 	maxSurge := int32(1)

--- a/internal/controllers/controlplane/kairoscontrolplane_controller.go
+++ b/internal/controllers/controlplane/kairoscontrolplane_controller.go
@@ -523,6 +523,14 @@ func (r *KairosControlPlaneReconciler) reconcileMachines(ctx context.Context, lo
 		// If we are above desired replicas and have enough updated/ready replicas, delete one outdated machine
 		if currentReplicas > desiredReplicas && updatedReadyReplicas >= desiredReplicas {
 			target := outdatedMachines[0]
+			// ADR 0005 §E.2: refuse a quorum-breaking rollout delete. The guard
+			// fails closed and is bypassed only under whole-cluster teardown.
+			if ok, reason, err := r.canRemoveMember(ctx, kcp, cluster, target); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to evaluate etcd quorum safety: %w", err)
+			} else if !ok {
+				log.Info("Holding back outdated-machine rollout — etcd quorum would break", "machine", target.Name, "reason", reason)
+				return ctrl.Result{RequeueAfter: joinerGateRequeueAfter}, nil
+			}
 			log.Info("Deleting outdated control plane machine", "machine", target.Name)
 			if err := r.Delete(ctx, target); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to delete outdated control plane machine: %w", err)
@@ -561,6 +569,14 @@ func (r *KairosControlPlaneReconciler) reconcileMachines(ctx context.Context, lo
 	if currentReplicas > desiredReplicas {
 		target := r.selectMachineForDeletion(machines, outdatedMachines)
 		if target != nil {
+			// ADR 0005 §E.2: refuse a quorum-breaking scale-down. The guard fails
+			// closed and is bypassed only under whole-cluster teardown.
+			if ok, reason, err := r.canRemoveMember(ctx, kcp, cluster, target); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to evaluate etcd quorum safety: %w", err)
+			} else if !ok {
+				log.Info("Holding back control-plane scale-down — etcd quorum would break", "machine", target.Name, "reason", reason)
+				return ctrl.Result{RequeueAfter: joinerGateRequeueAfter}, nil
+			}
 			log.Info("Scaling down control plane machine", "machine", target.Name)
 			if err := r.Delete(ctx, target); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to delete control plane machine: %w", err)

--- a/internal/controllers/controlplane/kairoscontrolplane_controller.go
+++ b/internal/controllers/controlplane/kairoscontrolplane_controller.go
@@ -361,8 +361,9 @@ func (r *KairosControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		conditions.MarkFalse(kcp, controlplanev1beta2.AvailableCondition, controlplanev1beta2.WaitingForMachinesReason, clusterv1.ConditionSeverityInfo, "Waiting for control plane initialization")
 	}
 
-	// HA conditions (ADR 0005 Phase 3): join progress + the VIP/endpoint warning.
-	r.setHAConditions(kcp, cluster, endpointReady)
+	// HA conditions (ADR 0005 Phase 3 + §E.4): join progress, the VIP/endpoint
+	// warning, and etcd health.
+	r.setHAConditions(ctx, kcp, cluster, endpointReady)
 
 	// Failure fields were cleared above immediately after reconcileMachines
 	// returned nil (KD-14, maintainer-confirmed decision #3). The previous
@@ -625,6 +626,30 @@ func (r *KairosControlPlaneReconciler) initMachineJoinable(ctx context.Context, 
 			return false, "k0s controller-join token not yet pushed by init node", nil
 		}
 	}
+
+	// ADR 0005 §E.1: gate joiners on the init node having reported a healthy,
+	// voting etcd member into the etcd-status Secret (node-push; no etcd dial).
+	// This prevents cutting a joiner loose to `--server` into an init whose etcd
+	// is not yet a stable quorum member.
+	etcdStatus, err := r.readEtcdStatus(ctx, cluster)
+	if err != nil {
+		return false, "", err
+	}
+	initMember, reported := etcdStatus[init.Status.NodeRef.Name]
+	if distribution == "k0s" {
+		// k0s is authoritative (`k0s etcd member-list`): require a healthy voting
+		// report before opening the gate.
+		if !reported || !initMember.Healthy || !initMember.Voting {
+			return false, "init node has not yet reported a healthy voting etcd member", nil
+		}
+	} else {
+		// k3s is health-only best-effort (KD-5d): only block if the init HAS
+		// reported and explicitly says unhealthy. A missing report falls through
+		// so k3s bring-up is never regressed by the reporter's best-effort nature.
+		if reported && (!initMember.Healthy || !initMember.Voting) {
+			return false, "init node reported an unhealthy etcd member", nil
+		}
+	}
 	return true, "", nil
 }
 
@@ -859,7 +884,7 @@ func (r *KairosControlPlaneReconciler) selectMachineForDeletion(machines []*clus
 //     block nor an already-populated control-plane endpoint — it then has no
 //     stable floatable endpoint. CAPK is exempt (its LB Service is the
 //     endpoint). This does not block reconciliation; it is operator guidance.
-func (r *KairosControlPlaneReconciler) setHAConditions(kcp *controlplanev1beta2.KairosControlPlane, _ *clusterv1.Cluster, endpointReady bool) {
+func (r *KairosControlPlaneReconciler) setHAConditions(ctx context.Context, kcp *controlplanev1beta2.KairosControlPlane, cluster *clusterv1.Cluster, endpointReady bool) {
 	desiredReplicas := int32(1)
 	if kcp.Spec.Replicas != nil {
 		desiredReplicas = *kcp.Spec.Replicas
@@ -888,6 +913,30 @@ func (r *KairosControlPlaneReconciler) setHAConditions(kcp *controlplanev1beta2.
 				"set spec.ha.vip for kube-vip, or point the InfraCluster endpoint at an external load balancer",
 			desiredReplicas)
 	}
+
+	// EtcdHealthyCondition (ADR 0005 §E.4): derived from the node-reported
+	// etcd-status Secret's healthy+voting member count against the quorum
+	// minimum. Best-effort — a transient Secret read error leaves the condition
+	// unchanged rather than failing the reconcile.
+	etcdStatus, err := r.readEtcdStatus(ctx, cluster)
+	if err != nil {
+		return
+	}
+	voting := etcdVotingHealthyCount(etcdStatus)
+	quorum := desiredReplicas/2 + 1
+	switch {
+	case int32(voting) >= desiredReplicas:
+		conditions.MarkTrue(kcp, controlplanev1beta2.EtcdHealthyCondition)
+	case int32(voting) > quorum:
+		conditions.MarkFalse(kcp, controlplanev1beta2.EtcdHealthyCondition,
+			controlplanev1beta2.EtcdQuorumDegradedReason, clusterv1.ConditionSeverityInfo,
+			"%d/%d etcd members healthy", voting, desiredReplicas)
+	default: // at or below the (N/2)+1 quorum minimum (also the not-yet-formed window)
+		conditions.MarkFalse(kcp, controlplanev1beta2.EtcdHealthyCondition,
+			controlplanev1beta2.EtcdQuorumAtRiskReason, clusterv1.ConditionSeverityWarning,
+			"%d/%d etcd members healthy — at or below the quorum minimum ((N/2)+1=%d)",
+			voting, desiredReplicas, quorum)
+	}
 }
 
 func (r *KairosControlPlaneReconciler) updateStatus(ctx context.Context, log logr.Logger, kcp *controlplanev1beta2.KairosControlPlane, cluster *clusterv1.Cluster) error {
@@ -900,8 +949,6 @@ func (r *KairosControlPlaneReconciler) updateStatus(ctx context.Context, log log
 
 	readyReplicas := int32(0)
 	updatedReplicas := int32(0)
-	unavailableReplicas := int32(0)
-
 	availableReplicas := int32(0)
 	for _, machine := range machines {
 		// Check if machine is ready (has NodeRef)
@@ -914,17 +961,26 @@ func (r *KairosControlPlaneReconciler) updateStatus(ctx context.Context, log log
 			updatedReplicas++
 		}
 
-		// Check if machine is unavailable
-		if machine.Status.Phase != string(clusterv1.MachinePhaseRunning) {
-			unavailableReplicas++
-		}
-
 		// Available = ready (NodeRef set), Running phase, and not being deleted.
 		if machine.Status.NodeRef != nil &&
 			machine.Status.Phase == string(clusterv1.MachinePhaseRunning) &&
 			machine.DeletionTimestamp.IsZero() {
 			availableReplicas++
 		}
+	}
+
+	// unavailableReplicas is measured against DESIRED, not the actual machine
+	// count (ADR 0005 §E.4). During an add-before-remove surge the actual count
+	// transiently exceeds desired; counting every non-Running machine then
+	// double-counted the surge node as unavailable. Contract semantics:
+	// unavailable = replicas not available toward the desired spec, floored at 0.
+	desiredReplicas := int32(1)
+	if kcp.Spec.Replicas != nil {
+		desiredReplicas = *kcp.Spec.Replicas
+	}
+	unavailableReplicas := desiredReplicas - availableReplicas
+	if unavailableReplicas < 0 {
+		unavailableReplicas = 0
 	}
 
 	// ReadyReplicas should only be counted when NodeRef is actually set

--- a/internal/controllers/controlplane/kairoscontrolplane_controller.go
+++ b/internal/controllers/controlplane/kairoscontrolplane_controller.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/record"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -55,7 +56,15 @@ import (
 // KairosControlPlaneReconciler reconciles a KairosControlPlane object
 type KairosControlPlaneReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
+
+	// WorkloadClientFactory builds a client for the workload cluster from its
+	// `<cluster>-kubeconfig` Secret. It backs the etcd-leave handshake (ADR 0005
+	// §E.3), which must reach the workload apiserver. nil → defaultWorkloadClient;
+	// tests inject a fake. Kept as a struct field (not a hard dependency on
+	// remote.NewClusterClient) so unit tests need no live workload cluster.
+	WorkloadClientFactory func(ctx context.Context, cluster *clusterv1.Cluster) (client.Client, error)
 }
 
 const controlPlaneLBServiceSuffix = "control-plane-lb"
@@ -476,6 +485,28 @@ func (r *KairosControlPlaneReconciler) reconcileMachines(ctx context.Context, lo
 
 	log.Info("Reconciling control plane machines", "desired", desiredReplicas, "current", currentReplicas)
 
+	// HA (ADR 0005 §E.3): before any scale/rollout math, progress the etcd-leave
+	// pre-terminate handshake for every owned control-plane Machine that is
+	// terminating and still carries our hook. This single sweep covers the
+	// controller's own quorum-approved deletes below, operator/MHC-initiated
+	// Machine deletes, and crash recovery — the hook keeps CAPI paused (after
+	// drain, node still up) until the member has cleanly left etcd. A workload
+	// client/read error keeps the hook set (fail-safe: the delete stays blocked
+	// and quorum is preserved) and requeues; an in-progress leave requeues so we
+	// do not churn other machines while a member is draining out of etcd.
+	for _, m := range machines {
+		if m.DeletionTimestamp.IsZero() || !hasEtcdLeaveHook(m) {
+			continue
+		}
+		done, err := r.reconcileMemberLeave(ctx, log, kcp, cluster, m)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to reconcile etcd member leave for %s: %w", m.Name, err)
+		}
+		if !done {
+			return ctrl.Result{RequeueAfter: joinerGateRequeueAfter}, nil
+		}
+	}
+
 	// HA: ensure the per-cluster join-token Secret exists before any joiner is
 	// created (ADR 0005 Phase 3). For k3s the controller generates the shared
 	// server token up front; for k0s the Secret is created empty and the init
@@ -531,6 +562,10 @@ func (r *KairosControlPlaneReconciler) reconcileMachines(ctx context.Context, lo
 				log.Info("Holding back outdated-machine rollout — etcd quorum would break", "machine", target.Name, "reason", reason)
 				return ctrl.Result{RequeueAfter: joinerGateRequeueAfter}, nil
 			}
+			// k3s embedded etcd has no supported member-remove (KD-5d); warn that
+			// the member will linger. For k0s the sweep above drives a clean
+			// `k0s etcd leave` while CAPI is paused at the pre-terminate hook.
+			r.warnIfK3sEtcdLimitation(kcp, target)
 			log.Info("Deleting outdated control plane machine", "machine", target.Name)
 			if err := r.Delete(ctx, target); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to delete outdated control plane machine: %w", err)
@@ -577,6 +612,10 @@ func (r *KairosControlPlaneReconciler) reconcileMachines(ctx context.Context, lo
 				log.Info("Holding back control-plane scale-down — etcd quorum would break", "machine", target.Name, "reason", reason)
 				return ctrl.Result{RequeueAfter: joinerGateRequeueAfter}, nil
 			}
+			// k3s embedded etcd has no supported member-remove (KD-5d); warn that
+			// the member will linger. For k0s the sweep above drives a clean
+			// `k0s etcd leave` while CAPI is paused at the pre-terminate hook.
+			r.warnIfK3sEtcdLimitation(kcp, target)
 			log.Info("Scaling down control plane machine", "machine", target.Name)
 			if err := r.Delete(ctx, target); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to delete control plane machine: %w", err)
@@ -673,10 +712,7 @@ func (r *KairosControlPlaneReconciler) createControlPlaneMachine(ctx context.Con
 	machineName := fmt.Sprintf("%s-%d", kcp.Name, index)
 
 	// Create KairosConfig
-	distribution := kcp.Spec.Distribution
-	if distribution == "" {
-		distribution = "k0s"
-	}
+	distribution := distributionOf(kcp)
 	kairosConfig := &bootstrapv1beta2.KairosConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-%d", kcp.Name, index),
@@ -765,6 +801,19 @@ func (r *KairosControlPlaneReconciler) createControlPlaneMachine(ctx context.Con
 				Namespace:  infraMachine.GetNamespace(),
 			},
 		},
+	}
+
+	// HA (ADR 0005 §E.3): stamp the etcd-leave pre-terminate hook on k0s HA
+	// control-plane Machines so CAPI pauses termination after drain (node still
+	// up) until the controller has driven a clean `k0s etcd leave`. Only k0s
+	// init/join are hooked — single-node has no etcd cluster and k3s has no
+	// supported member-remove (KD-5d). The empty annotation value is the CAPI
+	// convention for a hook awaiting external completion.
+	if shouldStampEtcdLeaveHook(kcp, role) {
+		if machine.Annotations == nil {
+			machine.Annotations = map[string]string{}
+		}
+		machine.Annotations[etcdLeaveHookAnnotation()] = ""
 	}
 
 	return r.Create(ctx, machine)
@@ -1607,6 +1656,16 @@ func (r *KairosControlPlaneReconciler) triggerClusterReconciliation(ctx context.
 // bypass the deferred Patch -- this path has already finalized the object
 // via a bare r.Update and a follow-up Patch would race with apiserver GC.
 func (r *KairosControlPlaneReconciler) reconcileDelete(ctx context.Context, log logr.Logger, kcp *controlplanev1beta2.KairosControlPlane) (ctrl.Result, bool, error) {
+	// ADR 0005 §E.3 (LOAD-BEARING): strip the etcd-leave pre-terminate hook from
+	// every owned Machine BEFORE draining. The hook pauses CAPI termination, and
+	// only the non-delete-path sweep (reconcileMachines) removes it during normal
+	// operation — so on whole-cluster teardown it would deadlock the drain.
+	// Teardown discards etcd wholesale, so no per-member leave is needed.
+	if err := stripEtcdLeaveHooks(ctx, r.Client, kcp); err != nil {
+		log.Error(err, "Failed to strip etcd-leave pre-terminate hooks during teardown",
+			"kcp", kcp.Name, "namespace", kcp.Namespace, "uid", kcp.UID)
+		return ctrl.Result{}, false, err
+	}
 	remaining, err := drainOwnedMachines(ctx, r.Client, kcp)
 	if err != nil {
 		log.Error(err, "Failed to drain owned Machines",

--- a/internal/controllers/controlplane/kairoscontrolplane_controller.go
+++ b/internal/controllers/controlplane/kairoscontrolplane_controller.go
@@ -652,10 +652,14 @@ func (r *KairosControlPlaneReconciler) controlPlaneRoleForNewMachine(desiredRepl
 //     kubeconfig — KD-3b), AND
 //   - for k0s only, the join-token Secret has a non-empty token (the init node
 //     minted `k0s token create` and pushed it back). For k3s the token is
-//     controller-generated up front, so this clause is skipped.
+//     controller-generated up front, so this clause is skipped, AND
+//   - the init node has reported a healthy voting etcd member into the
+//     etcd-status Secret (ADR 0005 §E.1) — strict for k0s (authoritative
+//     `k0s etcd member-list`), advisory for k3s (block only on an explicit
+//     unhealthy report; a missing report never regresses k3s bring-up).
 //
-// Real etcd-member health is deferred to Phase 4. reason is a short
-// human-readable explanation when not joinable (for logging/conditions).
+// reason is a short human-readable explanation when not joinable (for
+// logging/conditions).
 func (r *KairosControlPlaneReconciler) initMachineJoinable(ctx context.Context, kcp *controlplanev1beta2.KairosControlPlane, cluster *clusterv1.Cluster, machines []*clusterv1.Machine) (bool, string, error) {
 	if len(machines) == 0 {
 		return false, "init machine not created yet", nil

--- a/main.go
+++ b/main.go
@@ -149,8 +149,11 @@ func main() {
 	}
 
 	if err = (&controlplane.KairosControlPlaneReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("kairoscontrolplane-controller"),
+		// WorkloadClientFactory left nil → defaultWorkloadClient (builds a client
+		// from the <cluster>-kubeconfig Secret) for the etcd-leave handshake.
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KairosControlPlane")
 		os.Exit(1)

--- a/test/envtest/controlplane_ha_test.go
+++ b/test/envtest/controlplane_ha_test.go
@@ -181,11 +181,13 @@ func TestHA_K0sJoinTokenSecret_CreatedEmpty(t *testing.T) {
 }
 
 // TestHA_RoleAssignment_InitFirstThenJoin asserts the sequencing gate + role
-// assignment (ADR 0005 Phase 3): the first CP KairosConfig is created with
-// role=init, and NO join KairosConfig is created until the init machine is
-// joinable (NodeRef + KubeconfigReady + k0s token present). We drive that state
-// by hand (pre-create the init Machine with a NodeRef, push the kubeconfig
-// Secret, populate the k0s token) and assert a join KairosConfig then appears.
+// assignment (ADR 0005 Phase 3 + Phase-4 §E.1): the first CP KairosConfig is
+// created with role=init, and NO join KairosConfig is created until the init
+// machine is joinable (NodeRef + KubeconfigReady + k0s token present + the init
+// node has reported a healthy voting etcd member). We drive that state by hand
+// (pre-create the init Machine with a NodeRef, push the kubeconfig Secret,
+// populate the k0s token, write the init node's etcd-status report) and assert a
+// join KairosConfig then appears.
 func TestHA_RoleAssignment_InitFirstThenJoin(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -227,7 +229,8 @@ func TestHA_RoleAssignment_InitFirstThenJoin(t *testing.T) {
 	// Now make the init machine joinable:
 	//  (1) pre-create the init Machine with a NodeRef and Running phase,
 	//  (2) push the kubeconfig Secret (opens KubeconfigReady),
-	//  (3) populate the k0s join-token Secret (init-node push simulation).
+	//  (3) populate the k0s join-token Secret (init-node push simulation),
+	//  (4) report the init node's healthy voting etcd member (ADR 0005 §E.1).
 	initMachine := &clusterv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kcpName + "-0",
@@ -268,6 +271,25 @@ func TestHA_RoleAssignment_InitFirstThenJoin(t *testing.T) {
 	tokenSecret.Data[bootstrapv1beta2.ControlPlaneJoinTokenSecretDataKey] = []byte("k0s-controller-join-token")
 	g.Expect(c.Update(ctx, tokenSecret)).To(Succeed())
 
+	// (4) Simulate the init node reporting a healthy, voting etcd member into the
+	// per-cluster etcd-status Secret (ADR 0005 §E.1). The Phase-4 k0s joiner gate
+	// requires this before opening; envtest has no real node reporter, so we write
+	// it by hand keyed on the init node's Node name. The controller creates this
+	// Secret (Cluster-owned, empty) for replicas>1, so retry until it exists and
+	// on write conflicts.
+	etcdStatusName := bootstrapv1beta2.EtcdStatusSecretName(clusterName)
+	g.Eventually(func() error {
+		es := &corev1.Secret{}
+		if err := c.Get(ctx, types.NamespacedName{Name: etcdStatusName, Namespace: nsName}, es); err != nil {
+			return err
+		}
+		if es.Data == nil {
+			es.Data = map[string][]byte{}
+		}
+		es.Data["init-node"] = []byte(`{"name":"init-node","healthy":true,"voting":true,"members":1,"reportedAt":"t"}`)
+		return c.Update(ctx, es)
+	}, 15*time.Second, 500*time.Millisecond).Should(Succeed())
+
 	// The gate should now open and the controller should create the join config.
 	g.Eventually(func() (bootstrapv1beta2.ControlPlaneRole, error) {
 		cfg := &bootstrapv1beta2.KairosConfig{}
@@ -275,7 +297,7 @@ func TestHA_RoleAssignment_InitFirstThenJoin(t *testing.T) {
 			return "", err
 		}
 		return cfg.Spec.ControlPlaneRole, nil
-	}, 20*time.Second, 500*time.Millisecond).Should(Equal(bootstrapv1beta2.ControlPlaneRoleJoin),
+	}, 30*time.Second, 500*time.Millisecond).Should(Equal(bootstrapv1beta2.ControlPlaneRoleJoin),
 		"join config must be created once the init machine is joinable")
 }
 


### PR DESCRIPTION
## Summary

Phase-4 **day-2** for HA control planes: quorum-safe control-plane replacement, per-member etcd health, and clean k0s etcd-member eviction on removal. Builds on the multi-node bring-up merged in #74 (Phase-4 day-0) and the Phase 1–3 HA work (#70–#72).

With this PR a k0s HA control plane survives node replacement without orphaning etcd members, refuses removals that would break etcd quorum, and surfaces etcd health as a condition. k3s HA remains supported for bring-up but its embedded etcd has no clean member-remove (documented limitation, KD-5d).

## What's included

- **etcd health reporting** — each control-plane node pushes its own etcd member health (member id, voting, healthy, member-list count) into a per-cluster, Cluster-owned `<cluster>-etcd-status` Secret over the existing node-push channel (k0s full via `k0s etcd member-list`; k3s health-only).
- **`EtcdHealthy` condition** on `KairosControlPlane` (True when all desired voting members are healthy; Warning/Info as quorum degrades), plus a joiner gate that graduates a joiner only once the init node reports a healthy voting member, and an `unavailableReplicas = max(0, desired-available)` fix so an add-before-remove surge node no longer double-counts.
- **Quorum-safe replacement guard** (`canRemoveMember`) on every non-teardown control-plane delete site — fails closed, bypassed only by whole-cluster teardown, and counts healthy+voting reporters (never the unvalidated node-reported member list).
- **Clean k0s etcd-leave** — a CAPI pre-terminate lifecycle hook pauses termination after drain (node still up); the controller writes a `leave-requested` sentinel into a workload-cluster `kube-system/kairos-etcd-leave` ConfigMap; a node-side systemd responder runs `k0s etcd leave` and acks `left` (both read and ack via the control-plane VIP, the surviving endpoint); the controller then removes the hook and lets the delete proceed. No synchronous etcd/SSH in Reconcile. `reconcileDelete` strips the hook from all owned Machines before draining so whole-cluster teardown never deadlocks. k3s emits an `EtcdMemberRemoveUnsupportedForK3s` warning instead (KD-5d).
- **Docs** — README/QUICKSTART_CAPV/API_REFERENCE HA sections, a 3-node k0s HA sample (`config/samples/capv/kairos_cluster_k0s_ha.yaml`), release notes, and the stale "HA on the roadmap" wording corrected across the quickstarts.

## Design

Hook-paused, sweep-driven (the canonical CAPI pre-terminate pattern): the hook is stamped at Machine creation for k0s init/join only, and a single sweep in `reconcileMachines` drives the leave handshake for any owned + terminating + hooked Machine — covering the controller's own rollout/scale-down deletes, operator/MHC deletes, and crash recovery uniformly. The quorum guard is the pre-delete authorization; the leave handshake is cleanup only and never calls `Delete`, so a forged health/ack signal can only make an already-authorized delete cleaner, never break quorum.

## Testing

- Unit + golden tests for every stage (reporter render, guard math table, leave state machine incl. no-NodeRef / non-k0s / write-then-wait / ack / etcd-status-absent / timeout / client-build-error-retains-hook / stale-ack-does-not-short-circuit, teardown strip). `go test ./...` green (envtest job excluded as before).
- **Lab e2e** on CAPV k0s 3-node HA: bring-up to `readyReplicas=3` (`EtcdHealthy=True`), clean etcd member eviction with the member list staying consistent and **no orphan across two consecutive same-name evictions**, `left` ack in ~30s via the VIP, replacement rejoin to 3, teardown draining multi-hook clusters without deadlock. The e2e surfaced and this PR fixes three multi-node-only bugs (member-key trailing-newline, ack-via-dying-local-apiserver, stale-ack reuse) that unit/golden coverage could not catch.

## Known limitations

- **k3s** HA control-plane replacement leaves an orphaned etcd member (no supported member-remove); manual `etcdctl member remove` required. k0s is the fully-supported HA path.
- A k0s node that never acks its leave within ~5 min is deleted anyway (quorum already proven safe); watch for the `EtcdMemberLeaveTimedOut` warning — the member may need manual removal.
- Node-self-reported etcd health and the leave ack are written with vanilla RBAC on shared objects and are therefore forgeable by a compromised control-plane node (not privilege escalation, and cannot force an unsafe delete). Per-member-scoped signals are tracked future hardening.
