### PR TITLE
docs(release): prepare v0.1.0-beta.2 release notes and version stamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ This project provides two Cluster API (CAPI) providers for managing Kubernetes c
 
 ## Status
 
-**Latest release**: [`v0.1.0-beta.1`](https://github.com/kairos-io/cluster-api-provider-kairos/releases/tag/v0.1.0-beta.1) — pre-1.0; API surface may still change before v1.0.
+**Latest release**: [`v0.1.0-beta.2`](https://github.com/kairos-io/cluster-api-provider-kairos/releases/tag/v0.1.0-beta.2) — pre-1.0; API surface may still change before v1.0.
 
 Supports single-node and highly-available k0s and k3s clusters with CAPD, CAPV, CAPK, and CAPM3 (Metal3 bare metal). HA control planes (`spec.replicas: 3` or `5`) are supported on CAPK, CAPV, and CAPM3 for both k0s and k3s. CAPD is dev-only; HA is not exercised on CAPD. `KairosControlPlane.spec.replicas` accepts `1` (single-node), `3`, or `5`; even counts and values above `5` are webhook-rejected. See [High-Availability control planes](#high-availability-control-planes) below. k0s is the fully-supported HA distribution; k3s HA has a known day-2 limitation (KD-5d).
 
-Read the [v0.1.0-beta.1 release notes](docs/release-notes/v0.1.0-beta.1.md) before installing — there are breaking changes, security hardening requirements, and known limitations that affect all operators upgrading from alpha.2. Additional infrastructure providers (Tinkerbell, hyperscalers) are on the roadmap.
+Read the [v0.1.0-beta.2 release notes](docs/release-notes/v0.1.0-beta.2.md) before installing. This release adds a second, `clusterctl`-native install path — if you run `clusterctl` on your management cluster, the Breaking Changes section is required reading: the `clusterctl` and flat-manifest paths are mutually exclusive and cannot be swapped in place. Additional infrastructure providers (Tinkerbell, hyperscalers) are on the roadmap.
 
 ## Install (released version)
 
@@ -49,7 +49,7 @@ clusterctl init --bootstrap kairos --control-plane kairos
 ### Path 2 - flat manifest (`kubectl apply`)
 
 ```bash
-kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-beta.1/kairos-capi-provider.yaml
+kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-beta.2/kairos-capi-provider.yaml
 ```
 
 This applies an all-in-one manifest: both providers run as one Deployment in namespace `kairos-capi-system`, labeled `cluster.x-k8s.io/provider: kairos`. It is not a `clusterctl` artifact; it is kept as a `kubectl apply` convenience alongside the `clusterctl` path through the beta series.

--- a/config/samples/capm3/kairos_cluster_k0s_single_node.yaml
+++ b/config/samples/capm3/kairos_cluster_k0s_single_node.yaml
@@ -18,8 +18,8 @@
 #   3. baremetal-operator (BMO) v0.13+ and Ironic running and accessible.
 #      Verify: kubectl get baremetalhosts -A
 #
-#   4. Kairos CAPI provider v0.1.0-beta.1+ installed.
-#      kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-beta.1/kairos-capi-provider.yaml
+#   4. Kairos CAPI provider v0.1.0-beta.2+ installed.
+#      kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-beta.2/kairos-capi-provider.yaml
 #
 #   5. A fully-installed Kairos k0s disk image served over HTTP.
 #      See docs/QUICKSTART_CAPM3.md section "Building the disk image".

--- a/config/samples/capm3/kairos_cluster_k3s_single_node.yaml
+++ b/config/samples/capm3/kairos_cluster_k3s_single_node.yaml
@@ -15,8 +15,8 @@
 #   3. baremetal-operator (BMO) v0.13+ and Ironic running and accessible.
 #      Verify: kubectl get baremetalhosts -A
 #
-#   4. Kairos CAPI provider v0.1.0-beta.1+ installed.
-#      kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-beta.1/kairos-capi-provider.yaml
+#   4. Kairos CAPI provider v0.1.0-beta.2+ installed.
+#      kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-beta.2/kairos-capi-provider.yaml
 #
 #   5. A fully-installed Kairos k3s disk image served over HTTP.
 #      See the "Building the disk image" section in docs/QUICKSTART_CAPM3.md.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # API Reference
 
-Last verified against: Kairos v3.6.0+, CAPI v1.13.4 (v1beta2 contract), provider v0.1.0-beta.1.
+Last verified against: Kairos v3.6.0+, CAPI v1.13.4 (v1beta2 contract), provider v0.1.0-beta.2.
 
 This document provides a reference for all Custom Resource Definitions (CRDs) provided by the Kairos CAPI Provider. See [Install guide](INSTALL.md) for development install. Quickstarts: [CAPD](QUICKSTART_CAPD.md), [CAPV](QUICKSTART_CAPV.md), [CAPK](QUICKSTART_CAPK.md), [CAPM3](QUICKSTART_CAPM3.md).
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,7 +1,7 @@
 # Install Guide
 
 Last verified against: Kairos v3.6.0+, CAPI v1.13.4, cert-manager v1.15+,
-provider v0.1.0-beta.1.
+provider v0.1.0-beta.2.
 
 Three install paths: `clusterctl` (recommended), the released flat artifact (`kubectl apply`), and a developer install from source. Path 1 and Path 2 are mutually exclusive on one management cluster: see [Path 1 and Path 2 are mutually exclusive](#path-1-and-path-2-are-mutually-exclusive) below before picking one.
 
@@ -92,7 +92,7 @@ Use this if you want a single `kubectl apply -f` without configuring `clusterctl
 ### Install
 
 ```bash
-kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-beta.1/kairos-capi-provider.yaml
+kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-beta.2/kairos-capi-provider.yaml
 ```
 
 This applies the all-in-one provider manifest: CRDs, RBAC, webhook configurations, and the controller Deployment in the `kairos-capi-system` namespace, labeled `cluster.x-k8s.io/provider: kairos`. It is not a `clusterctl` artifact. Do not run `clusterctl init --bootstrap kairos` against a management cluster installed this way; see [Path 1 and Path 2 are mutually exclusive](#path-1-and-path-2-are-mutually-exclusive).
@@ -114,7 +114,7 @@ Expected: one Deployment `kairos-capi-controller-manager` in `kairos-capi-system
 ### Uninstall
 
 ```bash
-kubectl delete -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-beta.1/kairos-capi-provider.yaml
+kubectl delete -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-beta.2/kairos-capi-provider.yaml
 ```
 
 **Re-install note**: if you are re-installing across a name-prefix change or a previous failed install, stale `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration` objects from the previous install may point at a webhook Service that no longer exists. Delete them before re-installing:
@@ -211,4 +211,4 @@ for the full configuration steps.
 - [CAPK Quickstart](QUICKSTART_CAPK.md) — create a cluster with KubeVirt.
 - [CAPM3 Quickstart](QUICKSTART_CAPM3.md) — create a cluster on bare metal via Metal3.
 
-For the current release status, breaking changes, and security caveats, read the [v0.1.0-beta.1 release notes](release-notes/v0.1.0-beta.1.md).
+For the current release status, breaking changes, and security caveats, read the [v0.1.0-beta.2 release notes](release-notes/v0.1.0-beta.2.md).

--- a/docs/QUICKSTART_CAPD.md
+++ b/docs/QUICKSTART_CAPD.md
@@ -1,6 +1,6 @@
 # Quick Start Guide - CAPD (Docker)
 
-Last verified against: Kairos v3.6.0+, CAPI v1.13.4, provider v0.1.0-beta.1.
+Last verified against: Kairos v3.6.0+, CAPI v1.13.4, provider v0.1.0-beta.2.
 
 This guide walks you through creating a single-node k0s cluster on Kairos using Cluster API with the Docker provider (CAPD).
 
@@ -28,7 +28,7 @@ Install CAPI and CAPD using your preferred method. See the [Cluster API book](ht
 **Recommended (released artifact):**
 
 ```bash
-kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-beta.1/kairos-capi-provider.yaml
+kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-beta.2/kairos-capi-provider.yaml
 ```
 
 **Developer install (from source):**

--- a/docs/QUICKSTART_CAPK.md
+++ b/docs/QUICKSTART_CAPK.md
@@ -1,6 +1,6 @@
 # Quickstart: CAPK (KubeVirt)
 
-Last verified against: Kairos v3.6.0+, CAPI v1.13.4, KubeVirt v1.8.2, CAPK v0.1.x, provider v0.1.0-beta.1.
+Last verified against: Kairos v4.1.2, CAPI v1.13.4, KubeVirt v1.9, CAPK v0.1.x, provider v0.1.0-beta.2.
 
 This guide covers two paths:
 
@@ -167,7 +167,7 @@ This walkthrough uses the flat manifest (`kubectl apply -f kairos-capi-provider.
   - A LoadBalancer implementation (MetalLB or equivalent)
 - Kairos CAPI provider installed:
   ```bash
-  kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-beta.1/kairos-capi-provider.yaml
+  kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-beta.2/kairos-capi-provider.yaml
   ```
 - A Kairos image uploaded to CDI as a DataVolume named `kairos-rootdisk` (for k0s) or `kairos-k3s-rootdisk` (for k3s) in namespace `default`. The image must be a Kairos live-installer image — not a pre-installed disk image.
 

--- a/docs/QUICKSTART_CAPM3.md
+++ b/docs/QUICKSTART_CAPM3.md
@@ -1,6 +1,6 @@
 # Quick Start Guide - CAPM3 (Metal3 / bare metal)
 
-Last verified against: Kairos v3.6.0+, Kairos Hadron v0.0.4, CAPI v1.13.4, CAPM3 v1.13.0, BMO v0.13.0, provider v0.1.0-beta.1. Verified on emulated bare metal (sushy-tools Redfish BMC + libvirt/KVM) and on physical hardware (Hadron whole-disk deploy to bare metal); the same flow applies to physical hardware with a Redfish/IPMI BMC.
+Last verified against: Kairos v3.6.0+, Kairos Hadron v0.0.4, CAPI v1.13.4, CAPM3 v1.13.0, BMO v0.13.0, provider v0.1.0-beta.2. Verified on emulated bare metal (sushy-tools Redfish BMC + libvirt/KVM) and on physical hardware (Hadron whole-disk deploy to bare metal); the same flow applies to physical hardware with a Redfish/IPMI BMC.
 
 This guide walks you through creating a single-node k3s or k0s cluster on Kairos using Cluster API with the Metal3 infrastructure provider (CAPM3). k0s and k3s use the identical flow and differ only in distribution and version fields. For a 3-node HA control plane, see [High-Availability control plane](#high-availability-control-plane) below.
 
@@ -206,7 +206,7 @@ The k3s or k0s version is fixed at image-build time. `KairosControlPlane.spec.ve
    kubectl get crd metal3clusters.infrastructure.cluster.x-k8s.io
    ```
 
-5. **Kairos CAPI Provider**: v0.1.0-beta.1+ installed (see [INSTALL.md](INSTALL.md)).
+5. **Kairos CAPI Provider**: v0.1.0-beta.2+ installed (see [INSTALL.md](INSTALL.md)).
 
 6. **Fully-installed Kairos disk image**: See "Building the disk image" above.
 
@@ -221,7 +221,7 @@ The k3s or k0s version is fixed at image-build time. `KairosControlPlane.spec.ve
 Install CAPM3 using `clusterctl` or the upstream manifests. Refer to the [Metal3 documentation](https://book.metal3.io/capm3/introduction) for the current install procedure. The Kairos CAPI provider is installed separately:
 
 ```bash
-kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-beta.1/kairos-capi-provider.yaml
+kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-beta.2/kairos-capi-provider.yaml
 ```
 
 See [INSTALL.md](INSTALL.md) for the full provider install and verification steps.

--- a/docs/QUICKSTART_CAPV.md
+++ b/docs/QUICKSTART_CAPV.md
@@ -1,6 +1,6 @@
 # Quick Start Guide - CAPV (vSphere)
 
-Last verified against: Kairos v3.6.0+, CAPI v1.13.4, CAPV v1.11.x+, provider v0.1.0-beta.1.
+Last verified against: Kairos v3.6.0+, CAPI v1.13.4, CAPV v1.11.x+, provider v0.1.0-beta.2.
 
 This guide walks you through creating a single-node k0s or k3s cluster on Kairos using Cluster API with the vSphere provider (CAPV). For a 3-node highly-available k0s control plane, see [High-Availability: 3-node k0s control plane](#high-availability-3-node-k0s-control-plane) below.
 
@@ -69,7 +69,7 @@ kubectl label namespace default vsphere-identity=allowed
 **Recommended (released artifact):**
 
 ```bash
-kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-beta.1/kairos-capi-provider.yaml
+kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-beta.2/kairos-capi-provider.yaml
 ```
 
 **Developer install (from source):**

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,6 +1,6 @@
 # Testing
 
-Last verified against: Go toolchain 1.26.3, provider v0.1.0-beta.1.
+Last verified against: Go toolchain 1.26.3, provider v0.1.0-beta.2.
 
 See [Install guide](INSTALL.md) for development install.
 
@@ -45,7 +45,7 @@ This is the highest-confidence gate but requires Docker and a host with enough m
 
 After the cluster is `Available=true`, drain a node via `kubectl drain <node> --ignore-daemonsets --delete-emptydir-data`, restart the underlying VM (`virtctl restart <vm>` for CAPK; vSphere "Restart Guest OS" for CAPV), uncordon, and verify `kubectl get nodes` shows `Ready` within 5 minutes. This validates KD-23's persistence injection — k0s/k3s state, SSH host keys, and CNI config must survive the reboot.
 
-## Supported configurations (v0.1.0-beta.1)
+## Supported configurations (v0.1.0-beta.2)
 
 Single-node and 3-node HA control planes are supported on CAPK, CAPV, and CAPM3, for both k0s and k3s. CAPD is dev-only (single-node); HA is not exercised on CAPD. CAPD is tested via unit/envtest rather than a live e2e run.
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -200,6 +200,46 @@ single-node cluster to HA, provision a new HA cluster rather than editing
 
 ---
 
+## v0.1.0-beta.1 → v0.1.0-beta.2
+
+Full release notes: [v0.1.0-beta.2](release-notes/v0.1.0-beta.2.md).
+
+This release adds a second, `clusterctl`-native install path (ADR 0007) and
+bumps the required CAPI core version. Neither change force-migrates an
+existing install.
+
+### If you stay on the flat manifest: no action required
+
+`kairos-capi-provider.yaml` keeps the same namespace (`kairos-capi-system`)
+and provider label (`cluster.x-k8s.io/provider: kairos`) it has always had.
+Upgrade in place with the usual `kubectl apply`:
+
+```bash
+kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-beta.2/kairos-capi-provider.yaml
+```
+
+### If you want to move to `clusterctl`: not an in-place upgrade
+
+The `clusterctl` providers use different namespaces and provider labels
+than the flat manifest, and `Deployment.spec.selector` /
+`ClusterRoleBinding.roleRef` are immutable, so moving to `clusterctl` is an
+uninstall-old / install-new operation, not a re-apply. See
+[Moving from the flat install to clusterctl packaging](#moving-from-the-flat-install-to-clusterctl-packaging)
+below for the full procedure and the namespace/label comparison table.
+
+### CAPI core v1.13.4 required
+
+The management-side CAPI dependency moves from v1.13.3 to v1.13.4, a
+low-risk patch release — `controller-runtime` (v0.23.3) and `k8s.io/*`
+(v0.35.4) are unchanged. Upgrade the management cluster's Cluster API core
+to v1.13.4 or later before upgrading this provider:
+
+```bash
+kubectl apply -f https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.13.4/cluster-api-components.yaml
+```
+
+---
+
 ## Moving from the flat install to clusterctl packaging
 
 Full design: ADR 0007 (maintained in the repository's internal decision records).

--- a/docs/release-notes/v0.1.0-beta.2.md
+++ b/docs/release-notes/v0.1.0-beta.2.md
@@ -1,0 +1,180 @@
+# v0.1.0-beta.2 — Release Notes
+
+This is a pre-1.0 release. The API surface may still change before v1.0.
+
+Read the [upgrade guide](https://github.com/kairos-io/cluster-api-provider-kairos/blob/v0.1.0-beta.2/docs/UPGRADING.md)
+before installing.
+
+> This release introduces a second, `clusterctl`-native install path. **If
+> you run `clusterctl` on your management cluster, read the Breaking
+> Changes section before installing — the `clusterctl` and flat-manifest
+> paths are mutually exclusive and cannot be swapped in place.**
+
+---
+
+## Highlights
+
+- **clusterctl-installable packaging (ADR 0007).** One image, packaged as
+  two `clusterctl` providers (`bootstrap-kairos`, `control-plane-kairos`)
+  via a new `--controllers=bootstrap|control-plane|all` flag. A release now
+  publishes `bootstrap-components.yaml` + `control-plane-components.yaml` +
+  `metadata.yaml` (all digest-pinned) alongside the flat
+  `kairos-capi-provider.yaml`.
+- **Baseline modernization.** Kubernetes v1.36 validated/recommended across
+  the CAPI v1.13 management band (v1.30-v1.36); CAPI core v1.13.3 →
+  v1.13.4; Kairos v4.1.2; e2e on KubeVirt v1.9 / kindest/node v1.36.1 / k3s
+  v1.36.1.
+- **SSH-fallback condition stability fix (#85).** `KubeconfigReady` no
+  longer flaps under SSH fallback.
+
+---
+
+## Breaking Changes
+
+### clusterctl install path uses new namespaces and labels (and is mutually exclusive with the flat manifest)
+
+> **If you stay on the flat `kubectl apply` manifest, no action is
+> required.** `kairos-capi-provider.yaml` keeps the same namespace
+> (`kairos-capi-system`) and provider label
+> (`cluster.x-k8s.io/provider: kairos`) it has always had.
+>
+> The new `clusterctl` providers deliberately use **different** namespaces
+> and labels: `capi-kairos-bootstrap-system` / `bootstrap-kairos` and
+> `capi-kairos-control-plane-system` / `control-plane-kairos`. Because
+> `Deployment.spec.selector` and `ClusterRoleBinding.roleRef` are immutable
+> and the namespaces differ, applying one path over the other does **not**
+> upgrade it in place — it stands up a second, independent set of
+> controllers/webhooks watching the same CRDs, which is unsupported. The
+> two paths are mutually exclusive on one management cluster.
+>
+> Moving an existing flat install to `clusterctl` is an uninstall-old /
+> install-new operation, not a re-apply. Your `KairosConfig` /
+> `KairosControlPlane` objects and the CRDs are untouched; only the
+> controller Deployments, RBAC, webhooks, and their namespace/label change.
+> Reconciliation resumes once the new controllers start.
+
+| | Flat install (unchanged) | clusterctl providers (new) |
+| --- | --- | --- |
+| Namespace | `kairos-capi-system` | `capi-kairos-bootstrap-system` (bootstrap), `capi-kairos-control-plane-system` (control plane) |
+| `cluster.x-k8s.io/provider` label | `kairos` | `bootstrap-kairos`, `control-plane-kairos` |
+
+Summary, if you decide to move:
+
+1. Uninstall the flat manifest:
+   ```bash
+   kubectl delete -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-beta.1/kairos-capi-provider.yaml
+   ```
+2. Confirm no stale webhook configurations remain:
+   ```bash
+   kubectl get mutatingwebhookconfigurations,validatingwebhookconfigurations | grep kairos
+   ```
+3. Install via `clusterctl`:
+   ```bash
+   clusterctl init --bootstrap kairos --control-plane kairos
+   ```
+
+Full step-by-step procedure: [UPGRADING — Moving from the flat install to clusterctl packaging](https://github.com/kairos-io/cluster-api-provider-kairos/blob/v0.1.0-beta.2/docs/UPGRADING.md#moving-from-the-flat-install-to-clusterctl-packaging).
+
+---
+
+## New Features
+
+- **Two `clusterctl` providers from one image (ADR 0007).** The new
+  `--controllers=bootstrap|control-plane|all` flag selects which
+  controllers and webhooks a given process registers; a role-specific
+  `LeaderElectionID` and a `--namespace` flag bring single-namespace-watch
+  compliance. A release now publishes the four artifacts described in
+  Highlights above. The flat manifest is retained through the beta series
+  as a `kubectl apply` convenience.
+- **Per-provider least-privilege RBAC.** RBAC is split into two
+  per-namespace sets, one per `clusterctl` provider; five dead cluster-wide
+  grants are removed, including an unused `webhookconfigurations` `patch`
+  permission (a MITM primitive). See Security below.
+- **CA injection is now standard cert-manager.**
+  `hack/post-install-webhook-ca-injection.sh` is retired; each provider
+  wires `cert-manager.io/inject-ca-from` per namespace.
+- **`clusterctl` plumbing fixed.** `config/clusterctl/metadata.yaml` is
+  reshaped to a valid `Metadata` document; the stray `provider.yaml` is
+  deleted.
+
+---
+
+## Bug Fixes
+
+### SSH-fallback `KubeconfigReady` condition no longer flaps (#85)
+
+Under SSH fallback the main reconciler was clobbering the sibling
+condition's Reason, and misconfiguration was only detected through a
+contention-sensitive worker round-trip. The condition is now written
+deterministically and stays stable; misconfiguration is detected without
+the flaky round-trip.
+
+---
+
+## Known Limitations
+
+### No cosign signing or SBOM yet
+
+Release artifacts are image-digest-pinned but not cosign-signed and ship no
+SBOM. Tracked for a future release. (Carried from beta.1.)
+
+### k3s HA day-2: control-plane replacement orphans an etcd member (KD-5d)
+
+k3s embedded etcd has no supported clean member-remove operation; replacing
+or scaling down a k3s HA control-plane node leaves an orphaned etcd member
+requiring manual `etcdctl member remove`. k0s remains the fully-supported
+HA distribution. See
+[v0.1.0-beta.1 — Known Limitations](https://github.com/kairos-io/cluster-api-provider-kairos/blob/v0.1.0-beta.2/docs/release-notes/v0.1.0-beta.1.md#known-limitations)
+for the full HA day-2 signal set (the `EtcdMemberLeaveTimedOut` timeout
+case and KD-51's forgeable node-self-reported signals), which is unchanged
+in this release.
+
+---
+
+## Security
+
+- **RBAC reduction as attack-surface reduction.** Five dead cluster-wide
+  grants are removed, including the unused webhook-config `patch`
+  primitive.
+- **CA injection via standard `inject-ca-from`.** The post-install script
+  that required broad permissions is gone.
+- **Supply chain: digest-pinned, not yet signed.** Release artifacts are
+  image-digest-pinned but **not** cosign-signed and ship **no SBOM** —
+  repeated here from Known Limitations because it is a supply-chain gap,
+  not just a missing feature.
+
+---
+
+## Compatibility
+
+See [README — Target Versions](https://github.com/kairos-io/cluster-api-provider-kairos/blob/v0.1.0-beta.2/README.md#target-versions)
+for the current matrix. Summary of what changed since v0.1.0-beta.1:
+
+| Component | v0.1.0-beta.1 | v0.1.0-beta.2 |
+| --- | --- | --- |
+| Cluster API core | v1.13.3 | v1.13.4 (v1beta2 contract) |
+| Kubernetes (management) | v1.35 | v1.30-v1.36 (v1.36 validated/recommended) |
+| Kubernetes (workload) | v1.34+ | v1.30-v1.36 |
+| Kairos | v3.6.0+ | v4.1.2 |
+| k0s | ~v1.34.8+k0s | ~v1.36.1+k0s |
+| k3s | ~v1.34.8+k3s1 | ~v1.36.1+k3s1 |
+| controller-runtime | v0.23.3 | v0.23.3 (unchanged) |
+| k8s.io/* | v0.35.4 | v0.35.4 (unchanged) |
+| e2e stack | KubeVirt v1.8.2 | KubeVirt v1.9 / kindest/node v1.36.1 |
+
+Management-cluster v1.36 support is delivered via tooling (envtest
+v1.36.2, `kindest/node:v1.36.1`, the e2e management cluster moving to
+v1.36), **not** a library bump — `controller-runtime` and `k8s.io/*` stay
+pinned to CAPI v1.13.4's own versions. v1.36 is validated and recommended,
+not a hard floor.
+
+---
+
+## Upgrade Notes
+
+Flat-install users: no action beyond the CAPI core v1.13.4 baseline (see
+Compatibility above) — no manifest changes required.
+
+If you want to move an existing flat install to the `clusterctl` path, see
+[UPGRADING — Moving from the flat install to clusterctl packaging](https://github.com/kairos-io/cluster-api-provider-kairos/blob/v0.1.0-beta.2/docs/UPGRADING.md#moving-from-the-flat-install-to-clusterctl-packaging)
+for the full step-by-step procedure.


### PR DESCRIPTION
## Summary

Release preparation for **v0.1.0-beta.2**: adds `docs/release-notes/v0.1.0-beta.2.md` and bumps the version stamps across the docs. Merging this enables tagging `v0.1.0-beta.2` — the release workflow refuses to release unless the release-notes file exists on the tagged commit.

This release ships #84 (Kubernetes 1.36 / Cluster API v1.13.4 / Kairos v4.1.2 baseline + clusterctl-installable packaging) and #85 (SSH-fallback condition de-flake). All `main` CI is green, including the e2e job (kind + KubeVirt v1.9 + Kairos v4.1.2 on a k8s-1.36 management cluster).

## Changes

- **New**: `docs/release-notes/v0.1.0-beta.2.md` — leads with the clusterctl-installable packaging (ADR 0007); makes the namespace/label mutual-exclusivity the prominent breaking change (framed as a no-op for flat-manifest users); covers the baseline modernization, the #85 fix, the compatibility delta table, and discloses the cosign/SBOM supply-chain gap.
- **README**: latest-release link and flat-manifest download URL to beta.2; the release-notes pointer rewritten around the clusterctl breaking change.
- **docs**: provider version stamp to beta.2 across INSTALL / API_REFERENCE / TESTING / QUICKSTART_*. The CAPK quickstart also moves to Kairos v4.1.2 / KubeVirt v1.9 (the path the CI e2e validates on this baseline); the CAPV and CAPM3 "Last verified against" Kairos values are left unchanged, since those labs were not re-run on v4.1.2.
- **UPGRADING**: a `v0.1.0-beta.1 -> v0.1.0-beta.2` section pointing at the flat-install-to-clusterctl migration procedure.
- **config/samples/capm3**: single-node sample comment bumps.

## After merge

Tag `v0.1.0-beta.2` on the merge commit. The release workflow then builds the multi-arch image, resolves its digest, and publishes the digest-pinned `bootstrap-components.yaml` + `control-plane-components.yaml` + `metadata.yaml` + flat `kairos-capi-provider.yaml` as a GitHub release with these notes as the body. This is the first run of the release plumbing added in #84; `make release-manifests` was validated locally (four artifacts, all components digest-pinned).
