### PR TITLE
docs(controlplane): correct the SSH-fallback host-retry comment

### DIFF
--- a/internal/controllers/controlplane/ssh_fallback_controller.go
+++ b/internal/controllers/controlplane/ssh_fallback_controller.go
@@ -196,8 +196,9 @@ func (r *SSHFallbackReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	host, err := r.resolveControlPlaneHost(ctx, log, kcp, cluster)
 	if err != nil {
 		log.Info("could not resolve control-plane host; will retry", "error", err.Error())
-		// Soft retry: no condition change, no job enqueue. The next
-		// reconcile (woken by Machine status update) will retry.
+		// No condition change and no job enqueue: requeue on the eval cadence
+		// (evalRequeue) so host resolution is retried once the control-plane
+		// Machine reports an address.
 		return ctrl.Result{RequeueAfter: r.evalRequeue()}, nil
 	}
 


### PR DESCRIPTION
Comment-only cleanup spotted while de-flaking #81. The host-unresolvable branch in the SSH-fallback reconciler returns `ctrl.Result{RequeueAfter: r.evalRequeue()}` (a timed requeue on the eval cadence), but the comment described it as a watch-only "soft retry" woken by a Machine status update. Corrects the comment to match the code. No behavior change.

Generated with Claude Code