### PR TITLE
docs(release-notes): fix dead links and remove § in v0.1.0-beta.1 notes

### DIFF
--- a/docs/release-notes/v0.1.0-beta.1.md
+++ b/docs/release-notes/v0.1.0-beta.1.md
@@ -2,7 +2,7 @@
 
 This is a pre-1.0 release. The API surface may still change before v1.0.
 
-Read the [upgrade guide](../UPGRADING.md) before installing. If you are
+Read the [upgrade guide](https://github.com/kairos-io/cluster-api-provider-kairos/blob/v0.1.0-beta.1/docs/UPGRADING.md) before installing. If you are
 upgrading from v0.1.0-alpha.2, the breaking-changes section below is required
 reading.
 
@@ -48,8 +48,7 @@ The management-side CAPI dependency moves from v1.8 to v1.13.3, adopting
 `sigs.k8s.io/cluster-api/api/core/v1beta2` object references
 (`ContractVersionedObjectReference` / `MachineNodeReference`) in place of the
 v1beta1 pointer-based references. **Management clusters must run CAPI core
-v1.13.3+.** See [ADR 0006](../../.claude/decisions/0006-dependency-bump-capi-v1.13.md)
-for the full migration rationale.
+v1.13.3+.**
 
 **Deploy CRDs via kustomize or clusterctl, never raw `kubectl apply -f
 config/crd/bases/`.** This provider's CRDs must carry the
@@ -132,9 +131,9 @@ finish — no orphaned etcd member on k0s.
 New samples: `config/samples/capk/kubevirt_cluster_{k0s,k3s}_ha.yaml`,
 `config/samples/capv/kairos_cluster_{k0s,k3s}_ha.yaml`,
 `config/samples/capm3/kairos_cluster_{k0s,k3s}_ha.yaml`. New quickstart
-sections: [QUICKSTART_CAPK.md § High-availability](../QUICKSTART_CAPK.md#high-availability-control-plane),
-[QUICKSTART_CAPV.md § High-Availability](../QUICKSTART_CAPV.md#high-availability-3-node-k0s-control-plane),
-[QUICKSTART_CAPM3.md § High-Availability](../QUICKSTART_CAPM3.md#high-availability-control-plane).
+sections: [CAPK quickstart — High-availability](https://github.com/kairos-io/cluster-api-provider-kairos/blob/v0.1.0-beta.1/docs/QUICKSTART_CAPK.md#high-availability-control-plane),
+[CAPV quickstart — High-Availability](https://github.com/kairos-io/cluster-api-provider-kairos/blob/v0.1.0-beta.1/docs/QUICKSTART_CAPV.md#high-availability-3-node-k0s-control-plane),
+[CAPM3 quickstart — High-Availability](https://github.com/kairos-io/cluster-api-provider-kairos/blob/v0.1.0-beta.1/docs/QUICKSTART_CAPM3.md#high-availability-control-plane).
 
 ---
 
@@ -211,7 +210,7 @@ scheduled yet.
 
 ## Compatibility
 
-See [README.md § Target Versions](../../README.md#target-versions) for the
+See [README — Target Versions](https://github.com/kairos-io/cluster-api-provider-kairos/blob/v0.1.0-beta.1/README.md#target-versions) for the
 current matrix. Summary of what changed since v0.1.0-alpha.2:
 
 | Component | v0.1.0-alpha.2 | v0.1.0-beta.1 |
@@ -233,5 +232,5 @@ cluster (`spec.ha.vip`, `replicas: 3`/`5`, additional control-plane
 Machines) rather than expect an in-place single-node-to-HA conversion; that
 migration path is not supported.
 
-See [UPGRADING.md § v0.1.0-alpha.2 → v0.1.0-beta.1](../UPGRADING.md#v010-alpha2--v010-beta1)
+See [UPGRADING — v0.1.0-alpha.2 to v0.1.0-beta.1](https://github.com/kairos-io/cluster-api-provider-kairos/blob/v0.1.0-beta.1/docs/UPGRADING.md#v010-alpha2--v010-beta1)
 for the full step-by-step upgrade procedure.


### PR DESCRIPTION
Fixes the v0.1.0-beta.1 release notes so their links actually resolve.

**Problems**
- Relative links (`../UPGRADING.md`, `../../README.md`, `../QUICKSTART_*.md`) don't resolve on the **GitHub release page** — release-page markdown isn't rendered relative to the file's repo path.
- The `../../.claude/decisions/0006-...` ADR link pointed into `.claude/`, which is **gitignored** and absent from GitHub — a permanently dead link.
- `§` used in link display text (maintainer preference to drop it).

**Fix**
- All links rewritten as absolute URLs pinned to the `v0.1.0-beta.1` tag (each verified HTTP 200).
- Non-public ADR link removed.
- `§` removed from link text. No content changes.

The **published GitHub release body was already updated in place** to match; this brings the repo source into line.