### PR TITLE
docs: remove § section-sign from docs and sample manifests

### DIFF
--- a/config/samples/capm3/kairos_cluster_k0s_single_node.yaml
+++ b/config/samples/capm3/kairos_cluster_k0s_single_node.yaml
@@ -22,7 +22,7 @@
 #      kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-beta.1/kairos-capi-provider.yaml
 #
 #   5. A fully-installed Kairos k0s disk image served over HTTP.
-#      See docs/QUICKSTART_CAPM3.md § "Building the disk image".
+#      See docs/QUICKSTART_CAPM3.md section "Building the disk image".
 #      Use a Kairos installer ISO built with k0s, e.g.:
 #        kairos-ubuntu-24.04-standard-amd64-generic-v3.6.0-k0sv1.32.3+k0s.0.iso
 #
@@ -49,8 +49,8 @@
 # HADRON IMAGES: an auroraboot disk.raw or build-iso output for Hadron also
 # does not work. The node will boot into recovery mode (kairos-agent reports
 # boot_mode=recovery_boot) and k0s will never start. Build a fully-installed
-# disk using the QEMU procedure. See docs/QUICKSTART_CAPM3.md §
-# "Hadron images: additional failure mode" and § "Hadron on Metal3: operator
+# disk using the QEMU procedure. See docs/QUICKSTART_CAPM3.md section
+# "Hadron images: additional failure mode" and section "Hadron on Metal3: operator
 # notes" for the build pipeline and IP-pinning guidance.
 #
 # !! CRITICAL: KUBERNETES VERSION IS BAKED INTO THE DISK IMAGE !!

--- a/config/samples/capm3/kairos_cluster_k3s_single_node.yaml
+++ b/config/samples/capm3/kairos_cluster_k3s_single_node.yaml
@@ -57,8 +57,8 @@
 #
 # You MUST supply a fully-installed disk image (COS_ACTIVE + COS_PERSISTENT
 # for standard Kairos; "state" + "recovery" for Hadron). See
-# docs/QUICKSTART_CAPM3.md § "Building the disk image" for the QEMU
-# install-to-disk procedure and § "Hadron on Metal3: operator notes" for
+# docs/QUICKSTART_CAPM3.md section "Building the disk image" for the QEMU
+# install-to-disk procedure and section "Hadron on Metal3: operator notes" for
 # Hadron-specific guidance including control-plane IP pinning.
 #
 # !! CRITICAL: KUBERNETES VERSION IS BAKED INTO THE DISK IMAGE !!

--- a/config/samples/capv/kairos_cluster_k0s_ha.yaml
+++ b/config/samples/capv/kairos_cluster_k0s_ha.yaml
@@ -19,7 +19,7 @@
 #     pool), and spec.ha.vip.interface must be the NIC name that exists on the
 #     nodes (e.g. "ens192" on vSphere Hadron images — verify with `ip link`).
 #
-# DAY-2 BEHAVIOUR (ADR 0005 §E):
+# DAY-2 BEHAVIOUR (ADR 0005 section E):
 #   - Each control-plane node reports its etcd member health into a per-cluster
 #     Secret; the controller surfaces it as the EtcdHealthy condition on the
 #     KairosControlPlane (kubectl get kairoscontrolplane -o yaml).

--- a/config/samples/capv/kairos_cluster_k3s_ha.yaml
+++ b/config/samples/capv/kairos_cluster_k3s_ha.yaml
@@ -32,7 +32,7 @@
 # member requiring manual `etcdctl member remove`. See the limitations
 # footer at the bottom of this file and docs/QUICKSTART_CAPV.md.
 #
-# DAY-2 BEHAVIOUR (ADR 0005 §E):
+# DAY-2 BEHAVIOUR (ADR 0005 section E):
 #   - Each control-plane node reports its etcd member health into a per-cluster
 #     Secret; the controller surfaces it as the EtcdHealthy condition on the
 #     KairosControlPlane (kubectl get kairoscontrolplane -o yaml).

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -503,7 +503,7 @@ When `KairosControlPlane.spec.replicas == 1`, the controller automatically sets 
 
 `KairosControlPlane.spec.replicas` accepts `1`, `3`, or `5`. The validating webhook rejects even counts (they give the same etcd fault tolerance as the next-lower odd count while raising the quorum requirement — always use the next-higher odd number instead) and values above `5` (beyond 5 members the quorum cost outweighs the added fault tolerance for a control plane).
 
-`3` and `5` configure a highly-available control plane. Set `spec.ha.vip` on CAPV, CAPM3, and CAPD clusters so kube-vip provides a stable, failover-capable endpoint — do not set it on CAPK, which supplies its own LoadBalancer-backed endpoint. See [HAConfig](#haconfig) and [EtcdHealthy condition](#etcdhealthy-condition) above, and [README.md § High-Availability control planes](../README.md#high-availability-control-planes) for the full day-2 behavior (quorum-safe replacement, k0s clean etcd-leave, and the k3s orphaned-member limitation tracked as KD-5d).
+`3` and `5` configure a highly-available control plane. Set `spec.ha.vip` on CAPV, CAPM3, and CAPD clusters so kube-vip provides a stable, failover-capable endpoint — do not set it on CAPK, which supplies its own LoadBalancer-backed endpoint. See [HAConfig](#haconfig) and [EtcdHealthy condition](#etcdhealthy-condition) above, and [README.md — High-Availability control planes](../README.md#high-availability-control-planes) for the full day-2 behavior (quorum-safe replacement, k0s clean etcd-leave, and the k3s orphaned-member limitation tracked as KD-5d).
 
 ### Security Considerations
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -132,7 +132,7 @@ curl -k https://<mgmt-api-server-host>:6443/api
 For air-gapped or strictly-segmented network environments, enable the opt-in
 `SSHFallback` mechanism on the `KairosControlPlane`. This requires a
 host-key-verified SSH identity Secret and a `known_hosts` Secret. See
-[QUICKSTART_CAPV.md §Air-gapped fallback](QUICKSTART_CAPV.md#air-gapped-fallback-sshfallback)
+[QUICKSTART_CAPV.md — Air-gapped fallback](QUICKSTART_CAPV.md#air-gapped-fallback-sshfallback)
 for the full configuration steps.
 
 ---

--- a/docs/QUICKSTART_CAPM3.md
+++ b/docs/QUICKSTART_CAPM3.md
@@ -357,7 +357,7 @@ If the node cannot reach the management API server, enable the opt-in [Air-gappe
 
 CAPM3 supports a 3- or 5-node control plane fronted by a kube-vip virtual IP (VIP), using [`config/samples/capm3/kairos_cluster_k0s_ha.yaml`](../config/samples/capm3/kairos_cluster_k0s_ha.yaml) or [`kairos_cluster_k3s_ha.yaml`](../config/samples/capm3/kairos_cluster_k3s_ha.yaml). Read the single-node walkthrough above first — the disk-image, BareMetalHost, and credentials-Secret steps are identical. This section covers only what's different for HA.
 
-k0s is the fully-supported HA distribution. k3s HA bring-up works the same way, but replacing a k3s control-plane node afterward leaves an orphaned etcd member requiring manual cleanup (KD-5d) — see [README.md § Day-2](../README.md#day-2-etcd-health-and-quorum-safe-replacement).
+k0s is the fully-supported HA distribution. k3s HA bring-up works the same way, but replacing a k3s control-plane node afterward leaves an orphaned etcd member requiring manual cleanup (KD-5d) — see [README.md — Day-2](../README.md#day-2-etcd-health-and-quorum-safe-replacement).
 
 ### HA prerequisites
 

--- a/docs/QUICKSTART_CAPV.md
+++ b/docs/QUICKSTART_CAPV.md
@@ -316,7 +316,7 @@ on the `KairosControlPlane`.
 
 This section walks through a 3-node HA k0s control plane fronted by a kube-vip virtual IP (VIP), using [`config/samples/capv/kairos_cluster_k0s_ha.yaml`](../config/samples/capv/kairos_cluster_k0s_ha.yaml). A k3s HA sample with the same shape is at [`config/samples/capv/kairos_cluster_k3s_ha.yaml`](../config/samples/capv/kairos_cluster_k3s_ha.yaml). Read the [single-node walkthrough](#creating-a-cluster) above first — the vSphere template, credentials Secret, and `userPasswordSecretRef` steps are identical. This section covers only what's different for HA.
 
-k0s is the fully-supported HA distribution. k3s HA bring-up works the same way, but replacing a k3s control-plane node afterward leaves an orphaned etcd member requiring manual cleanup — see [README.md § High-Availability control planes](../README.md#high-availability-control-planes) for the full day-2 explanation (KD-5d).
+k0s is the fully-supported HA distribution. k3s HA bring-up works the same way, but replacing a k3s control-plane node afterward leaves an orphaned etcd member requiring manual cleanup — see [README.md — High-Availability control planes](../README.md#high-availability-control-planes) for the full day-2 explanation (KD-5d).
 
 ### HA prerequisites
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -190,7 +190,7 @@ the YAML shape (including an explicit `metadata: {}`) is unaffected.
 Previously only `1` was accepted. `replicas: 3` or `5` now provisions a
 multi-node control plane; even counts and values above `5` are
 webhook-rejected. Existing `replicas: 1` deployments are unaffected. See
-[README.md § High-Availability control planes](../README.md#high-availability-control-planes)
+[README.md — High-Availability control planes](../README.md#high-availability-control-planes)
 for the new HA fields (`spec.ha.vip`, provider-specific endpoint mechanism)
 and the [HA sample manifests](../config/samples/) for CAPK, CAPV, and CAPM3.
 

--- a/docs/release-notes/v0.1.0-alpha.2.md
+++ b/docs/release-notes/v0.1.0-alpha.2.md
@@ -50,7 +50,7 @@ controller (no node-push block) must receive a new bootstrap Secret before the
 controller can acquire the workload kubeconfig. Trigger a KCP rollout (or
 delete the KairosConfig) to re-render the Secret with the alpha-2 template.
 Clusters that are already healthy and whose kubeconfig Secret is present are
-unaffected. See [UPGRADING.md §KD-3b](../UPGRADING.md#kd-3b-ssh-eliminated-from-controller-normal-operation).
+unaffected. See [UPGRADING.md — KD-3b](../UPGRADING.md#kd-3b-ssh-eliminated-from-controller-normal-operation).
 
 ---
 
@@ -76,7 +76,7 @@ code changes targeted at it in this release.
 
 **Installed-disk requirement:** Ironic must deploy a fully-installed Kairos
 raw disk image (not an auroraboot auto-reset image). See
-[QUICKSTART_CAPM3.md §Building the disk image](QUICKSTART_CAPM3.md#building-the-disk-image)
+[QUICKSTART_CAPM3.md — Building the disk image](QUICKSTART_CAPM3.md#building-the-disk-image)
 for the build pipeline and Hadron-specific failure modes.
 
 ### Opt-in host-key-verified SSH fallback for air-gapped environments (SSHFallback)
@@ -100,8 +100,8 @@ spec:
     activateAfter: 15m   # must exceed the 10m Info→Warning threshold
 ```
 
-See [QUICKSTART_CAPV.md §Air-gapped fallback](QUICKSTART_CAPV.md#air-gapped-fallback-sshfallback)
-and [QUICKSTART_CAPM3.md §Air-gapped fallback](QUICKSTART_CAPM3.md#air-gapped-fallback-sshfallback)
+See [QUICKSTART_CAPV.md — Air-gapped fallback](QUICKSTART_CAPV.md#air-gapped-fallback-sshfallback)
+and [QUICKSTART_CAPM3.md — Air-gapped fallback](QUICKSTART_CAPM3.md#air-gapped-fallback-sshfallback)
 for worked examples.
 
 ### KairosControlPlaneTemplate validating/mutating webhook
@@ -119,7 +119,7 @@ Files are now written to the node's filesystem via the cloud-config
 infrastructure providers (CAPV, CAPK, CAPD, CAPM3).
 
 Validation rejects non-absolute paths, `..` traversal segments, non-octal
-permissions, and malformed `user:group` owners. See [API_REFERENCE.md §Writing
+permissions, and malformed `user:group` owners. See [API_REFERENCE.md — Writing
 files to nodes](API_REFERENCE.md#writing-files-to-nodes) for limits and the
 static-IP caveat when using `spec.files` for systemd-networkd configuration on
 pre-installed images.
@@ -227,7 +227,7 @@ CAPD is development-only and exercised via unit/envtest rather than live e2e.
 | cert-manager | v1.15+ |
 
 The `go.mod` pins CAPI v1.8 Go types as a compile-time detail; the CRD and
-wire API group is `v1beta2` throughout. See [API_REFERENCE.md §API Version
+wire API group is `v1beta2` throughout. See [API_REFERENCE.md — API Version
 Compatibility](API_REFERENCE.md#api-version-compatibility) for the full
 explanation (KD-13).
 
@@ -249,7 +249,7 @@ explanation (KD-13).
   `.network` file via `spec.files` does not take effect on the running boot
   if networkd already holds a DHCP lease. Use infrastructure-layer IP
   management (DHCP reservation or IPAM) instead. See
-  [API_REFERENCE.md §Static IP via systemd-networkd](API_REFERENCE.md#static-ip-via-systemd-networkd--known-limitation-on-pre-installed-images).
+  [API_REFERENCE.md — Static IP via systemd-networkd](API_REFERENCE.md#static-ip-via-systemd-networkd--known-limitation-on-pre-installed-images).
 
 ---
 


### PR DESCRIPTION
Follow-up to the v0.1.0-beta.1 release-notes cleanup — removes the `§` section-sign from the remaining user-facing docs and sample manifests, per maintainer preference.

- Markdown cross-reference link text `[FILE.md § Section]` → `[FILE.md — Section]` (em dash, matching the beta.1 notes).
- Prose / YAML-comment section refs (`ADR 0005 §E`, `QUICKSTART_CAPM3.md § "Building the disk image"`) → the word `section`.

Text-only: no link targets, anchors, or behavior change. 10 files (docs + config/samples). The already-published v0.1.0-alpha.2 GitHub release body is not affected by editing its notes file in-repo.