### PR TITLE
feat(bootstrap): fleet providerID self-discovery for k0s (CAPV)

### DIFF
--- a/internal/bootstrap/fleet_providerid_test.go
+++ b/internal/bootstrap/fleet_providerid_test.go
@@ -1,6 +1,8 @@
 package bootstrap
 
 import (
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -104,17 +106,180 @@ func TestRenderK3sCapvFleet_NonFleetUnchanged(t *testing.T) {
 	}
 }
 
-// TestRenderK0sFleet_FailsLoudly guards against the silent k0s+fleet dead-end: the k0s
-// templates have no fleet branch (fleet is k3s-only for now), so a k0s fleet render
-// must error rather than fall through to vSphere DMI discovery.
-func TestRenderK0sFleet_FailsLoudly(t *testing.T) {
-	_, err := RenderK0sCloudConfig(TemplateData{
-		Role: "control-plane", SingleNode: true, Hostname: "n0", UserName: "kairos", IsFleet: true,
-	})
-	if err == nil {
-		t.Fatal("expected k0s + fleet render to fail loudly, got nil error")
+// TestRenderK0sCapvFleetProviderID covers the Kairos fleet (AuroraBoot) providerID
+// self-discovery path for k0s. Unlike k3s (which uses one config.yaml.d drop-in for
+// both roles), k0s splits by role because it has no config.yaml.d-style pre-start
+// kubelet drop-in and workers have no admin.conf:
+//
+//   - control-plane: derives kairos-fleet://<node-id> from the persisted credentials
+//     and patches the Node post-bootstrap via `k0s kubectl` (admin.conf is CP-only);
+//   - worker: writes a KubeletConfiguration providerID drop-in the kubelet reads via
+//     a STATIC --config-dir arg, before the kubelet registers the Node.
+//
+// Both derive the node-id from /usr/local/.kairos/phonehome-credentials.yaml, validate
+// it as a UUID, and must never leak the vSphere DMI self-discovery.
+func TestRenderK0sCapvFleetProviderID(t *testing.T) {
+	for _, role := range []string{"control-plane", "worker"} {
+		t.Run(role, func(t *testing.T) {
+			data := TemplateData{
+				Role:        role,
+				SingleNode:  role == "control-plane",
+				Hostname:    "fleet-node-0",
+				UserName:    "kairos",
+				IsFleet:     true,
+				ProviderID:  "", // fleet never has a render-time providerID
+				WorkerToken: "test-token",
+			}
+			result, err := RenderK0sCloudConfig(data)
+			if err != nil {
+				t.Fatalf("render: %v", err)
+			}
+
+			// (a+b) node-id derived from the persisted credentials, validated as a
+			// UUID, and written as a kairos-fleet:// providerID — for both roles.
+			if !strings.Contains(result, "/usr/local/.kairos/phonehome-credentials.yaml") {
+				t.Error("fleet discovery must read the persisted phone-home credentials")
+			}
+			if !strings.Contains(result, `'^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$'`) {
+				t.Error("fleet discovery must validate node_id as a UUID (injection guard) before use")
+			}
+			if !strings.Contains(result, "kairos-fleet://") {
+				t.Error("fleet discovery must produce a kairos-fleet:// providerID")
+			}
+
+			// (c) no vSphere/DMI self-discovery in a fleet render, for either role.
+			if strings.Contains(result, "product_uuid") {
+				t.Error("vSphere DMI discovery (product_uuid) leaked into a fleet render")
+			}
+			if strings.Contains(result, "vsphere://") {
+				t.Error("vsphere:// providerID leaked into a fleet render")
+			}
+
+			// Role-specific mechanism assertions.
+			switch role {
+			case "control-plane":
+				// CP patches its own Node via the local admin kubeconfig.
+				if !strings.Contains(result, "export KUBECONFIG=/var/lib/k0s/pki/admin.conf") {
+					t.Error("fleet control-plane must use the local admin kubeconfig for the patch")
+				}
+				if !strings.Contains(result, "k0s kubectl patch node") {
+					t.Error("fleet control-plane must patch the Node providerID via k0s kubectl")
+				}
+				// The worker-only pre-start mechanism must NOT appear on the CP.
+				if strings.Contains(result, "kairos-k0s-fleet-provider-id.sh") {
+					t.Error("fleet control-plane must not emit the worker pre-start discovery script")
+				}
+			case "worker":
+				// Worker sets providerID pre-start via a KubeletConfiguration drop-in
+				// read through a STATIC --config-dir arg.
+				if !strings.Contains(result, "/usr/local/bin/kairos-k0s-fleet-provider-id.sh") {
+					t.Error("fleet worker must emit the pre-start discovery script")
+				}
+				if !strings.Contains(result, "ExecStartPre=/bin/sh -c '/usr/local/bin/kairos-k0s-fleet-provider-id.sh || true'") {
+					t.Error("fleet worker discovery script must be wired as a k0sworker ExecStartPre")
+				}
+				if !strings.Contains(result, "--kubelet-extra-args=--config-dir=/etc/kubernetes/kubelet.conf.d") {
+					t.Error("fleet worker must point the kubelet at the config-dir drop-in")
+				}
+				if !strings.Contains(result, "10-provider-id.conf") {
+					t.Error("fleet worker must write the KubeletConfiguration providerID drop-in")
+				}
+				if !strings.Contains(result, "kind: KubeletConfiguration") {
+					t.Error("fleet worker drop-in must be a KubeletConfiguration")
+				}
+				// Never pin an empty --provider-id= (would never match kairos-fleet://).
+				if strings.Contains(result, "--kubelet-extra-args=--provider-id=") {
+					t.Error("fleet worker must not emit a --provider-id kubelet arg (empty or otherwise)")
+				}
+				// The CP-only kubectl-patch mechanism must NOT appear on the worker.
+				if strings.Contains(result, "k0s kubectl patch node") {
+					t.Error("fleet worker must not run the control-plane kubectl-patch path")
+				}
+			}
+
+			// (d) valid YAML.
+			var parsed any
+			if err := yaml.Unmarshal([]byte(result), &parsed); err != nil {
+				t.Errorf("render is not valid YAML: %v", err)
+			}
+		})
 	}
-	if !strings.Contains(err.Error(), "fleet") || !strings.Contains(err.Error(), "k0s") {
-		t.Errorf("error should name k0s + fleet, got: %v", err)
+}
+
+// TestRenderK0sCapvFleet_BashSyntax runs `bash -n` on the k0s fleet shell that only
+// executes at node boot: the control-plane's inline discovery+patch (inside the
+// post-bootstrap script) and the worker's kairos-k0s-fleet-provider-id.sh. The
+// in-script UUID validation (`grep -qE`) never runs at unit-test time, so a syntax
+// regression there would otherwise stay invisible until lab provisioning.
+func TestRenderK0sCapvFleet_BashSyntax(t *testing.T) {
+	bashPath, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not available; skipping rendered-script syntax check")
+	}
+	cases := []struct {
+		name        string
+		role        string
+		script      string // write_files path suffix of the script to syntax-check
+		mustContain string // marker proving we extracted the fleet variant
+	}{
+		{"control-plane", "control-plane", "kairos-k0s-post-bootstrap.sh", "fleet: discovered providerID"},
+		{"worker", "worker", "kairos-k0s-fleet-provider-id.sh", "phonehome-credentials.yaml"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := RenderK0sCloudConfig(TemplateData{
+				Role:        tc.role,
+				SingleNode:  tc.role == "control-plane",
+				Hostname:    "fleet-node-0",
+				UserName:    "kairos",
+				IsFleet:     true,
+				WorkerToken: "test-token",
+			})
+			if err != nil {
+				t.Fatalf("render: %v", err)
+			}
+			script := extractWriteFile(t, out, tc.script)
+			if script == "" {
+				t.Fatalf("%s script (%s) not found in rendered write_files", tc.name, tc.script)
+			}
+			if !strings.Contains(script, tc.mustContain) {
+				t.Fatalf("extracted %s does not contain %q; may have extracted the wrong file", tc.script, tc.mustContain)
+			}
+			f := filepathJoinTemp(t, "kairos-k0s-fleet-"+tc.name+".sh")
+			if err := os.WriteFile(f, []byte(script), 0o600); err != nil {
+				t.Fatalf("write temp script: %v", err)
+			}
+			if o, err := exec.Command(bashPath, "-n", f).CombinedOutput(); err != nil {
+				t.Fatalf("bash -n on rendered %s failed: %v\n%s", tc.script, err, o)
+			}
+		})
+	}
+}
+
+// TestRenderK0sCapvFleet_NonFleetUnchanged is the regression guard: a non-fleet CAPV
+// k0s control-plane with no render-time providerID must still use the vSphere DMI
+// self-discovery and must NOT emit any fleet discovery.
+func TestRenderK0sCapvFleet_NonFleetUnchanged(t *testing.T) {
+	data := TemplateData{
+		Role:       "control-plane",
+		SingleNode: true,
+		Hostname:   "capv-cp-0",
+		UserName:   "kairos",
+		IsFleet:    false,
+		ProviderID: "",
+	}
+	result, err := RenderK0sCloudConfig(data)
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if strings.Contains(result, "kairos-k0s-fleet-provider-id.sh") {
+		t.Error("non-fleet render must NOT emit the fleet discovery script")
+	}
+	if strings.Contains(result, "kairos-fleet://") {
+		t.Error("non-fleet render must NOT emit a kairos-fleet:// providerID")
+	}
+	if !strings.Contains(result, "product_uuid") {
+		t.Error("non-fleet CAPV control-plane must still use vSphere DMI self-discovery")
 	}
 }

--- a/internal/bootstrap/template.go
+++ b/internal/bootstrap/template.go
@@ -68,14 +68,21 @@ type TemplateData struct {
 	// SUPPRESS our providerID arg + kubectl-patch block, because CAPM3 owns
 	// Node.spec.providerID. Metal3 rides the generic (non-KubeVirt) CAPV
 	// template. (ADR 0004, OQ-1 RESOLVED.)
-	Metal3                         bool
+	Metal3 bool
 	// IsFleet selects the Kairos fleet (AuroraBoot) render path: the node is claimed
 	// from a group after the bootstrap data is generated, so no providerID is known at
-	// render time. Instead of the vSphere/DMI self-discovery, the node runs
-	// kairos-fleet-discover-provider-id.sh, which reads the AuroraBoot node-id from the
-	// phone-home agent's persisted credentials and writes a kairos-fleet://<node-id>
-	// kubelet drop-in before k3s/k0s starts (for both control-plane and worker roles).
-	// Fleet nodes ride the generic (non-KubeVirt) CAPV template.
+	// render time. Instead of the vSphere/DMI self-discovery, the node derives the
+	// AuroraBoot node-id from the phone-home agent's persisted credentials and produces
+	// a kairos-fleet://<node-id> providerID. The delivery differs by distribution:
+	//   - k3s (both roles): kairos-fleet-discover-provider-id.sh writes the k3s
+	//     config.yaml.d kubelet drop-in before k3s starts.
+	//   - k0s control-plane: derives the providerID from the credentials and patches
+	//     the Node post-bootstrap via `k0s kubectl` (admin.conf is control-plane only).
+	//   - k0s worker: kairos-k0s-fleet-provider-id.sh writes a KubeletConfiguration
+	//     providerID drop-in that the kubelet reads via a static --config-dir arg
+	//     before it registers (a worker has no admin.conf to patch).
+	// Fleet nodes ride the generic (non-KubeVirt) CAPV template; fleet never co-occurs
+	// with KubeVirt.
 	IsFleet                        bool
 	Install                        *InstallConfig
 	ProviderID                     string // ProviderID for the Node (e.g., "vsphere://<vm-uuid>"). Validated against providerIDPattern at render time.
@@ -254,15 +261,15 @@ func (d TemplateData) RenderKubeVIP() bool {
 }
 
 // RenderK0sCloudConfig renders the k0s Kairos cloud-config template.
+//
+// Kairos fleet (AuroraBoot) providerID self-discovery is implemented on the CAPV
+// template only: the control-plane derives kairos-fleet://<node-id> from the
+// phone-home credentials and patches its Node post-bootstrap (admin.conf is
+// CP-only), while workers write a KubeletConfiguration providerID drop-in read
+// via --config-dir before the kubelet registers. Fleet never co-occurs with
+// KubeVirt (isFleetMachine and isKubevirtMachine are mutually exclusive Kinds),
+// so the CAPK path needs no fleet branch.
 func RenderK0sCloudConfig(data TemplateData) (string, error) {
-	// The Kairos fleet providerID self-discovery is implemented for k3s only. The k0s
-	// templates would fall through to vSphere DMI discovery and self-register a
-	// vsphere://<uuid> providerID that never matches the KairosFleetMachine's
-	// kairos-fleet://<node-id> — a silent provisioning dead-end. Fail loudly instead
-	// until k0s fleet support lands.
-	if data.IsFleet {
-		return "", fmt.Errorf("k0s is not yet supported with the Kairos fleet infrastructure provider (KairosFleetMachine); use k3s")
-	}
 	templatePath := "templates/k0s_kairos_cloud_config_capv.yaml.tmpl"
 	if data.IsKubeVirt {
 		templatePath = "templates/k0s_kairos_cloud_config_capk.yaml.tmpl"

--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
@@ -114,7 +114,17 @@ k0s-worker:
   enabled: true
   args:
     - --token-file /etc/k0s/token
-    {{- if and .ProviderID (not .Metal3) }}
+    {{- if and .IsFleet (not .ProviderID) }}
+    # Fleet (AuroraBoot): the providerID is not known at bootstrap render (the node
+    # is claimed from a group afterwards), and a worker has no admin.conf to patch
+    # its Node post-bootstrap. So the kubelet must self-register with the right
+    # providerID: it reads a KubeletConfiguration drop-in from --config-dir (a
+    # STATIC path, no interpolation) that kairos-k0s-fleet-provider-id.sh writes as
+    # an ExecStartPre BEFORE the kubelet starts. We deliberately do NOT emit an
+    # empty --provider-id= here — that would pin the k0s default and never match
+    # kairos-fleet://<node-id>. The dynamic node-id is validated in-script.
+    - --kubelet-extra-args=--config-dir=/etc/kubernetes/kubelet.conf.d
+    {{- else if and .ProviderID (not .Metal3) }}
     # KD-3c: same providerID-at-startup story as the control-plane block above.
     # Not emitted for Metal3: CAPM3 owns Node.spec.providerID (ADR 0004).
     - --kubelet-extra-args=--provider-id={{ .ProviderID }}
@@ -200,6 +210,74 @@ write_files:
     permissions: "0644"
     content: |
       {{ .WorkerToken }}
+  {{- end }}
+  {{- if and .IsFleet (not .ProviderID) (ne .Role "control-plane") }}
+  # Fleet (AuroraBoot) providerID self-discovery for k0s WORKERS.
+  #
+  # A worker has no admin.conf, so the control-plane's post-bootstrap kubectl-patch
+  # path is unavailable; the kubelet must instead register the Node with the right
+  # providerID on FIRST registration (providerID is immutable once non-empty). The
+  # k0s-worker args carry a STATIC --kubelet-extra-args=--config-dir=/etc/kubernetes/kubelet.conf.d,
+  # and this ExecStartPre writes a KubeletConfiguration drop-in there BEFORE the
+  # worker's kubelet starts. k0sworker.service cannot successfully start until
+  # /etc/k0s/token (written by write_files) is present, so this drop-in — also from
+  # write_files — is guaranteed in place before the registration that matters.
+  #
+  # SECURITY: STATIC shell — there is NO render-time interpolation of the node-id,
+  # so no Go-template injection surface. node_id is read from the credentials file
+  # at boot and validated against the UUID pattern BEFORE it reaches the drop-in;
+  # the script fails closed (writes nothing, exit 0) on any missing/malformed value.
+  - path: /etc/systemd/system/k0sworker.service.d/z-provider-id.conf
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      [Service]
+      ExecStartPre=/bin/sh -c '/usr/local/bin/kairos-k0s-fleet-provider-id.sh || true'
+  - path: /usr/local/bin/kairos-k0s-fleet-provider-id.sh
+    permissions: "0755"
+    owner: root
+    group: root
+    content: |
+      #!/bin/bash
+      set -eu
+      CREDS="/usr/local/.kairos/phonehome-credentials.yaml"
+      DROPIN_DIR="/etc/kubernetes/kubelet.conf.d"
+      # Bounded wait for the phone-home agent's credentials. On an enrolled fleet
+      # node these already exist (registration precedes the claim); the wait just
+      # tolerates a slow first boot without racing the kubelet.
+      i=0
+      while [ ! -f "${CREDS}" ] && [ "${i}" -lt 30 ]; do
+        sleep 2
+        i=$((i + 1))
+      done
+      if [ ! -f "${CREDS}" ]; then
+        echo "fleet: no credentials at ${CREDS}; leaving providerID to k0s default"
+        exit 0
+      fi
+      # Extract node_id (a server-assigned UUID); strip the key, whitespace, quotes.
+      NODE_ID="$(sed -n 's/^[[:space:]]*node_id:[[:space:]]*//p' "${CREDS}" | head -n1 | tr -d '[:space:]"')"
+      # Defence in depth, mirroring the DMI/Metal3 blocks in this file: first reject
+      # any value with a character outside [hex,dash] (closes provider-id injection
+      # and a multi-line smuggle), then enforce the exact UUID shape with bash =~
+      # (string-anchored, not line-anchored). This keeps the validation correct even
+      # if the upstream whitespace strip ever changed.
+      uuid_re='^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$'
+      case "${NODE_ID}" in
+        "" | *[!0-9a-fA-F-]* )
+          echo "fleet: node_id in ${CREDS} is empty or contains illegal characters; leaving providerID to k0s default"
+          exit 0 ;;
+      esac
+      if ! [[ "${NODE_ID}" =~ ${uuid_re} ]]; then
+        echo "fleet: node_id in ${CREDS} does not match the UUID pattern; leaving providerID to k0s default"
+        exit 0
+      fi
+      mkdir -p "${DROPIN_DIR}"
+      # KubeletConfiguration drop-in merged via --config-dir before the kubelet
+      # registers the Node. Written with printf (not an interpolated heredoc); the
+      # only substituted value is the UUID validated above.
+      printf 'apiVersion: kubelet.config.k8s.io/v1beta1\nkind: KubeletConfiguration\nproviderID: kairos-fleet://%s\n' "${NODE_ID}" > "${DROPIN_DIR}/10-provider-id.conf"
+      echo "fleet: providerID set to kairos-fleet://${NODE_ID}"
   {{- end }}
   {{- /*
     Post-bootstrap unit + script writes were previously emitted via
@@ -400,7 +478,93 @@ MANIFEST_EOF
       {{- end }}
       {{- end }}
 
-      {{- if and .ProviderID (not .Metal3) }}
+      {{- if and .IsFleet (not .ProviderID) (eq .Role "control-plane") }}
+      # Fleet (AuroraBoot) providerID self-discovery for the CONTROL-PLANE, then
+      # patch. The node is claimed from a group AFTER bootstrap render, so the
+      # providerID is not known at render time; derive kairos-fleet://<node-id> from
+      # the phone-home agent's persisted credentials and patch the Node. The CP has
+      # /var/lib/k0s/pki/admin.conf, so the post-bootstrap kubectl patch is available
+      # (mirrors the DMI path below; the worker path instead sets it pre-start).
+      # KD-55: fail-OPEN — a providerID hiccup must not abort the kubeconfig push.
+      #
+      # SECURITY: STATIC shell — NODE_ID is read from the credentials file at boot
+      # and validated against the UUID pattern BEFORE it reaches the patch JSON.
+      # There is NO render-time interpolation of the node-id (no injection surface).
+      export KUBECONFIG=/var/lib/k0s/pki/admin.conf
+      PROVIDER_ID=""
+      CREDS="/usr/local/.kairos/phonehome-credentials.yaml"
+      # Bounded wait for the phone-home credentials (present on an enrolled node).
+      i=0
+      while [ ! -f "${CREDS}" ] && [ "${i}" -lt 30 ]; do
+        sleep 2
+        i=$((i + 1))
+      done
+      if [ ! -f "${CREDS}" ]; then
+        echo "WARN: fleet: no credentials at ${CREDS}; skipping providerID (continuing post-bootstrap)"
+      else
+        NODE_ID="$(sed -n 's/^[[:space:]]*node_id:[[:space:]]*//p' "${CREDS}" | head -n1 | tr -d '[:space:]"')"
+        # Whole-string UUID validation before the value reaches the patch JSON,
+        # mirroring the DMI/Metal3 blocks: reject any character outside [hex,dash],
+        # then enforce the exact UUID shape with bash =~ (string-anchored).
+        uuid_re='^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$'
+        case "${NODE_ID}" in
+          "" | *[!0-9a-fA-F-]* ) NODE_ID="" ;;
+        esac
+        if [ -n "${NODE_ID}" ] && [[ "${NODE_ID}" =~ ${uuid_re} ]]; then
+          PROVIDER_ID="kairos-fleet://${NODE_ID}"
+          echo "fleet: discovered providerID ${PROVIDER_ID}"
+        else
+          echo "WARN: fleet: node_id in ${CREDS} is missing or not a UUID; skipping providerID (continuing post-bootstrap)"
+        fi
+      fi
+      if [ -n "${PROVIDER_ID}" ]; then
+        echo "Waiting for k0s node to be registered..."
+        # Use `k0s kubectl` (resolves the local admin kubeconfig). The Hadron k0s
+        # image ships no standalone `kubectl` binary, so bare `kubectl` would fail
+        # and silently never set the providerID — mirrors the non-fleet paths.
+        node_registered=false
+        MAX_WAIT=300
+        ELAPSED=0
+        while [ $ELAPSED -lt $MAX_WAIT ]; do
+          if k0s kubectl get node $(hostname) &>/dev/null; then
+            node_registered=true
+            break
+          fi
+          echo "Waiting for node to be registered... (${ELAPSED}s/${MAX_WAIT}s)"
+          sleep 5
+          ELAPSED=$((ELAPSED + 5))
+        done
+        if [ "$node_registered" != "true" ]; then
+          echo "WARN: timed out waiting for Node registration; skipping providerID (continuing post-bootstrap)"
+        else
+          # Set the discovered providerID on the Node. The kubelet registers the CP
+          # Node with an EMPTY providerID (no --provider-id on the fleet CP), and the
+          # apiserver permits setting a previously-empty providerID, so this patch
+          # succeeds on first registration. ${PROVIDER_ID} is validated above.
+          echo "Setting providerID=${PROVIDER_ID} on node $(hostname)..."
+          PROVIDER_ID_SET=false
+          for i in {1..30}; do
+            if k0s kubectl patch node $(hostname) --type=merge -p "{\"spec\":{\"providerID\":\"${PROVIDER_ID}\"}}" &>/dev/null; then
+              echo "Successfully set providerID=${PROVIDER_ID} on node $(hostname)"
+              PROVIDER_ID_SET=true
+              break
+            fi
+            echo "Attempt $i/30: Failed to set providerID, retrying in 5 seconds..."
+            sleep 5
+          done
+          if [ "$PROVIDER_ID_SET" != "true" ]; then
+            echo "WARN: failed to set providerID after 30 attempts; continuing post-bootstrap (Machine may stay NodeNotFound until providerID is set)"
+          fi
+        fi
+      fi
+      {{- else if and .IsFleet (not .ProviderID) }}
+      # Fleet worker: the providerID is set PRE-START via the kubelet --config-dir
+      # KubeletConfiguration drop-in written by kairos-k0s-fleet-provider-id.sh (see
+      # write_files). A worker has no admin.conf, so there is no post-bootstrap
+      # kubectl patch here — and, critically, no fall-through to the vSphere DMI
+      # self-discovery below (which would self-register a vsphere DMI providerID and
+      # never match kairos-fleet://<node-id>).
+      {{- else if and .ProviderID (not .Metal3) }}
       # Wait for k0s to be ready and the Node to be registered, then set providerID.
       # KD-55: fail-OPEN. A providerID hiccup (API blip, slow registration) must NOT
       # abort the rest of post-bootstrap — the kubeconfig push below MUST still run,
@@ -867,6 +1031,15 @@ MANIFEST_EOF
 {{- /* DNS overrides */}}
 stages:
   boot:
+    {{- if and .IsFleet (not .ProviderID) (ne .Role "control-plane") }}
+    # Fleet worker: also run the providerID drop-in writer as an early boot stage
+    # (belt-and-suspenders alongside the k0sworker.service ExecStartPre), so the
+    # KubeletConfiguration drop-in is present before the kubelet registers. The
+    # script is idempotent and fails closed on a missing/malformed node_id.
+    - name: "Discover providerID for k0s worker (fleet self-discovery)"
+      commands:
+        - /usr/local/bin/kairos-k0s-fleet-provider-id.sh || true
+    {{- end }}
     - name: "Ensure SSH service is enabled"
       commands:
         - systemctl enable --now sshd || systemctl enable --now ssh || true


### PR DESCRIPTION
## What

Adds k0s support for the Kairos fleet (AuroraBoot) providerID self-discovery, mirroring the merged k3s fleet path (#80). A `KairosFleetMachine` is claimed from an AuroraBoot group *after* its bootstrap data is rendered, so the providerID is unknown at render time (like Metal3). The node derives `kairos-fleet://<node-id>` from the phone-home agent's persisted credentials (`/usr/local/.kairos/phonehome-credentials.yaml`, key `node_id`) and self-registers so CAPI can bind the Node to its Machine.

## Why it's not a straight copy of k3s

k0s has **no `config.yaml.d`-style pre-start kubelet drop-in**, so delivery is split by role:

- **control-plane** — derive the providerID from the credentials and patch the Node post-bootstrap via `k0s kubectl` (admin.conf is control-plane only), reusing the existing wait-for-registration + patch loop (swaps the DMI byte-swap for a creds read).
- **worker** — a worker has no admin.conf, so the kubelet must register with the right providerID on *first* registration (providerID is immutable). A **static** `--kubelet-extra-args=--config-dir=/etc/kubernetes/kubelet.conf.d` is baked onto the `k0s-worker` service, and an `ExecStartPre` on `k0sworker.service` (`kairos-k0s-fleet-provider-id.sh`) writes a `KubeletConfiguration{providerID}` drop-in there before the kubelet starts. `k0sworker` can't start before `/etc/k0s/token` (write_files), so the drop-in — also from write_files — is guaranteed in place before the registration that matters. This also fills the gap the Metal3 block called out ("k0s worker providerID not implemented").

Both fleet branches are gated **ahead of** the vSphere DMI self-discovery, so a fleet render never self-registers `vsphere://<uuid>`.

## Safety (RCE-sensitive renderer)

- The node-id is **never interpolated through `text/template`** into any shell/script body — the scripts are static; the value is read at boot and validated in-script (reject any char outside `[hex,dash]`, then a string-anchored UUID `[[ =~ ]]`, mirroring the DMI/Metal3 blocks in the same file) before it reaches any file/shell/JSON context. Fail-closed on missing/malformed input.
- Replaces the fail-loud `RenderK0sCloudConfig` guard (and its `TestRenderK0sFleet_FailsLoudly`) with the real implementation.

## Tests

- `TestRenderK0sCapvFleetProviderID` (control-plane + worker): fleet discovery present per role, node-id read + UUID-validated, `kairos-fleet://` emitted, no `product_uuid`/`vsphere://` leak, valid YAML.
- `TestRenderK0sCapvFleet_BashSyntax`: `bash -n` on both rendered scripts (CP inline block + worker discovery script).
- `TestRenderK0sCapvFleet_NonFleetUnchanged`: non-fleet CAPV k0s control-plane still uses DMI, emits no fleet discovery.
- Full `internal/bootstrap` + `internal/controllers/bootstrap` suites green; `gofmt`/`go vet`/`go build ./...` clean.

## Lab validation

2-node k0s cluster on Kairos v4.1.0 (Hadron) + k0s v1.35.4:

| Node | `Node.spec.providerID` | mechanism | after reboot |
|---|---|---|---|
| control-plane | `kairos-fleet://<cp-node-id>` | post-bootstrap `k0s kubectl` patch | persists |
| worker | `kairos-fleet://<worker-node-id>` | config-dir `KubeletConfiguration` drop-in at first registration | persists |

The worker registered with the fleet providerID on its first kubelet registration (kubelet honors `--config-dir` + `providerID`), and both survived a reboot.
