### PR TITLE
feat(bootstrap): fleet providerID self-discovery for k3s (CAPV)

### DIFF
--- a/internal/bootstrap/fleet_providerid_test.go
+++ b/internal/bootstrap/fleet_providerid_test.go
@@ -1,0 +1,120 @@
+package bootstrap
+
+import (
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+// TestRenderK3sCapvFleetProviderID covers the Kairos fleet (AuroraBoot) providerID
+// self-discovery path. A fleet node is claimed from a group after its bootstrap data
+// is generated, so the providerID is not known at render time; the node runs
+// kairos-fleet-discover-provider-id.sh (before k3s starts) to derive
+// kairos-fleet://<node-id> from the phone-home agent's persisted credentials.
+//
+// Assertions, for both control-plane and worker roles:
+//
+//	(a) the fleet discovery script is rendered and wired as a k3s ExecStartPre;
+//	(b) it reads the persisted credentials, validates the node-id as a UUID, and
+//	    writes the kairos-fleet:// kubelet drop-in;
+//	(c) the vSphere DMI / hostname discovery does NOT leak into a fleet render;
+//	(d) output is valid YAML.
+func TestRenderK3sCapvFleetProviderID(t *testing.T) {
+	for _, role := range []string{"control-plane", "worker"} {
+		t.Run(role, func(t *testing.T) {
+			data := TemplateData{
+				Role:         role,
+				SingleNode:   role == "control-plane",
+				Hostname:     "fleet-node-0",
+				UserName:     "kairos",
+				IsFleet:      true,
+				ProviderID:   "", // fleet never has a render-time providerID
+				K3sToken:     "test-token",
+				K3sServerURL: "https://198.51.100.10:6443",
+			}
+			result, err := RenderK3sCloudConfig(data)
+			if err != nil {
+				t.Fatalf("render: %v", err)
+			}
+
+			// (a) discovery script present and wired as an ExecStartPre.
+			if !strings.Contains(result, "/usr/local/bin/kairos-fleet-discover-provider-id.sh") {
+				t.Error("missing fleet discovery script kairos-fleet-discover-provider-id.sh")
+			}
+			if !strings.Contains(result, "ExecStartPre=/bin/sh -c '/usr/local/bin/kairos-fleet-discover-provider-id.sh || true'") {
+				t.Error("fleet discovery script is not wired as a k3s ExecStartPre")
+			}
+
+			// (b) reads creds, validates UUID, writes the kairos-fleet:// drop-in.
+			if !strings.Contains(result, "/usr/local/.kairos/phonehome-credentials.yaml") {
+				t.Error("fleet discovery must read the persisted phone-home credentials")
+			}
+			if !strings.Contains(result, `'^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$'`) {
+				t.Error("fleet discovery must validate node_id as a UUID (injection guard) before use")
+			}
+			if !strings.Contains(result, "provider-id=kairos-fleet://") {
+				t.Error("fleet discovery must write a kairos-fleet:// kubelet drop-in")
+			}
+			if !strings.Contains(result, "/etc/rancher/k3s/config.yaml.d") || !strings.Contains(result, "90-provider-id.yaml") {
+				t.Error("fleet discovery must write the k3s provider-id drop-in under config.yaml.d")
+			}
+
+			// (c) no vSphere/DMI or hostname discovery in a fleet render.
+			if strings.Contains(result, "product_uuid") {
+				t.Error("vSphere DMI discovery (product_uuid) leaked into a fleet render")
+			}
+			if strings.Contains(result, "kairos-k3s-discover-provider-id.sh") {
+				t.Error("vSphere self-discovery script leaked into a fleet render")
+			}
+			if strings.Contains(result, "vsphere://") {
+				t.Error("vsphere:// providerID leaked into a fleet render")
+			}
+
+			// (d) valid YAML.
+			var parsed any
+			if err := yaml.Unmarshal([]byte(result), &parsed); err != nil {
+				t.Errorf("render is not valid YAML: %v", err)
+			}
+		})
+	}
+}
+
+// TestRenderK3sCapvFleet_NonFleetUnchanged is the regression guard: a non-fleet CAPV
+// control-plane with no render-time providerID must still use the vSphere DMI
+// self-discovery and must NOT emit the fleet script.
+func TestRenderK3sCapvFleet_NonFleetUnchanged(t *testing.T) {
+	data := TemplateData{
+		Role:       "control-plane",
+		SingleNode: true,
+		Hostname:   "capv-cp-0",
+		UserName:   "kairos",
+		IsFleet:    false,
+		ProviderID: "",
+	}
+	result, err := RenderK3sCloudConfig(data)
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if strings.Contains(result, "kairos-fleet-discover-provider-id.sh") {
+		t.Error("non-fleet render must NOT emit the fleet discovery script")
+	}
+	if !strings.Contains(result, "product_uuid") {
+		t.Error("non-fleet CAPV control-plane must still use vSphere DMI self-discovery")
+	}
+}
+
+// TestRenderK0sFleet_FailsLoudly guards against the silent k0s+fleet dead-end: the k0s
+// templates have no fleet branch (fleet is k3s-only for now), so a k0s fleet render
+// must error rather than fall through to vSphere DMI discovery.
+func TestRenderK0sFleet_FailsLoudly(t *testing.T) {
+	_, err := RenderK0sCloudConfig(TemplateData{
+		Role: "control-plane", SingleNode: true, Hostname: "n0", UserName: "kairos", IsFleet: true,
+	})
+	if err == nil {
+		t.Fatal("expected k0s + fleet render to fail loudly, got nil error")
+	}
+	if !strings.Contains(err.Error(), "fleet") || !strings.Contains(err.Error(), "k0s") {
+		t.Errorf("error should name k0s + fleet, got: %v", err)
+	}
+}

--- a/internal/bootstrap/template.go
+++ b/internal/bootstrap/template.go
@@ -69,6 +69,14 @@ type TemplateData struct {
 	// Node.spec.providerID. Metal3 rides the generic (non-KubeVirt) CAPV
 	// template. (ADR 0004, OQ-1 RESOLVED.)
 	Metal3                         bool
+	// IsFleet selects the Kairos fleet (AuroraBoot) render path: the node is claimed
+	// from a group after the bootstrap data is generated, so no providerID is known at
+	// render time. Instead of the vSphere/DMI self-discovery, the node runs
+	// kairos-fleet-discover-provider-id.sh, which reads the AuroraBoot node-id from the
+	// phone-home agent's persisted credentials and writes a kairos-fleet://<node-id>
+	// kubelet drop-in before k3s/k0s starts (for both control-plane and worker roles).
+	// Fleet nodes ride the generic (non-KubeVirt) CAPV template.
+	IsFleet                        bool
 	Install                        *InstallConfig
 	ProviderID                     string // ProviderID for the Node (e.g., "vsphere://<vm-uuid>"). Validated against providerIDPattern at render time.
 	K3sServerURL                   string
@@ -247,6 +255,14 @@ func (d TemplateData) RenderKubeVIP() bool {
 
 // RenderK0sCloudConfig renders the k0s Kairos cloud-config template.
 func RenderK0sCloudConfig(data TemplateData) (string, error) {
+	// The Kairos fleet providerID self-discovery is implemented for k3s only. The k0s
+	// templates would fall through to vSphere DMI discovery and self-register a
+	// vsphere://<uuid> providerID that never matches the KairosFleetMachine's
+	// kairos-fleet://<node-id> — a silent provisioning dead-end. Fail loudly instead
+	// until k0s fleet support lands.
+	if data.IsFleet {
+		return "", fmt.Errorf("k0s is not yet supported with the Kairos fleet infrastructure provider (KairosFleetMachine); use k3s")
+	}
 	templatePath := "templates/k0s_kairos_cloud_config_capv.yaml.tmpl"
 	if data.IsKubeVirt {
 		templatePath = "templates/k0s_kairos_cloud_config_capk.yaml.tmpl"

--- a/internal/bootstrap/templates/k3s_kairos_cloud_config_capv.yaml.tmpl
+++ b/internal/bootstrap/templates/k3s_kairos_cloud_config_capv.yaml.tmpl
@@ -278,6 +278,18 @@ write_files:
     content: |
       [Service]
       ExecStartPre=/bin/sh -c '/usr/local/bin/kairos-k3s-metal3-providerid.sh || true'
+  {{- else if and .IsFleet (not .ProviderID) }}
+  # Fleet (AuroraBoot): the node self-discovers its providerID before k3s starts.
+  # Runs for BOTH control-plane and worker roles — the providerID is not known at
+  # bootstrap render (the node is claimed from a group afterwards). z-provider-id.conf
+  # loads after override.conf.
+  - path: /etc/systemd/system/k3s.service.d/z-provider-id.conf
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      [Service]
+      ExecStartPre=/bin/sh -c '/usr/local/bin/kairos-fleet-discover-provider-id.sh || true'
   {{- else if and (eq .Role "control-plane") (not .Metal3) }}
   # Systemd override: write providerID to k3s config before k3s starts.
   # k3s loads /etc/rancher/k3s/config.yaml.d/*.yaml at startup - more reliable than wrapper.
@@ -375,7 +387,53 @@ write_files:
       printf 'kubelet-arg:\n  - provider-id=metal3://%s\nnode-label:\n  - metal3.io/uuid=%s\n' "${uuid}" "${uuid}" > /etc/rancher/k3s/config.yaml.d/90-provider-id.yaml
       echo "metal3-providerid: wrote provider-id=metal3://${uuid} and metal3.io/uuid=${uuid} for kubelet registration"
   {{- end }}
-  {{- if and (eq .Role "control-plane") (not .ProviderID) (not .Metal3) }}
+  {{- if and .IsFleet (not .ProviderID) }}
+  # Fleet (AuroraBoot) providerID self-discovery (runs as the k3s ExecStartPre above,
+  # BEFORE k3s/kubelet starts, for both control-plane and worker roles).
+  #
+  # The KairosFleetMachine controller sets spec.providerID = kairos-fleet://<node-id>
+  # where <node-id> is the AuroraBoot managed-node UUID. That same UUID is persisted on
+  # the node by the phone-home agent at /usr/local/.kairos/phonehome-credentials.yaml
+  # (yaml key node_id; /usr/local is COS_PERSISTENT, so it survives reboots). This
+  # script derives the providerID from that file so the kubelet registers with the
+  # identical string on first registration (providerID is immutable).
+  #
+  # This block is STATIC shell — there is NO render-time interpolation, so no
+  # Go-template injection surface. The node-id is validated as a UUID before it
+  # reaches a file/shell context, and the script fails closed (writes nothing) on any
+  # missing/malformed value.
+  - path: /usr/local/bin/kairos-fleet-discover-provider-id.sh
+    permissions: "0755"
+    owner: root
+    group: root
+    content: |
+      #!/bin/bash
+      set -eu
+      CREDS="/usr/local/.kairos/phonehome-credentials.yaml"
+      DROPIN_DIR="/etc/rancher/k3s/config.yaml.d"
+      # Wait briefly for the phone-home agent to have written its credentials. On an
+      # enrolled fleet node these already exist (registration precedes the claim); the
+      # bounded wait just tolerates a slow first boot without racing k3s.
+      i=0
+      while [ ! -f "${CREDS}" ] && [ "${i}" -lt 30 ]; do
+        sleep 2
+        i=$((i + 1))
+      done
+      if [ ! -f "${CREDS}" ]; then
+        echo "fleet: no credentials at ${CREDS}; leaving providerID to k3s default"
+        exit 0
+      fi
+      # Extract node_id (a server-assigned UUID); strip the key, whitespace and quotes.
+      NODE_ID="$(sed -n 's/^[[:space:]]*node_id:[[:space:]]*//p' "${CREDS}" | head -n1 | tr -d '[:space:]"')"
+      # Defence in depth: only accept a well-formed UUID before it reaches the drop-in.
+      if ! printf '%s' "${NODE_ID}" | grep -qE '^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$'; then
+        echo "fleet: node_id in ${CREDS} is missing or not a UUID; leaving providerID to k3s default"
+        exit 0
+      fi
+      mkdir -p "${DROPIN_DIR}"
+      printf 'kubelet-arg:\n  - provider-id=kairos-fleet://%s\n' "${NODE_ID}" > "${DROPIN_DIR}/90-provider-id.yaml"
+      echo "fleet: providerID set to kairos-fleet://${NODE_ID}"
+  {{- else if and (eq .Role "control-plane") (not .ProviderID) (not .Metal3) }}
   # VM self-discovery of providerID when not available at bootstrap (runs before k3s via ExecStartPre).
   # Omitted for Metal3: discovery is done at post-bootstrap via config-drive read (ADR 0004).
   # Writes to k3s config file - k3s loads config.yaml.d/*.yaml at startup
@@ -646,7 +704,11 @@ MANIFEST_EOF
 {{- /* DNS overrides and bootstrap stages */}}
 stages:
   boot:
-    {{- if and (eq .Role "control-plane") (not .ProviderID) (not .Metal3) }}
+    {{- if and .IsFleet (not .ProviderID) }}
+    - name: "Discover providerID for k3s (fleet self-discovery)"
+      commands:
+        - /usr/local/bin/kairos-fleet-discover-provider-id.sh || true
+    {{- else if and (eq .Role "control-plane") (not .ProviderID) (not .Metal3) }}
     - name: "Discover providerID for k3s (VM self-discovery)"
       commands:
         - /usr/local/bin/kairos-k3s-discover-provider-id.sh || true

--- a/internal/controllers/bootstrap/kairosconfig_controller.go
+++ b/internal/controllers/bootstrap/kairosconfig_controller.go
@@ -246,7 +246,10 @@ func (r *KairosConfigReconciler) reconcileBootstrapData(ctx context.Context, log
 	// secret. Zeroing it here prevents the reconcile loop from treating CAPM3's post-registration providerID as a
 	// "missing from secret" signal and triggering infinite regeneration. (ADR 0004.)
 	currentProviderID := r.getProviderID(ctx, log, machine)
-	if isMetal3Machine(machine) {
+	if isMetal3Machine(machine) || isFleetMachine(machine) {
+		// Metal3: CAPM3 owns providerID end-to-end. Fleet: the node is claimed after
+		// bootstrap render and self-discovers providerID. Either way, do not embed it
+		// in the secret (avoids the "missing from secret" regeneration loop).
 		currentProviderID = ""
 	}
 
@@ -685,6 +688,20 @@ func isMetal3Machine(machine *clusterv1.Machine) bool {
 	return machine.Spec.InfrastructureRef.Kind == "Metal3Machine"
 }
 
+// isFleetMachine reports whether machine is backed by the Kairos fleet
+// infrastructure provider (KairosFleetMachine). Like Metal3, the providerID is not
+// known at bootstrap-render time (the node is claimed from an AuroraBoot group after
+// the bootstrap data is generated), so the node self-discovers it: the rendered
+// cloud-config carries kairos-fleet-discover-provider-id.sh, which derives
+// kairos-fleet://<node-id> from the phone-home agent's persisted credentials before
+// k3s/k0s starts.
+func isFleetMachine(machine *clusterv1.Machine) bool {
+	if machine == nil {
+		return false
+	}
+	return machine.Spec.InfrastructureRef.Kind == "KairosFleetMachine"
+}
+
 func (r *KairosConfigReconciler) sanitizeCapkUserdataSecret(ctx context.Context, log logr.Logger, kairosConfig *bootstrapv1beta2.KairosConfig, machine *clusterv1.Machine) (bool, bool, error) {
 	secretName := ""
 	if machine != nil && machine.Spec.Bootstrap.DataSecretName != nil && *machine.Spec.Bootstrap.DataSecretName != "" {
@@ -1046,7 +1063,9 @@ func (r *KairosConfigReconciler) generateK0sCloudConfig(ctx context.Context, log
 	// the template does not emit --provider-id args or the kubectl patch block.
 	// (ADR 0004, OQ-1 RESOLVED.)
 	var providerID string
-	if !isMetal3Machine(machine) {
+	if !isMetal3Machine(machine) && !isFleetMachine(machine) {
+		// Fleet, like Metal3, does not embed a render-time providerID: the node is
+		// claimed after render and self-discovers kairos-fleet://<node-id>.
 		providerID = r.getProviderID(ctx, log, machine)
 	}
 
@@ -1088,6 +1107,7 @@ func (r *KairosConfigReconciler) generateK0sCloudConfig(ctx context.Context, log
 		ClusterNS:                      "",
 		IsKubeVirt:                     isKubevirtMachine(machine),
 		Metal3:                         isMetal3Machine(machine),
+		IsFleet:                        isFleetMachine(machine),
 		Install:                        installConfig,
 		ProviderID:                     providerID,
 		ControlPlaneLBServiceName:      "",
@@ -1231,7 +1251,9 @@ func (r *KairosConfigReconciler) generateK3sCloudConfig(ctx context.Context, log
 	// the template does not emit --provider-id args or the kubectl patch block.
 	// (ADR 0004, OQ-1 RESOLVED.)
 	var providerID string
-	if !isMetal3Machine(machine) {
+	if !isMetal3Machine(machine) && !isFleetMachine(machine) {
+		// Fleet, like Metal3, does not embed a render-time providerID: the node is
+		// claimed after render and self-discovers kairos-fleet://<node-id>.
 		providerID = r.getProviderID(ctx, log, machine)
 	}
 
@@ -1265,6 +1287,7 @@ func (r *KairosConfigReconciler) generateK3sCloudConfig(ctx context.Context, log
 		ClusterNS:                      "",
 		IsKubeVirt:                     isKubevirtMachine(machine),
 		Metal3:                         isMetal3Machine(machine),
+		IsFleet:                        isFleetMachine(machine),
 		Install:                        installConfig,
 		ProviderID:                     providerID,
 		K3sServerURL:                   serverAddress,


### PR DESCRIPTION
Adds the **node-side** half of the Kairos fleet (AuroraBoot) providerID coordination. Pairs with the new [`cluster-api-provider-kairos-fleet` infrastructure provider](https://github.com/kairos-io/cluster-api-provider-kairos-fleet/pull/1).

## Why
A `KairosFleetMachine` node is claimed from an AuroraBoot group **after** its bootstrap data is generated, so the providerID is not known at render time (like Metal3). The infra provider sets `spec.providerID = kairos-fleet://<node-id>`; for CAPI to bind the Node to its Machine, the node's kubelet must register the identical string. This teaches the bootstrap provider to make the node self-discover it.

## What
- **Auto-detect** `InfrastructureRef.Kind == KairosFleetMachine` (`isFleetMachine`) and mirror the Metal3 pattern: zero the render-time providerID, skip `getProviderID`, set `TemplateData.IsFleet`. **No new user-facing API field.**
- **k3s CAPV template**: three `IsFleet` branches (ExecStartPre, discovery script, yip boot stage) — placed ahead of the vSphere branch so a fleet node never takes the DMI path — that emit `kairos-fleet-discover-provider-id.sh` for **both control-plane and worker** roles. The script reads `node_id` from the phone-home agent's persisted credentials (`/usr/local/.kairos/phonehome-credentials.yaml`, on `COS_PERSISTENT`), validates it as a UUID (fail-closed), and writes the k3s kubelet drop-in before k3s starts.
- **k0s + fleet fails loudly** (`RenderK0sCloudConfig` errors) rather than silently self-registering `vsphere://<dmi-uuid>` — k0s fleet support is a follow-up (it needs a worker-side pre-start mechanism).

## Safety
The embedded script is **static shell** (no template interpolation of user-controlled fields), guarded on `and .IsFleet (not .ProviderID)`. Reviewed on the RCE-sensitive rendering path — **security verdict: APPROVE** (no injection surface; node_id UUID-validated fail-closed; Metal3/vSphere paths unweakened).

## Validation
Proved end-to-end on a live Kairos v4.1.2 + k3s node: planted creds → `ExecStartPre` → drop-in → `Node.spec.providerID == kairos-fleet://<node-id>`, surviving a reboot. `node_id` == AuroraBoot `ManagedNode.ID` == the provider's `node.ID` by construction (verified from source). Tests cover both roles, the no-vSphere-leak invariant, non-fleet regression, and the k0s fail-loud guard; full bootstrap suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)