### PR TITLE
docs(readme): slim the README and move HA detail into docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,42 +21,14 @@ Read the [v0.1.0-beta.2 release notes](docs/release-notes/v0.1.0-beta.2.md) befo
 
 ## Install (released version)
 
-> Requires [cert-manager](https://cert-manager.io) v1.15+ and Cluster API core v1.13.4+ installed on the management cluster. See the [install guide](docs/INSTALL.md) for the full prerequisite list.
+> Requires [cert-manager](https://cert-manager.io) v1.15+ and Cluster API core v1.13.4+ installed on the management cluster.
 
-The provider ships two ways. Pick one per management cluster: they are mutually exclusive, see below.
+The provider ships two ways; pick one per management cluster, they are mutually exclusive:
 
-### Path 1 - clusterctl (recommended)
+- **clusterctl (recommended)**: register the provider, then run `clusterctl init --bootstrap kairos --control-plane kairos`.
+- **Flat manifest**: `kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-beta.2/kairos-capi-provider.yaml`.
 
-Per ADR 0007, this provider packages as two `clusterctl` providers built from one image: a bootstrap provider and a control-plane provider. It is not yet in the upstream `clusterctl` provider list, so add it explicitly to your `clusterctl` configuration first:
-
-```yaml
-# ~/.cluster-api/clusterctl.yaml (or pass --config <path> to clusterctl)
-providers:
-  - name: "kairos"
-    url: "https://github.com/kairos-io/cluster-api-provider-kairos/releases/latest/download/bootstrap-components.yaml"
-    type: "BootstrapProvider"
-  - name: "kairos"
-    url: "https://github.com/kairos-io/cluster-api-provider-kairos/releases/latest/download/control-plane-components.yaml"
-    type: "ControlPlaneProvider"
-```
-
-```bash
-clusterctl init --bootstrap kairos --control-plane kairos
-```
-
-`clusterctl init` installs cert-manager and Cluster API core automatically if they are not already present. This installs the bootstrap provider (label `bootstrap-kairos`) in namespace `capi-kairos-bootstrap-system` and the control-plane provider (label `control-plane-kairos`) in namespace `capi-kairos-control-plane-system`. See the [install guide](docs/INSTALL.md) for the full procedure, including combining this with `--infrastructure <provider>` in one call.
-
-### Path 2 - flat manifest (`kubectl apply`)
-
-```bash
-kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-beta.2/kairos-capi-provider.yaml
-```
-
-This applies an all-in-one manifest: both providers run as one Deployment in namespace `kairos-capi-system`, labeled `cluster.x-k8s.io/provider: kairos`. It is not a `clusterctl` artifact; it is kept as a `kubectl apply` convenience alongside the `clusterctl` path through the beta series.
-
-### The two paths are mutually exclusive on one management cluster
-
-They use different namespaces and different `cluster.x-k8s.io/provider` label values. Applying one path after the other does not upgrade or replace it: it runs a second, independent set of controllers and webhooks watching the same CRDs, which is unsupported. Pick one path per management cluster. See [docs/UPGRADING.md](docs/UPGRADING.md) if you need to move an existing installation from one path to the other.
+See the [install guide](docs/INSTALL.md) for provider registration, the full procedure for both paths, and why they cannot be mixed on one management cluster.
 
 ## Credentials
 
@@ -64,45 +36,7 @@ Provide node credentials via `userPasswordSecretRef` (recommended) or `sshPublic
 
 ## High-Availability control planes
 
-`KairosControlPlane.spec.replicas` accepts `1`, `3`, or `5`. `1` is single-node. `3` or `5` configure a multi-node control plane with etcd quorum (the webhook rejects even counts and values above `5`, since they add quorum cost without additional fault tolerance).
-
-HA control planes need a stable endpoint that survives the loss of any one node. The mechanism depends on the infrastructure provider:
-
-- **CAPV and CAPM3**: configure a kube-vip virtual IP via `spec.ha.vip`. `Cluster.spec.controlPlaneEndpoint.host` must equal `spec.ha.vip.address` — CAPI core copies the InfraCluster's endpoint into `Cluster.spec.controlPlaneEndpoint`, and every node and kubeconfig targets that value.
-- **CAPK**: do not set `spec.ha.vip`. CAPK provisions its own LoadBalancer Service and reflects its IP into the control-plane endpoint; a kube-vip VIP alongside it would produce a conflicting ARP announcement.
-- **CAPD**: dev-only; HA is not exercised.
-
-```yaml
-spec:
-  replicas: 3
-  ha:
-    vip:
-      address: "192.168.1.50"   # must equal Cluster.spec.controlPlaneEndpoint.host
-      interface: "ens192"       # NIC name present on the control-plane nodes
-      mode: ARP                 # ARP (default, flat L2 subnet) or BGP (routed fabric)
-```
-
-Where `spec.ha.vip` applies, the controller renders a kube-vip DaemonSet into each control-plane node's bootstrap cloud-config; one Pod holds leader election and advertises the VIP, failing over to a surviving node if the leader is lost.
-
-Worked samples:
-
-- [`config/samples/capv/kairos_cluster_k0s_ha.yaml`](config/samples/capv/kairos_cluster_k0s_ha.yaml) / [`kairos_cluster_k3s_ha.yaml`](config/samples/capv/kairos_cluster_k3s_ha.yaml)
-- [`config/samples/capk/kubevirt_cluster_k0s_ha.yaml`](config/samples/capk/kubevirt_cluster_k0s_ha.yaml) / [`kubevirt_cluster_k3s_ha.yaml`](config/samples/capk/kubevirt_cluster_k3s_ha.yaml)
-- [`config/samples/capm3/kairos_cluster_k0s_ha.yaml`](config/samples/capm3/kairos_cluster_k0s_ha.yaml) / [`kairos_cluster_k3s_ha.yaml`](config/samples/capm3/kairos_cluster_k3s_ha.yaml)
-
-See the [CAPV HA quickstart walkthrough](docs/QUICKSTART_CAPV.md#high-availability-3-node-k0s-control-plane) for the full procedure.
-
-### Day-2: etcd health and quorum-safe replacement
-
-Each control-plane node reports its own etcd member health as the `EtcdHealthy` condition on `KairosControlPlane`: `True` when every voting member is healthy, `False(Info)` when quorum holds but a member is degraded, `False(Warning)` at or below the `(N/2)+1` quorum minimum.
-
-Rollouts and scale-downs are quorum-safe — the controller refuses a control-plane Machine delete that would drop etcd below `(N/2)+1` healthy voting members.
-
-On k0s, the departing node runs `k0s etcd leave` before the Machine is deleted; a CAPI pre-terminate hook blocks termination until it acks, so no member is left orphaned. **k3s has no supported clean member-remove (KD-5d):** replacing a k3s control-plane node leaves an orphaned etcd member requiring manual `etcdctl member remove` (the controller emits `EtcdMemberRemoveUnsupportedForK3s`). k0s is the fully-supported HA distribution.
-
-A k0s node that never acks its leave within ~5 minutes is deleted anyway (the delete was already proven quorum-safe); watch for `EtcdMemberLeaveTimedOut` and remove the member manually if it fires.
-
-**KD-51:** etcd health/leave signals are node-self-reported over vanilla RBAC, so a compromised control-plane node can forge them. Not a privilege escalation (a compromised node already has cluster-admin-equivalent access) and it cannot force an unsafe deletion — quorum-safety is decided independently of any node signal. A forged signal can only self-downgrade the clean-leave/health guarantee.
+`KairosControlPlane.spec.replicas` accepts `1`, `3`, or `5`. k0s is the fully-supported HA distribution; k3s HA has a known day-2 limitation replacing a control-plane node (KD-5d). See [docs/HIGH_AVAILABILITY.md](docs/HIGH_AVAILABILITY.md) for the per-provider VIP configuration, worked samples, and the etcd health / quorum-safe replacement day-2 behavior.
 
 ## Target Versions
 
@@ -126,6 +60,7 @@ Management-cluster support is the full Cluster API v1.13 band (v1.30-v1.36); v1.
 ## Documentation
 
 - [Install guide](docs/INSTALL.md) — installation paths (clusterctl, released flat artifact, and developer install from source).
+- [High-Availability control planes](docs/HIGH_AVAILABILITY.md) — VIP configuration, worked samples, and etcd day-2 behavior.
 - [Upgrade guide](docs/UPGRADING.md) — upgrade procedures and breaking-change migration steps.
 - [API Reference](docs/API_REFERENCE.md) — CRD reference.
 - [Testing](docs/TESTING.md) — how to run tests.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -503,7 +503,7 @@ When `KairosControlPlane.spec.replicas == 1`, the controller automatically sets 
 
 `KairosControlPlane.spec.replicas` accepts `1`, `3`, or `5`. The validating webhook rejects even counts (they give the same etcd fault tolerance as the next-lower odd count while raising the quorum requirement — always use the next-higher odd number instead) and values above `5` (beyond 5 members the quorum cost outweighs the added fault tolerance for a control plane).
 
-`3` and `5` configure a highly-available control plane. Set `spec.ha.vip` on CAPV, CAPM3, and CAPD clusters so kube-vip provides a stable, failover-capable endpoint — do not set it on CAPK, which supplies its own LoadBalancer-backed endpoint. See [HAConfig](#haconfig) and [EtcdHealthy condition](#etcdhealthy-condition) above, and [README.md — High-Availability control planes](../README.md#high-availability-control-planes) for the full day-2 behavior (quorum-safe replacement, k0s clean etcd-leave, and the k3s orphaned-member limitation tracked as KD-5d).
+`3` and `5` configure a highly-available control plane. Set `spec.ha.vip` on CAPV, CAPM3, and CAPD clusters so kube-vip provides a stable, failover-capable endpoint — do not set it on CAPK, which supplies its own LoadBalancer-backed endpoint. See [HAConfig](#haconfig) and [EtcdHealthy condition](#etcdhealthy-condition) above, and [docs/HIGH_AVAILABILITY.md](HIGH_AVAILABILITY.md) for the full day-2 behavior (quorum-safe replacement, k0s clean etcd-leave, and the k3s orphaned-member limitation tracked as KD-5d).
 
 ### Security Considerations
 

--- a/docs/HIGH_AVAILABILITY.md
+++ b/docs/HIGH_AVAILABILITY.md
@@ -1,0 +1,48 @@
+# High-Availability Control Planes
+
+Last verified against: provider v0.1.0-beta.2, CAPI v1.13.4.
+
+This page covers `KairosControlPlane` HA configuration (`spec.replicas` and
+`spec.ha.vip`) and the day-2 etcd health and quorum-safe replacement
+behavior. For installation, see [docs/INSTALL.md](INSTALL.md); for supported
+component versions, see [README.md — Target Versions](../README.md#target-versions).
+
+`KairosControlPlane.spec.replicas` accepts `1`, `3`, or `5`. `1` is single-node. `3` or `5` configure a multi-node control plane with etcd quorum (the webhook rejects even counts and values above `5`, since they add quorum cost without additional fault tolerance).
+
+HA control planes need a stable endpoint that survives the loss of any one node. The mechanism depends on the infrastructure provider:
+
+- **CAPV and CAPM3**: configure a kube-vip virtual IP via `spec.ha.vip`. `Cluster.spec.controlPlaneEndpoint.host` must equal `spec.ha.vip.address` — CAPI core copies the InfraCluster's endpoint into `Cluster.spec.controlPlaneEndpoint`, and every node and kubeconfig targets that value.
+- **CAPK**: do not set `spec.ha.vip`. CAPK provisions its own LoadBalancer Service and reflects its IP into the control-plane endpoint; a kube-vip VIP alongside it would produce a conflicting ARP announcement.
+- **CAPD**: dev-only; HA is not exercised.
+
+```yaml
+spec:
+  replicas: 3
+  ha:
+    vip:
+      address: "192.168.1.50"   # must equal Cluster.spec.controlPlaneEndpoint.host
+      interface: "ens192"       # NIC name present on the control-plane nodes
+      mode: ARP                 # ARP (default, flat L2 subnet) or BGP (routed fabric)
+```
+
+Where `spec.ha.vip` applies, the controller renders a kube-vip DaemonSet into each control-plane node's bootstrap cloud-config; one Pod holds leader election and advertises the VIP, failing over to a surviving node if the leader is lost.
+
+Worked samples:
+
+- [`config/samples/capv/kairos_cluster_k0s_ha.yaml`](../config/samples/capv/kairos_cluster_k0s_ha.yaml) / [`kairos_cluster_k3s_ha.yaml`](../config/samples/capv/kairos_cluster_k3s_ha.yaml)
+- [`config/samples/capk/kubevirt_cluster_k0s_ha.yaml`](../config/samples/capk/kubevirt_cluster_k0s_ha.yaml) / [`kubevirt_cluster_k3s_ha.yaml`](../config/samples/capk/kubevirt_cluster_k3s_ha.yaml)
+- [`config/samples/capm3/kairos_cluster_k0s_ha.yaml`](../config/samples/capm3/kairos_cluster_k0s_ha.yaml) / [`kairos_cluster_k3s_ha.yaml`](../config/samples/capm3/kairos_cluster_k3s_ha.yaml)
+
+See the [CAPV HA quickstart walkthrough](QUICKSTART_CAPV.md#high-availability-3-node-k0s-control-plane) for the full procedure.
+
+## Day-2: etcd health and quorum-safe replacement
+
+Each control-plane node reports its own etcd member health as the `EtcdHealthy` condition on `KairosControlPlane`: `True` when every voting member is healthy, `False(Info)` when quorum holds but a member is degraded, `False(Warning)` at or below the `(N/2)+1` quorum minimum.
+
+Rollouts and scale-downs are quorum-safe — the controller refuses a control-plane Machine delete that would drop etcd below `(N/2)+1` healthy voting members.
+
+On k0s, the departing node runs `k0s etcd leave` before the Machine is deleted; a CAPI pre-terminate hook blocks termination until it acks, so no member is left orphaned. **k3s has no supported clean member-remove (KD-5d):** replacing a k3s control-plane node leaves an orphaned etcd member requiring manual `etcdctl member remove` (the controller emits `EtcdMemberRemoveUnsupportedForK3s`). k0s is the fully-supported HA distribution.
+
+A k0s node that never acks its leave within ~5 minutes is deleted anyway (the delete was already proven quorum-safe); watch for `EtcdMemberLeaveTimedOut` and remove the member manually if it fires.
+
+**KD-51:** etcd health/leave signals are node-self-reported over vanilla RBAC, so a compromised control-plane node can forge them. Not a privilege escalation (a compromised node already has cluster-admin-equivalent access) and it cannot force an unsafe deletion — quorum-safety is decided independently of any node signal. A forged signal can only self-downgrade the clean-leave/health guarantee.

--- a/docs/QUICKSTART_CAPD.md
+++ b/docs/QUICKSTART_CAPD.md
@@ -60,7 +60,7 @@ Key components:
 - `Secret` — user password (referenced by `userPasswordSecretRef` in KairosConfigTemplate).
 - `Cluster` — references `DockerCluster` and `KairosControlPlane`.
 - `DockerCluster` — Docker infrastructure cluster.
-- `KairosControlPlane` — control plane with `replicas: 1` (this guide is single-node). HA (`replicas: 3`/`5`) is supported on CAPK, CAPV, and CAPM3 — see the [README HA section](../README.md#high-availability-control-planes). CAPD is dev-only and HA is not exercised on it; there is no CAPD HA sample.
+- `KairosControlPlane` — control plane with `replicas: 1` (this guide is single-node). HA (`replicas: 3`/`5`) is supported on CAPK, CAPV, and CAPM3 — see [docs/HIGH_AVAILABILITY.md](HIGH_AVAILABILITY.md). CAPD is dev-only and HA is not exercised on it; there is no CAPD HA sample.
 - `DockerMachineTemplate` — template for Docker machines.
 - `KairosConfigTemplate` — bootstrap configuration with `userPasswordSecretRef`.
 
@@ -150,7 +150,7 @@ This adds a `MachineDeployment` for worker nodes referencing a separate `KairosC
 
 - Configure additional Kubernetes manifests via `spec.manifests` in `KairosConfigTemplate`.
 - Scale worker nodes by updating `MachineDeployment.spec.replicas`.
-- HA control planes (`replicas: 3`/`5`) are supported on CAPK, CAPV, and CAPM3 — see the [README HA section](../README.md#high-availability-control-planes). CAPD is dev-only; HA is not exercised on it.
+- HA control planes (`replicas: 3`/`5`) are supported on CAPK, CAPV, and CAPM3 — see [docs/HIGH_AVAILABILITY.md](HIGH_AVAILABILITY.md). CAPD is dev-only; HA is not exercised on it.
 
 ## Cleanup
 

--- a/docs/QUICKSTART_CAPK.md
+++ b/docs/QUICKSTART_CAPK.md
@@ -219,7 +219,7 @@ kubectl apply -f config/samples/capk/kubevirt_cluster_k3s_ha.yaml
 
 Prerequisite specific to CAPK HA: etcd peers over each control-plane VM's own IP. KubeVirt's default `masquerade` interface gives every VM the same self-address (`10.0.2.2`), so etcd cannot peer across nodes on that interface alone. Each control-plane VM needs a second, routable NIC (a Multus-attached bridge network or equivalent) in addition to the default masquerade interface. See the header comments in the HA sample files for the exact `interfaces`/`networks` shape.
 
-k3s HA has the same day-2 limitation as other providers: replacing a k3s control-plane node leaves an orphaned etcd member requiring manual cleanup (KD-5d). See the [README Day-2 section](../README.md#day-2-etcd-health-and-quorum-safe-replacement).
+k3s HA has the same day-2 limitation as other providers: replacing a k3s control-plane node leaves an orphaned etcd member requiring manual cleanup (KD-5d). See [docs/HIGH_AVAILABILITY.md — Day-2](HIGH_AVAILABILITY.md#day-2-etcd-health-and-quorum-safe-replacement).
 
 ---
 

--- a/docs/QUICKSTART_CAPM3.md
+++ b/docs/QUICKSTART_CAPM3.md
@@ -357,7 +357,7 @@ If the node cannot reach the management API server, enable the opt-in [Air-gappe
 
 CAPM3 supports a 3- or 5-node control plane fronted by a kube-vip virtual IP (VIP), using [`config/samples/capm3/kairos_cluster_k0s_ha.yaml`](../config/samples/capm3/kairos_cluster_k0s_ha.yaml) or [`kairos_cluster_k3s_ha.yaml`](../config/samples/capm3/kairos_cluster_k3s_ha.yaml). Read the single-node walkthrough above first — the disk-image, BareMetalHost, and credentials-Secret steps are identical. This section covers only what's different for HA.
 
-k0s is the fully-supported HA distribution. k3s HA bring-up works the same way, but replacing a k3s control-plane node afterward leaves an orphaned etcd member requiring manual cleanup (KD-5d) — see [README.md — Day-2](../README.md#day-2-etcd-health-and-quorum-safe-replacement).
+k0s is the fully-supported HA distribution. k3s HA bring-up works the same way, but replacing a k3s control-plane node afterward leaves an orphaned etcd member requiring manual cleanup (KD-5d) — see [docs/HIGH_AVAILABILITY.md — Day-2](HIGH_AVAILABILITY.md#day-2-etcd-health-and-quorum-safe-replacement).
 
 ### HA prerequisites
 
@@ -601,7 +601,7 @@ If the node's IP changes after provisioning (DHCP lease reassignment), the `cont
 
 - Configure worker nodes via `MachineDeployment` with a `Metal3MachineTemplate` and a worker-role `KairosConfigTemplate`.
 - Add custom Kubernetes manifests via `spec.template.spec.manifests` in `KairosConfigTemplate`.
-- HA control planes (`replicas: 3`/`5` with a kube-vip VIP via `spec.ha.vip`) are supported on CAPM3 for both k0s and k3s — see [High-Availability control plane](#high-availability-control-plane) above and the [README HA section](../README.md#high-availability-control-planes).
+- HA control planes (`replicas: 3`/`5` with a kube-vip VIP via `spec.ha.vip`) are supported on CAPM3 for both k0s and k3s — see [High-Availability control plane](#high-availability-control-plane) above and [docs/HIGH_AVAILABILITY.md](HIGH_AVAILABILITY.md).
 - Static IPAM via Metal3DataTemplate / Metal3IPPool is a future phase.
 
 ---

--- a/docs/QUICKSTART_CAPV.md
+++ b/docs/QUICKSTART_CAPV.md
@@ -316,7 +316,7 @@ on the `KairosControlPlane`.
 
 This section walks through a 3-node HA k0s control plane fronted by a kube-vip virtual IP (VIP), using [`config/samples/capv/kairos_cluster_k0s_ha.yaml`](../config/samples/capv/kairos_cluster_k0s_ha.yaml). A k3s HA sample with the same shape is at [`config/samples/capv/kairos_cluster_k3s_ha.yaml`](../config/samples/capv/kairos_cluster_k3s_ha.yaml). Read the [single-node walkthrough](#creating-a-cluster) above first — the vSphere template, credentials Secret, and `userPasswordSecretRef` steps are identical. This section covers only what's different for HA.
 
-k0s is the fully-supported HA distribution. k3s HA bring-up works the same way, but replacing a k3s control-plane node afterward leaves an orphaned etcd member requiring manual cleanup — see [README.md — High-Availability control planes](../README.md#high-availability-control-planes) for the full day-2 explanation (KD-5d).
+k0s is the fully-supported HA distribution. k3s HA bring-up works the same way, but replacing a k3s control-plane node afterward leaves an orphaned etcd member requiring manual cleanup — see [docs/HIGH_AVAILABILITY.md](HIGH_AVAILABILITY.md) for the full day-2 explanation (KD-5d).
 
 ### HA prerequisites
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -190,7 +190,7 @@ the YAML shape (including an explicit `metadata: {}`) is unaffected.
 Previously only `1` was accepted. `replicas: 3` or `5` now provisions a
 multi-node control plane; even counts and values above `5` are
 webhook-rejected. Existing `replicas: 1` deployments are unaffected. See
-[README.md — High-Availability control planes](../README.md#high-availability-control-planes)
+[docs/HIGH_AVAILABILITY.md](HIGH_AVAILABILITY.md)
 for the new HA fields (`spec.ha.vip`, provider-specific endpoint mechanism)
 and the [HA sample manifests](../config/samples/) for CAPK, CAPV, and CAPM3.
 


### PR DESCRIPTION
## Summary

The top-level README carried deep operational detail that belongs in the docs tree. This slims it to a concise entry point (154 -> 89 lines) and relocates the detail without losing anything.

## Changes

- **New `docs/HIGH_AVAILABILITY.md`**: the full "High-Availability control planes" section and its day-2 etcd/quorum content (per-provider kube-vip VIP configuration, worked samples, quorum-safe replacement, k0s clean etcd-leave, the k3s KD-5d orphaned-member limitation), moved verbatim. The README keeps a short pointer.
- **Install section** trimmed from ~38 lines to a two-path summary (clusterctl / flat manifest) plus a link to `docs/INSTALL.md`, which already carries the provider-config YAML, the full procedure, and the mutual-exclusivity rationale.
- **Repointed** every inbound link to the moved HA anchors (`docs/UPGRADING.md`, `docs/API_REFERENCE.md`, and the four quickstarts) at `docs/HIGH_AVAILABILITY.md`.
- Added `docs/HIGH_AVAILABILITY.md` to the README documentation index.

No content is removed, only relocated. Overview, Status, Credentials, Target Versions, the documentation index, Development, and License are unchanged. Verified no stale `README.md#high-availability` / `#day-2` links remain outside the historical release notes.