### PR TITLE
fix(controlplane): de-flake SSH-fallback KubeconfigReady condition (fixes main test-envtest)

### DIFF
--- a/internal/controllers/controlplane/kairoscontrolplane_controller.go
+++ b/internal/controllers/controlplane/kairoscontrolplane_controller.go
@@ -1253,13 +1253,8 @@ func (r *KairosControlPlaneReconciler) observeKubeconfigSecret(ctx context.Conte
 	// still owns the timestamp anchor above and the success transition (once a
 	// Secret appears, the ready path handles it before we reach here); it just
 	// stops clobbering the sibling's Reason.
-	if cur := conditions.Get(kcp, controlplanev1beta2.KubeconfigReadyCondition); cur != nil {
-		switch cur.Reason {
-		case controlplanev1beta2.SSHFallbackDialingReason,
-			controlplanev1beta2.SSHFallbackFailedReason,
-			controlplanev1beta2.SSHFallbackMisconfiguredReason:
-			return false, nil
-		}
+	if sshFallbackOwnsKubeconfigCondition(kcp) {
+		return false, nil
 	}
 
 	severity := clusterv1.ConditionSeverityInfo

--- a/internal/controllers/controlplane/kairoscontrolplane_controller.go
+++ b/internal/controllers/controlplane/kairoscontrolplane_controller.go
@@ -1239,6 +1239,29 @@ func (r *KairosControlPlaneReconciler) observeKubeconfigSecret(ctx context.Conte
 		now := metav1.Now()
 		kcp.Status.LastNodePushObserved = &now
 	}
+
+	// Defer to the SSH-fallback sibling once it owns KubeconfigReadyCondition.
+	// When Spec.SSHFallback is enabled and the eligibility gate has fired, the
+	// sibling reconciler (ssh_fallback_controller.go) drives this condition
+	// through Dialing -> Failed/Misconfigured. Re-asserting WaitingForNodePush
+	// here on every missing-Secret reconcile would fight the sibling for the
+	// same condition and make the Reason flap between WaitingForNodePush and the
+	// SSH-fallback Reasons: cosmetically confusing in production, and under
+	// workqueue contention on a busy runner enough to keep the envtest suite from
+	// ever snapshotting a stable SSH-fallback Reason (the
+	// TestSSHFallback_MisconfiguredSurfacesCondition flake). The main reconciler
+	// still owns the timestamp anchor above and the success transition (once a
+	// Secret appears, the ready path handles it before we reach here); it just
+	// stops clobbering the sibling's Reason.
+	if cur := conditions.Get(kcp, controlplanev1beta2.KubeconfigReadyCondition); cur != nil {
+		switch cur.Reason {
+		case controlplanev1beta2.SSHFallbackDialingReason,
+			controlplanev1beta2.SSHFallbackFailedReason,
+			controlplanev1beta2.SSHFallbackMisconfiguredReason:
+			return false, nil
+		}
+	}
+
 	severity := clusterv1.ConditionSeverityInfo
 	message := fmt.Sprintf("Waiting for the workload node to push its kubeconfig as Secret %s/%s.", cluster.Namespace, secretName)
 	if elapsed := time.Since(kcp.Status.LastNodePushObserved.Time); elapsed > kubeconfigReadyTimeout {

--- a/internal/controllers/controlplane/ssh_fallback_controller.go
+++ b/internal/controllers/controlplane/ssh_fallback_controller.go
@@ -43,6 +43,7 @@ package controlplane
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -192,6 +193,29 @@ func (r *SSHFallbackReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{RequeueAfter: r.evalRequeue()}, nil
 	}
 
+	// Fail fast on a missing/empty Secret misconfiguration in the reconcile
+	// itself, before dispatching a worker. The worker would only reach the same
+	// SSHFallbackMisconfigured outcome several async hops later
+	// (reconcile -> enqueue -> worker -> result drain), and that chain can be
+	// starved for a long time under workqueue contention on a busy runner —
+	// long enough that the condition never settles on Misconfigured and flaps
+	// through Dialing instead. Deciding a plain missing-Secret misconfiguration
+	// here makes the condition deterministic and stable: it is set on this
+	// reconcile and re-confirmed idempotently on each eval-cadence requeue.
+	// When the operator creates the Secrets, the next reconcile finds them
+	// present and proceeds to dial. The worker still validates parseability and
+	// non-empty content when the Secrets exist.
+	if missing := r.missingSSHFallbackSecrets(ctx, kcp.Spec.SSHFallback, cluster.Namespace); len(missing) > 0 {
+		conditions.MarkFalse(kcp,
+			controlplanev1beta2.KubeconfigReadyCondition,
+			controlplanev1beta2.SSHFallbackMisconfiguredReason,
+			clusterv1.ConditionSeverityWarning,
+			"SSH fallback misconfigured; missing or empty Secret(s): %s.", strings.Join(missing, ", "),
+		)
+		patchOnExit = true
+		return ctrl.Result{RequeueAfter: r.evalRequeue()}, nil
+	}
+
 	// Resolve the host IP from the first control-plane Machine.
 	host, err := r.resolveControlPlaneHost(ctx, log, kcp, cluster)
 	if err != nil {
@@ -324,6 +348,45 @@ func (r *SSHFallbackReconciler) resolveControlPlaneHost(ctx context.Context, log
 		}
 	}
 	return "", fmt.Errorf("no control-plane Machine with a usable address found")
+}
+
+// missingSSHFallbackSecrets returns display names for the SSHFallback Secret
+// references that are absent or empty. It backs the reconcile-time fail-fast in
+// Reconcile so a plain missing-Secret misconfiguration is decided synchronously
+// rather than via a worker round-trip. Existence and non-empty-data-key only;
+// the worker still validates parseability when the Secrets are present. A
+// transient API error (anything other than NotFound) is deliberately NOT
+// treated as missing — that defers to the worker path and the next
+// eval-cadence retry rather than latching a false Misconfigured.
+func (r *SSHFallbackReconciler) missingSSHFallbackSecrets(ctx context.Context, spec *controlplanev1beta2.SSHFallback, clusterNamespace string) []string {
+	if spec == nil {
+		return nil
+	}
+	var missing []string
+	check := func(ref *controlplanev1beta2.SSHFallbackSecretReference, unsetLabel, defaultKey string) {
+		if ref == nil || ref.Name == "" {
+			missing = append(missing, unsetLabel)
+			return
+		}
+		key := ref.Key
+		if key == "" {
+			key = defaultKey
+		}
+		secret := &corev1.Secret{}
+		nn := client.ObjectKey{Name: ref.Name, Namespace: secretRefNamespace(ref, clusterNamespace)}
+		if err := r.Get(ctx, nn, secret); err != nil {
+			if apierrors.IsNotFound(err) {
+				missing = append(missing, ref.Name)
+			}
+			return
+		}
+		if v, ok := secret.Data[key]; !ok || len(v) == 0 {
+			missing = append(missing, ref.Name+" (empty key "+key+")")
+		}
+	}
+	check(spec.KnownHostsSecretRef, "knownHostsSecretRef (unset)", "known_hosts")
+	check(spec.IdentitySecretRef, "identitySecretRef (unset)", "ssh-privatekey")
+	return missing
 }
 
 // preferredMachineAddress returns the best dial target from a Machine's

--- a/internal/controllers/controlplane/ssh_fallback_controller.go
+++ b/internal/controllers/controlplane/ssh_fallback_controller.go
@@ -389,6 +389,27 @@ func (r *SSHFallbackReconciler) missingSSHFallbackSecrets(ctx context.Context, s
 	return missing
 }
 
+// sshFallbackOwnsKubeconfigCondition reports whether the SSH-fallback sibling
+// currently owns KubeconfigReadyCondition, i.e. its Reason is one of the
+// SSH-fallback Reasons (Dialing / Failed / Misconfigured). The main
+// KairosControlPlane reconciler consults this in observeKubeconfigSecret to
+// avoid clobbering the sibling's Reason back to WaitingForNodePush while the
+// fallback path is active.
+func sshFallbackOwnsKubeconfigCondition(kcp *controlplanev1beta2.KairosControlPlane) bool {
+	cur := conditions.Get(kcp, controlplanev1beta2.KubeconfigReadyCondition)
+	if cur == nil {
+		return false
+	}
+	switch cur.Reason {
+	case controlplanev1beta2.SSHFallbackDialingReason,
+		controlplanev1beta2.SSHFallbackFailedReason,
+		controlplanev1beta2.SSHFallbackMisconfiguredReason:
+		return true
+	default:
+		return false
+	}
+}
+
 // preferredMachineAddress returns the best dial target from a Machine's
 // Status.Addresses, prioritising InternalIP > ExternalIP > any.
 func preferredMachineAddress(m *clusterv1.Machine) string {

--- a/internal/controllers/controlplane/ssh_fallback_controller_test.go
+++ b/internal/controllers/controlplane/ssh_fallback_controller_test.go
@@ -17,14 +17,18 @@ permissions and limitations under the License.
 package controlplane
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	conditions "sigs.k8s.io/cluster-api/util/conditions/deprecated/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	controlplanev1beta2 "github.com/kairos-io/cluster-api-provider-kairos/api/controlplane/v1beta2"
@@ -174,6 +178,104 @@ func TestPreferredMachineAddress(t *testing.T) {
 			g := NewWithT(t)
 			m := &clusterv1.Machine{Status: clusterv1.MachineStatus{Addresses: tc.in}}
 			g.Expect(preferredMachineAddress(m)).To(Equal(tc.want))
+		})
+	}
+}
+
+// TestSSHFallbackOwnsKubeconfigCondition pins the predicate the main reconciler
+// uses to defer to the SSH-fallback sibling: only the SSH-fallback Reasons
+// (Dialing / Failed / Misconfigured) count as sibling-owned; WaitingForNodePush,
+// the ready Reason, and an unset condition do not.
+func TestSSHFallbackOwnsKubeconfigCondition(t *testing.T) {
+	cases := []struct {
+		name   string
+		set    bool
+		status corev1.ConditionStatus
+		reason string
+		want   bool
+	}{
+		{name: "no condition", set: false, want: false},
+		{name: "WaitingForNodePush", set: true, status: corev1.ConditionFalse, reason: controlplanev1beta2.WaitingForNodePushReason, want: false},
+		{name: "ready True", set: true, status: corev1.ConditionTrue, reason: controlplanev1beta2.KubeconfigReadyReason, want: false},
+		{name: "SSHFallbackDialing", set: true, status: corev1.ConditionFalse, reason: controlplanev1beta2.SSHFallbackDialingReason, want: true},
+		{name: "SSHFallbackFailed", set: true, status: corev1.ConditionFalse, reason: controlplanev1beta2.SSHFallbackFailedReason, want: true},
+		{name: "SSHFallbackMisconfigured", set: true, status: corev1.ConditionFalse, reason: controlplanev1beta2.SSHFallbackMisconfiguredReason, want: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			kcp := &controlplanev1beta2.KairosControlPlane{}
+			if tc.set {
+				conditions.Set(kcp, &clusterv1.Condition{
+					Type:   controlplanev1beta2.KubeconfigReadyCondition,
+					Status: tc.status,
+					Reason: tc.reason,
+				})
+			}
+			if got := sshFallbackOwnsKubeconfigCondition(kcp); got != tc.want {
+				t.Errorf("sshFallbackOwnsKubeconfigCondition() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSSHFallbackReconciler_MissingSSHFallbackSecrets covers the synchronous
+// missing/empty-Secret detection that lets the reconciler decide
+// SSHFallbackMisconfigured without a worker round-trip.
+func TestSSHFallbackReconciler_MissingSSHFallbackSecrets(t *testing.T) {
+	const ns = "test-ns"
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 to scheme: %v", err)
+	}
+	secret := func(name, key string, val []byte) *corev1.Secret {
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Data:       map[string][]byte{key: val},
+		}
+	}
+	ref := func(name string) *controlplanev1beta2.SSHFallbackSecretReference {
+		return &controlplanev1beta2.SSHFallbackSecretReference{Name: name}
+	}
+
+	cases := []struct {
+		name    string
+		objs    []client.Object
+		spec    *controlplanev1beta2.SSHFallback
+		wantLen int
+	}{
+		{name: "nil spec", spec: nil, wantLen: 0},
+		{
+			name:    "both present and non-empty",
+			objs:    []client.Object{secret("kh", "known_hosts", []byte("host key")), secret("id", "ssh-privatekey", []byte("pem"))},
+			spec:    &controlplanev1beta2.SSHFallback{KnownHostsSecretRef: ref("kh"), IdentitySecretRef: ref("id")},
+			wantLen: 0,
+		},
+		{
+			name:    "both missing",
+			spec:    &controlplanev1beta2.SSHFallback{KnownHostsSecretRef: ref("kh"), IdentitySecretRef: ref("id")},
+			wantLen: 2,
+		},
+		{
+			name:    "known-hosts ref unset",
+			objs:    []client.Object{secret("id", "ssh-privatekey", []byte("pem"))},
+			spec:    &controlplanev1beta2.SSHFallback{IdentitySecretRef: ref("id")},
+			wantLen: 1,
+		},
+		{
+			name:    "known-hosts data key empty",
+			objs:    []client.Object{secret("kh", "known_hosts", []byte{}), secret("id", "ssh-privatekey", []byte("pem"))},
+			spec:    &controlplanev1beta2.SSHFallback{KnownHostsSecretRef: ref("kh"), IdentitySecretRef: ref("id")},
+			wantLen: 1,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.objs...).Build()
+			r := &SSHFallbackReconciler{Client: c}
+			got := r.missingSSHFallbackSecrets(context.Background(), tc.spec, ns)
+			if len(got) != tc.wantLen {
+				t.Errorf("missingSSHFallbackSecrets() = %v (len %d), want len %d", got, len(got), tc.wantLen)
+			}
 		})
 	}
 }

--- a/test/envtest/controlplane_sshfallback_test.go
+++ b/test/envtest/controlplane_sshfallback_test.go
@@ -242,21 +242,13 @@ func TestSSHFallback_MisconfiguredSurfacesCondition(t *testing.T) {
 		return c.Status().Update(ctx, got)
 	}, 30*time.Second, time.Second).Should(Succeed())
 
-	// Eventually the worker fires, fails fast on the missing Secrets, and
-	// the result drain sets the Reason to SSHFallbackMisconfigured.
-	//
-	// Determinism: the sibling reconciler's time-based backstop is
-	// collapsed to EvalRequeue=2s in startKCPEnvtest, so once the gate is
-	// open the eligibility re-check fires within a couple of seconds
-	// rather than racing the 1-minute production cadence.
-	//
-	// The window is 180s (not the 2s cadence) because the SSH-fallback
-	// reconciler *shares the manager workqueue* with every other controller
-	// in this envtest suite (see its SetupWithManager note). On a busy/shared
-	// CI runner the full suite can starve its 2s requeues long enough to eat a
-	// tighter 90s window (observed: the same test passes on a quiet runner and
-	// intermittently times out on a contended one). 180s is headroom against
-	// that queue contention, not against the reconciler's own cadence.
+	// Once the gate is open the sibling reconciler decides the missing-Secret
+	// misconfiguration synchronously (missingSSHFallbackSecrets in
+	// ssh_fallback_controller.go) and sets SSHFallbackMisconfigured directly,
+	// without a reconcile -> worker -> result-drain round-trip that could be
+	// starved under workqueue contention. This makes the transition
+	// deterministic (seconds, not a race against queue pressure), so a modest
+	// window suffices even on a busy runner.
 	g.Eventually(func() string {
 		got := &controlplanev1beta2.KairosControlPlane{}
 		if err := c.Get(ctx, types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}, got); err != nil {
@@ -267,8 +259,28 @@ func TestSSHFallback_MisconfiguredSurfacesCondition(t *testing.T) {
 			return ""
 		}
 		return cond.Reason
-	}, 180*time.Second, 2*time.Second).Should(Equal(controlplanev1beta2.SSHFallbackMisconfiguredReason),
+	}, 90*time.Second, 2*time.Second).Should(Equal(controlplanev1beta2.SSHFallbackMisconfiguredReason),
 		"missing SSHFallback Secrets MUST surface SSHFallbackMisconfigured on KubeconfigReadyCondition")
+
+	// Regression pin for the de-flake: SSHFallbackMisconfigured must be STABLE.
+	// The main reconciler must not clobber it back to WaitingForNodePush (it
+	// defers to the sibling once an SSH-fallback Reason owns the condition), and
+	// the sibling must keep re-confirming it synchronously rather than flapping
+	// through Dialing. Before the fix the two reconcilers fought over
+	// KubeconfigReadyCondition and this Reason oscillated, which is what made
+	// the Eventually above flake under contention.
+	g.Consistently(func() string {
+		got := &controlplanev1beta2.KairosControlPlane{}
+		if err := c.Get(ctx, types.NamespacedName{Name: kcp.Name, Namespace: kcp.Namespace}, got); err != nil {
+			return "ERR: " + err.Error()
+		}
+		cond := conditions.Get(got, controlplanev1beta2.KubeconfigReadyCondition)
+		if cond == nil {
+			return ""
+		}
+		return cond.Reason
+	}, 6*time.Second, time.Second).Should(Equal(controlplanev1beta2.SSHFallbackMisconfiguredReason),
+		"SSHFallbackMisconfigured must stay stable, not flap back to WaitingForNodePush or through Dialing")
 }
 
 // TestSSHFallback_AnnotationDrivesReason (PR-9, exercises commit 3's


### PR DESCRIPTION
## Summary

Fixes the intermittent `test-envtest` failure on `main` where `TestSSHFallback_MisconfiguredSurfacesCondition` times out and the condition stays at `WaitingForNodePush`. This is a pre-existing flake (it failed on #80 and on #81's own window-widen, passed on #82/#83, and failed again on the #84 merge run), rooted in two coupled controller bugs that also produced a confusing flapping condition in production.

## Root cause

1. The main `KairosControlPlane` reconciler unconditionally re-asserted `KubeconfigReadyCondition=WaitingForNodePush` on every missing-Secret reconcile, clobbering the SSH-fallback sibling's `Dialing` / `Failed` / `Misconfigured` Reason. The two reconcilers fought over the same condition.
2. The sibling reported a missing-Secret misconfiguration only via the worker (`reconcile -> enqueue -> worker -> result drain`). Under workqueue contention that async chain is starved, so the condition never settled on `SSHFallbackMisconfigured`.

Together, on a contended runner, the Reason never stabilizes and the test times out.

## Fix

1. The main reconciler defers to the sibling once an SSH-fallback Reason owns the condition. It still anchors `LastNodePushObserved` and owns the success transition (the ready path runs before this point once a Secret appears).
2. The sibling detects a missing or empty SSHFallback Secret synchronously in `Reconcile` and sets `SSHFallbackMisconfigured` directly, re-confirming it idempotently on each eval-cadence requeue; when the Secrets appear it proceeds to dial. The worker still validates parseability and content when the Secrets exist.

Together these make the transition deterministic and the Reason stable. Neither reconciler clobbers the other, and the misconfigured decision no longer depends on a contention-sensitive worker round-trip.

## Validation

The envtest window drops from 180s back to 90s and gains a `Consistently` pin asserting the Reason does not flap. The full envtest suite (18/18) passes; `TestSSHFallback_MisconfiguredSurfacesCondition` resolves in ~10-15s on a deliberately contended machine (load ~6) that reproduces the CI conditions, where it previously timed out at ~188s.
