### PR TITLE
feat: support the Kairos fleet (AuroraBoot) infrastructure provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This project provides two Cluster API (CAPI) providers for managing Kubernetes c
 
 **Latest release**: [`v0.1.0-beta.2`](https://github.com/kairos-io/cluster-api-provider-kairos/releases/tag/v0.1.0-beta.2) — pre-1.0; API surface may still change before v1.0.
 
-Supports single-node and highly-available k0s and k3s clusters with CAPD, CAPV, CAPK, and CAPM3 (Metal3 bare metal). HA control planes (`spec.replicas: 3` or `5`) are supported on CAPK, CAPV, and CAPM3 for both k0s and k3s. CAPD is dev-only; HA is not exercised on CAPD. `KairosControlPlane.spec.replicas` accepts `1` (single-node), `3`, or `5`; even counts and values above `5` are webhook-rejected. See [High-Availability control planes](#high-availability-control-planes) below. k0s is the fully-supported HA distribution; k3s HA has a known day-2 limitation (KD-5d).
+Supports single-node and highly-available k0s and k3s clusters with CAPD, CAPV, CAPK, and CAPM3 (Metal3 bare metal), plus single-control-plane clusters with the Kairos fleet infrastructure provider (AuroraBoot-claimed nodes; ADR 0008, maintained in the repository's internal decision records). HA control planes (`spec.replicas: 3` or `5`) are supported on CAPK, CAPV, and CAPM3 for both k0s and k3s. CAPD is dev-only; HA is not exercised on CAPD. Fleet HA is not yet exercised — fleet is single-control-plane only today. `KairosControlPlane.spec.replicas` accepts `1` (single-node), `3`, or `5`; even counts and values above `5` are webhook-rejected. See [High-Availability control planes](#high-availability-control-planes) below. k0s is the fully-supported HA distribution; k3s HA has a known day-2 limitation (KD-5d).
 
 Read the [v0.1.0-beta.2 release notes](docs/release-notes/v0.1.0-beta.2.md) before installing. This release adds a second, `clusterctl`-native install path — if you run `clusterctl` on your management cluster, the Breaking Changes section is required reading: the `clusterctl` and flat-manifest paths are mutually exclusive and cannot be swapped in place. Additional infrastructure providers (Tinkerbell, hyperscalers) are on the roadmap.
 
@@ -50,6 +50,7 @@ Provide node credentials via `userPasswordSecretRef` (recommended) or `sshPublic
 | CAPV | v1.11.x+ |
 | CAPK | KubeVirt v1.9.x / CAPK v0.1.x |
 | CAPM3 | v1.13+; BMO/Ironic v0.13+ |
+| kairos-fleet | v0.1.0-beta.1+ (`cluster-api-provider-kairos-fleet`); AuroraBoot |
 | k0s | ~v1.36.1+k0s |
 | k3s | ~v1.36.1+k3s1 |
 | Kairos | v4.1.2 (standard and Hadron images) |
@@ -71,6 +72,7 @@ Management-cluster support is the full Cluster API v1.13 band (v1.30-v1.36); v1.
 - [CAPV (vSphere)](docs/QUICKSTART_CAPV.md)
 - [CAPK (KubeVirt)](docs/QUICKSTART_CAPK.md)
 - [Metal3 (bare metal)](docs/QUICKSTART_CAPM3.md)
+- [Fleet (AuroraBoot-claimed nodes)](docs/QUICKSTART_FLEET.md)
 
 ## Development
 

--- a/config/rbac/control-plane/role.yaml
+++ b/config/rbac/control-plane/role.yaml
@@ -108,6 +108,7 @@ rules:
   - infrastructure.cluster.x-k8s.io
   resources:
   - dockermachines
+  - kairosfleetmachines
   - kubevirtmachines
   - metal3machines
   - vspheremachines
@@ -119,6 +120,8 @@ rules:
   resources:
   - dockermachines/status
   - dockermachinetemplates
+  - kairosfleetmachines/status
+  - kairosfleetmachinetemplates
   - kubevirtmachines/status
   - kubevirtmachinetemplates
   - metal3machines/status

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -135,6 +135,7 @@ rules:
   - infrastructure.cluster.x-k8s.io
   resources:
   - dockermachines
+  - kairosfleetmachines
   verbs:
   - create
   - get
@@ -143,6 +144,8 @@ rules:
   resources:
   - dockermachines/status
   - dockermachinetemplates
+  - kairosfleetmachines/status
+  - kairosfleetmachinetemplates
   - kubevirtmachines/status
   - kubevirtmachinetemplates
   - metal3machines/status

--- a/config/samples/fleet/kairos_cluster_k0s_single_node.yaml
+++ b/config/samples/fleet/kairos_cluster_k0s_single_node.yaml
@@ -1,0 +1,263 @@
+# ============================================================================
+# Fleet Sample: Single Control-Plane k0s Cluster on Kairos OS
+# (Kairos fleet / AuroraBoot infrastructure provider)
+# ============================================================================
+#
+# NOTE: k0s uses the identical fleet claim/apply/reboot flow as the k3s
+# variant (kairos_cluster_k3s_single_node.yaml); only spec.distribution,
+# spec.version/kubernetesVersion, and the worker join-token field differ. k3s
+# is the reference / most-exercised fleet distribution; k0s fleet support is
+# newer. Prefer k3s if you do not have a specific reason to choose k0s. Read
+# the k3s sample's header comments in full before using this file — all
+# prerequisites and constraints described there apply equally here.
+#
+# PREREQUISITES (all must be satisfied before applying this manifest):
+#
+#   1. Cluster API core v1.13.4+ installed on the management cluster.
+#
+#   2. The Kairos bootstrap and control-plane providers (this repo) and the
+#      Kairos fleet infrastructure provider installed:
+#        clusterctl init --bootstrap kairos --control-plane kairos \
+#          --infrastructure kairos-fleet
+#      See docs/QUICKSTART_FLEET.md and docs/INSTALL.md.
+#
+#   3. An AuroraBoot instance reachable from the management cluster, with:
+#        - an admin bearer token
+#        - at least one enrolled, unclaimed node in the "control-plane" group
+#        - at least one enrolled, unclaimed node in the "workers" group
+#
+#   4. A control-plane endpoint (host:port) that you manage: a kube-vip VIP,
+#      a load balancer, or a DNS name, pointed at the control-plane node once
+#      it is up. This provider does NOT allocate or discover the endpoint
+#      (ADR 0008) — you must know it before the node is claimed.
+#
+#   5. The AuroraBoot admin-token Secret, created OUT OF BAND. Never put the
+#      token in a manifest that gets committed to version control:
+#
+#        kubectl create namespace default    # if it does not already exist
+#        kubectl create secret generic auroraboot-admin-token \
+#          --namespace default \
+#          --from-literal=token="$AURORABOOT_ADMIN_TOKEN"
+#
+#      $AURORABOOT_ADMIN_TOKEN should come from your own secret store or
+#      shell environment, not a hard-coded value.
+#
+# APPLY:
+#   kubectl apply -f config/samples/fleet/kairos_cluster_k0s_single_node.yaml
+#
+# ============================================================================
+#
+# SCOPE: single control plane only (replicas: 1) plus one worker. Fleet HA
+# (KairosControlPlane.spec.replicas: 3 or 5) is mechanically reachable but is
+# NOT exercised on fleet — no fleet HA sample is shipped (ADR 0008, "HA scope
+# (decision)"). See docs/HIGH_AVAILABILITY.md.
+#
+# NO install: block anywhere below. AuroraBoot nodes are already enrolled and
+# installed; the bootstrap cloud-config is staged to the node's existing
+# /oem overlay and applied on reboot, not used to install a new OS.
+#
+# ============================================================================
+
+# IMPORTANT: replace `password:` below with a strong value before applying.
+# `openssl rand -base64 32` generates a suitable value. Inline userPassword
+# in KairosConfig is deprecated; this Secret pattern is the recommended way
+# to provide it. Both KairosConfigTemplates (control plane and worker) below
+# reference this Secret.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kairos-user-password
+  namespace: default
+type: Opaque
+stringData:
+  password: REPLACE_WITH_A_STRONG_PASSWORD
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  name: fleet-demo
+  namespace: default
+spec:
+  # Optional: adjust to match your CNI/service-network configuration. These
+  # are the fleet template's own defaults; omit this block entirely to use
+  # your CNI's defaults instead.
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.128.0.0/12
+  infrastructureRef:
+    apiGroup: infrastructure.cluster.x-k8s.io
+    kind: KairosFleetCluster
+    name: fleet-demo
+  controlPlaneRef:
+    apiGroup: controlplane.cluster.x-k8s.io
+    kind: KairosControlPlane
+    name: fleet-demo-control-plane
+  # Do NOT set spec.controlPlaneEndpoint here. Set it ONLY on
+  # KairosFleetCluster.spec.controlPlaneEndpoint below — CAPI core copies
+  # that value down into this field once KairosFleetCluster reports it.
+  # Setting it in both places risks the two drifting out of sync.
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: KairosFleetCluster
+metadata:
+  name: fleet-demo
+  namespace: default
+spec:
+  # Operator-supplied; the provider does not allocate or discover it. Use a
+  # kube-vip VIP, a load balancer, or a DNS name you manage, pointed at the
+  # control-plane node once it is up. KairosFleetCluster does not report
+  # Provisioned until this is set, and KairosControlPlane stalls with
+  # Available=False(WaitingForInfrastructureControlPlaneEndpoint) until it
+  # does.
+  controlPlaneEndpoint:
+    host: "TODO-CONTROL-PLANE-ENDPOINT-HOST"
+    port: 6443
+  auroraboot:
+    # Base URL of the AuroraBoot fleet API.
+    url: "https://auroraboot.example.com:8080"
+    # References the Secret created in prerequisite step 5 above. Must exist
+    # in this namespace with a non-empty "token" key before this
+    # KairosFleetCluster reconciles successfully.
+    adminTokenSecretRef:
+      name: auroraboot-admin-token
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: KairosControlPlane
+metadata:
+  name: fleet-demo-control-plane
+  namespace: default
+spec:
+  # Single control-plane only. Fleet HA (replicas: 3/5) is unexercised — see
+  # the header comment above and docs/HIGH_AVAILABILITY.md. Do not set
+  # spec.ha.vip here: it is unnecessary for a single control-plane node and
+  # setHAConditions is a no-op at replicas <= 1.
+  replicas: 1
+  version: "v1.34.1+k0s.1"
+  # Explicit is recommended: an explicit value here always wins over the
+  # KairosConfigTemplate's distribution, removing any ambiguity.
+  distribution: k0s
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+      kind: KairosFleetMachineTemplate
+      name: fleet-demo-control-plane
+      namespace: default
+  kairosConfigTemplate:
+    name: fleet-demo-control-plane
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: KairosFleetMachineTemplate
+metadata:
+  name: fleet-demo-control-plane
+  namespace: default
+spec:
+  template:
+    spec:
+      # AuroraBoot group this machine is claimed from. Must have at least one
+      # enrolled, unclaimed node, or the KairosFleetMachine stays
+      # WaitingForCapacity.
+      group: control-plane
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+kind: KairosConfigTemplate
+metadata:
+  name: fleet-demo-control-plane
+  namespace: default
+spec:
+  template:
+    spec:
+      role: control-plane
+      distribution: k0s
+      kubernetesVersion: "v1.34.1+k0s.1"
+      # NO install: block — see the header comment above.
+      userName: kairos
+      # Password comes from the Secret defined at the top of this file.
+      # Alternative: set sshPublicKey: and omit userPasswordSecretRef.
+      userPasswordSecretRef:
+        name: kairos-user-password
+      userGroups:
+        - admin
+      # Optional: add SSH public key for direct node access.
+      # sshPublicKey: "ssh-rsa AAAAB3NzaC1yc2E..."
+      # Optional: import SSH public keys from a GitHub user's profile.
+      # githubUser: "your-github-username"
+---
+# k0s workers join using this token (k0s calls it a worker token). Create it
+# out of band from an existing k0s controller:
+#   k0s token create --role=worker
+# Do not commit a real token to version control.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: fleet-demo-worker-token
+  namespace: default
+type: Opaque
+stringData:
+  token: "REPLACE-WITH-K0S-WORKER-TOKEN"
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachineDeployment
+metadata:
+  name: fleet-demo-md-0
+  namespace: default
+spec:
+  clusterName: fleet-demo
+  replicas: 1
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: fleet-demo
+      cluster.x-k8s.io/deployment-name: fleet-demo-md-0
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: fleet-demo
+        cluster.x-k8s.io/deployment-name: fleet-demo-md-0
+    spec:
+      clusterName: fleet-demo
+      version: "v1.34.1+k0s.1"
+      bootstrap:
+        configRef:
+          apiGroup: bootstrap.cluster.x-k8s.io
+          kind: KairosConfigTemplate
+          name: fleet-demo-md-0
+      infrastructureRef:
+        apiGroup: infrastructure.cluster.x-k8s.io
+        kind: KairosFleetMachineTemplate
+        name: fleet-demo-md-0
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: KairosFleetMachineTemplate
+metadata:
+  name: fleet-demo-md-0
+  namespace: default
+spec:
+  template:
+    spec:
+      # AuroraBoot group worker machines are claimed from. Must have at
+      # least one enrolled, unclaimed node per desired worker replica.
+      group: workers
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+kind: KairosConfigTemplate
+metadata:
+  name: fleet-demo-md-0
+  namespace: default
+spec:
+  template:
+    spec:
+      role: worker
+      distribution: k0s
+      kubernetesVersion: "v1.34.1+k0s.1"
+      # NO install: block — see the header comment above.
+      workerTokenSecretRef:
+        name: fleet-demo-worker-token
+        key: token
+      userName: kairos
+      userPasswordSecretRef:
+        name: kairos-user-password
+      userGroups:
+        - admin

--- a/config/samples/fleet/kairos_cluster_k3s_single_node.yaml
+++ b/config/samples/fleet/kairos_cluster_k3s_single_node.yaml
@@ -1,0 +1,271 @@
+# ============================================================================
+# Fleet Sample: Single Control-Plane k3s Cluster on Kairos OS
+# (Kairos fleet / AuroraBoot infrastructure provider)
+# ============================================================================
+#
+# This manifest provisions one control-plane machine plus a 1-replica worker
+# MachineDeployment on nodes CLAIMED from an already-enrolled AuroraBoot
+# fleet, via the Kairos fleet infrastructure provider
+# (cluster-api-provider-kairos-fleet, clusterctl name `kairos-fleet`). This
+# provider does not create VMs or provision bare metal itself: it claims a
+# node that is already enrolled with AuroraBoot, hands it a bootstrap
+# cloud-config, and reboots it. See ADR 0008 and docs/QUICKSTART_FLEET.md.
+#
+# k3s is the reference / most-exercised fleet distribution. k0s is also
+# supported and newer; see kairos_cluster_k0s_single_node.yaml in this
+# directory for the k0s variant (identical shape; only distribution and
+# version fields differ).
+#
+# PREREQUISITES (all must be satisfied before applying this manifest):
+#
+#   1. Cluster API core v1.13.4+ installed on the management cluster.
+#
+#   2. The Kairos bootstrap and control-plane providers (this repo) and the
+#      Kairos fleet infrastructure provider installed:
+#        clusterctl init --bootstrap kairos --control-plane kairos \
+#          --infrastructure kairos-fleet
+#      See docs/QUICKSTART_FLEET.md and docs/INSTALL.md.
+#
+#   3. An AuroraBoot instance reachable from the management cluster, with:
+#        - an admin bearer token
+#        - at least one enrolled, unclaimed node in the "control-plane" group
+#        - at least one enrolled, unclaimed node in the "workers" group
+#
+#   4. A control-plane endpoint (host:port) that you manage: a kube-vip VIP,
+#      a load balancer, or a DNS name, pointed at the control-plane node once
+#      it is up. This provider does NOT allocate or discover the endpoint
+#      (ADR 0008) — you must know it before the node is claimed, the same
+#      sharp edge as CAPM3's DHCP-reservation requirement.
+#
+#   5. The AuroraBoot admin-token Secret, created OUT OF BAND. Never put the
+#      token in a manifest that gets committed to version control:
+#
+#        kubectl create namespace default    # if it does not already exist
+#        kubectl create secret generic auroraboot-admin-token \
+#          --namespace default \
+#          --from-literal=token="$AURORABOOT_ADMIN_TOKEN"
+#
+#      $AURORABOOT_ADMIN_TOKEN should come from your own secret store or
+#      shell environment, not a hard-coded value.
+#
+# APPLY:
+#   kubectl apply -f config/samples/fleet/kairos_cluster_k3s_single_node.yaml
+#
+# ============================================================================
+#
+# SCOPE: single control plane only (replicas: 1) plus one worker. Fleet HA
+# (KairosControlPlane.spec.replicas: 3 or 5) is mechanically reachable but is
+# NOT exercised on fleet — no fleet HA sample is shipped (ADR 0008, "HA scope
+# (decision)"). See docs/HIGH_AVAILABILITY.md.
+#
+# NO install: block anywhere below. AuroraBoot nodes are already enrolled and
+# installed; the bootstrap cloud-config is staged to the node's existing
+# /oem overlay and applied on reboot, not used to install a new OS. This is
+# the same reasoning as the CAPM3 whole-disk path — do not add an install:
+# block to either KairosConfigTemplate in this file.
+#
+# ============================================================================
+
+# IMPORTANT: replace `password:` below with a strong value before applying.
+# `openssl rand -base64 32` generates a suitable value. Inline userPassword
+# in KairosConfig is deprecated; this Secret pattern is the recommended way
+# to provide it. Both KairosConfigTemplates (control plane and worker) below
+# reference this Secret.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kairos-user-password
+  namespace: default
+type: Opaque
+stringData:
+  password: REPLACE_WITH_A_STRONG_PASSWORD
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  name: fleet-demo
+  namespace: default
+spec:
+  # Optional: adjust to match your CNI/service-network configuration. These
+  # are the fleet template's own defaults; omit this block entirely to use
+  # your CNI's defaults instead.
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    services:
+      cidrBlocks:
+        - 10.128.0.0/12
+  infrastructureRef:
+    apiGroup: infrastructure.cluster.x-k8s.io
+    kind: KairosFleetCluster
+    name: fleet-demo
+  controlPlaneRef:
+    apiGroup: controlplane.cluster.x-k8s.io
+    kind: KairosControlPlane
+    name: fleet-demo-control-plane
+  # Do NOT set spec.controlPlaneEndpoint here. Set it ONLY on
+  # KairosFleetCluster.spec.controlPlaneEndpoint below — CAPI core copies
+  # that value down into this field once KairosFleetCluster reports it.
+  # Setting it in both places risks the two drifting out of sync.
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: KairosFleetCluster
+metadata:
+  name: fleet-demo
+  namespace: default
+spec:
+  # Operator-supplied; the provider does not allocate or discover it. Use a
+  # kube-vip VIP, a load balancer, or a DNS name you manage, pointed at the
+  # control-plane node once it is up. KairosFleetCluster does not report
+  # Provisioned until this is set, and KairosControlPlane stalls with
+  # Available=False(WaitingForInfrastructureControlPlaneEndpoint) until it
+  # does.
+  controlPlaneEndpoint:
+    host: "TODO-CONTROL-PLANE-ENDPOINT-HOST"
+    port: 6443
+  auroraboot:
+    # Base URL of the AuroraBoot fleet API.
+    url: "https://auroraboot.example.com:8080"
+    # References the Secret created in prerequisite step 5 above. Must exist
+    # in this namespace with a non-empty "token" key before this
+    # KairosFleetCluster reconciles successfully.
+    adminTokenSecretRef:
+      name: auroraboot-admin-token
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: KairosControlPlane
+metadata:
+  name: fleet-demo-control-plane
+  namespace: default
+spec:
+  # Single control-plane only. Fleet HA (replicas: 3/5) is unexercised — see
+  # the header comment above and docs/HIGH_AVAILABILITY.md. Do not set
+  # spec.ha.vip here: it is unnecessary for a single control-plane node and
+  # setHAConditions is a no-op at replicas <= 1.
+  replicas: 1
+  version: "v1.34.3+k3s3"
+  # Explicit is recommended: an explicit value here always wins over the
+  # KairosConfigTemplate's distribution, removing any ambiguity.
+  distribution: k3s
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+      kind: KairosFleetMachineTemplate
+      name: fleet-demo-control-plane
+      namespace: default
+  kairosConfigTemplate:
+    name: fleet-demo-control-plane
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: KairosFleetMachineTemplate
+metadata:
+  name: fleet-demo-control-plane
+  namespace: default
+spec:
+  template:
+    spec:
+      # AuroraBoot group this machine is claimed from. Must have at least one
+      # enrolled, unclaimed node, or the KairosFleetMachine stays
+      # WaitingForCapacity.
+      group: control-plane
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+kind: KairosConfigTemplate
+metadata:
+  name: fleet-demo-control-plane
+  namespace: default
+spec:
+  template:
+    spec:
+      role: control-plane
+      distribution: k3s
+      kubernetesVersion: "v1.34.3+k3s3"
+      # NO install: block — see the header comment above.
+      userName: kairos
+      # Password comes from the Secret defined at the top of this file.
+      # Alternative: set sshPublicKey: and omit userPasswordSecretRef.
+      userPasswordSecretRef:
+        name: kairos-user-password
+      userGroups:
+        - admin
+      # Optional: add SSH public key for direct node access.
+      # sshPublicKey: "ssh-rsa AAAAB3NzaC1yc2E..."
+      # Optional: import SSH public keys from a GitHub user's profile.
+      # githubUser: "your-github-username"
+---
+# k3s workers join the control-plane server using this token. Create it out
+# of band (e.g. `k3s token create` on the control-plane node, or reuse the
+# server's node-token from /var/lib/rancher/k3s/server/node-token) — do not
+# commit a real token to version control.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: fleet-demo-k3s-token
+  namespace: default
+type: Opaque
+stringData:
+  token: "REPLACE-WITH-K3S-JOIN-TOKEN"
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachineDeployment
+metadata:
+  name: fleet-demo-md-0
+  namespace: default
+spec:
+  clusterName: fleet-demo
+  replicas: 1
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: fleet-demo
+      cluster.x-k8s.io/deployment-name: fleet-demo-md-0
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: fleet-demo
+        cluster.x-k8s.io/deployment-name: fleet-demo-md-0
+    spec:
+      clusterName: fleet-demo
+      version: "v1.34.3+k3s3"
+      bootstrap:
+        configRef:
+          apiGroup: bootstrap.cluster.x-k8s.io
+          kind: KairosConfigTemplate
+          name: fleet-demo-md-0
+      infrastructureRef:
+        apiGroup: infrastructure.cluster.x-k8s.io
+        kind: KairosFleetMachineTemplate
+        name: fleet-demo-md-0
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: KairosFleetMachineTemplate
+metadata:
+  name: fleet-demo-md-0
+  namespace: default
+spec:
+  template:
+    spec:
+      # AuroraBoot group worker machines are claimed from. Must have at
+      # least one enrolled, unclaimed node per desired worker replica.
+      group: workers
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+kind: KairosConfigTemplate
+metadata:
+  name: fleet-demo-md-0
+  namespace: default
+spec:
+  template:
+    spec:
+      role: worker
+      distribution: k3s
+      kubernetesVersion: "v1.34.3+k3s3"
+      # NO install: block — see the header comment above.
+      k3sTokenSecretRef:
+        name: fleet-demo-k3s-token
+        key: token
+      userName: kairos
+      userPasswordSecretRef:
+        name: kairos-user-password
+      userGroups:
+        - admin

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -406,7 +406,7 @@ Tracked as KD-23 (persistence injection) and KD-34 (in-place upgrade persistence
 
 ## Writing files to nodes
 
-`KairosConfig.spec.files` (and the equivalent field inside `KairosConfigTemplate.spec.template.spec.files`) writes files onto the node's filesystem via the cloud-config `write_files:` list. The files are rendered at bootstrap time on all distributions (k0s, k3s) and all infrastructure providers (CAPV, CAPK, CAPD, CAPM3).
+`KairosConfig.spec.files` (and the equivalent field inside `KairosConfigTemplate.spec.template.spec.files`) writes files onto the node's filesystem via the cloud-config `write_files:` list. The files are rendered at bootstrap time on all distributions (k0s, k3s) and all infrastructure providers (CAPV, CAPK, CAPD, CAPM3, and the Kairos fleet provider).
 
 ### Limits
 
@@ -475,7 +475,7 @@ This is a known limitation of post-boot file writes for network configuration on
 
 - **Kairos CAPI Provider APIs**: `bootstrap.cluster.x-k8s.io/v1beta2` and `controlplane.cluster.x-k8s.io/v1beta2`.
 - **CAPI Core Types**: The wire API version for `Cluster`, `Machine`, and related resources is `v1beta2` (`cluster.x-k8s.io/v1beta2`). `go.mod` imports `sigs.k8s.io/cluster-api v1.13.4` and this provider's controllers use the `ContractVersionedObjectReference` / `MachineNodeReference` value types introduced by that contract. CAPI core v1.13.4+ is required at runtime.
-- **Infrastructure Providers**: Use their respective API versions (e.g., CAPD/CAPV use `infrastructure.cluster.x-k8s.io/v1beta1`, CAPK uses `infrastructure.cluster.x-k8s.io/v1alpha1`).
+- **Infrastructure Providers**: Use their respective API versions (e.g., CAPD/CAPV use `infrastructure.cluster.x-k8s.io/v1beta1`, CAPK and the Kairos fleet provider use `infrastructure.cluster.x-k8s.io/v1alpha1`).
 
 ### Credential Requirements
 

--- a/docs/HIGH_AVAILABILITY.md
+++ b/docs/HIGH_AVAILABILITY.md
@@ -13,6 +13,7 @@ HA control planes need a stable endpoint that survives the loss of any one node.
 
 - **CAPV and CAPM3**: configure a kube-vip virtual IP via `spec.ha.vip`. `Cluster.spec.controlPlaneEndpoint.host` must equal `spec.ha.vip.address` — CAPI core copies the InfraCluster's endpoint into `Cluster.spec.controlPlaneEndpoint`, and every node and kubeconfig targets that value.
 - **CAPK**: do not set `spec.ha.vip`. CAPK provisions its own LoadBalancer Service and reflects its IP into the control-plane endpoint; a kube-vip VIP alongside it would produce a conflicting ARP announcement.
+- **Fleet (Kairos fleet / AuroraBoot)**: the control-plane endpoint is operator-supplied on `KairosFleetCluster.spec.controlPlaneEndpoint` (a kube-vip VIP, load balancer, or DNS name you manage) — the provider allocates and discovers nothing. **HA (`replicas: 3`/`5`) is not yet exercised on fleet: single control-plane only today.** No fleet HA sample is shipped (ADR 0008). See [docs/QUICKSTART_FLEET.md](QUICKSTART_FLEET.md).
 - **CAPD**: dev-only; HA is not exercised.
 
 ```yaml

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,7 +1,12 @@
 # Install Guide
 
 Last verified against: Kairos v3.6.0+, CAPI v1.13.4, cert-manager v1.15+,
-provider v0.1.0-beta.2.
+provider v0.1.0-beta.2. The "Registering the Kairos fleet infrastructure
+provider" section below documents `cluster-api-provider-kairos-fleet`
+v0.1.0-beta.1's own `clusterctl.yaml` entry; it has not been re-verified by
+running `clusterctl init --infrastructure kairos-fleet` in this repository's
+CI — see [docs/QUICKSTART_FLEET.md](QUICKSTART_FLEET.md) for the same
+caveat.
 
 Three install paths: `clusterctl` (recommended), the released flat artifact (`kubectl apply`), and a developer install from source. Path 1 and Path 2 are mutually exclusive on one management cluster: see [Path 1 and Path 2 are mutually exclusive](#path-1-and-path-2-are-mutually-exclusive) below before picking one.
 
@@ -36,16 +41,45 @@ providers:
 
 `clusterctl` discovers `metadata.yaml` next to each components file in the same GitHub release; it does not need its own entry in this file.
 
+### Registering the Kairos fleet infrastructure provider
+
+The Kairos fleet infrastructure provider (`cluster-api-provider-kairos-fleet`,
+clusterctl name `kairos-fleet`) is a separate repository and release series.
+Like the bootstrap and control-plane providers above, it is not yet in the
+upstream `clusterctl` provider list, so add it explicitly:
+
+```yaml
+# ~/.cluster-api/clusterctl.yaml
+providers:
+  - name: "kairos-fleet"
+    url: "https://github.com/kairos-io/cluster-api-provider-kairos-fleet/releases/latest/infrastructure-components.yaml"
+    type: "InfrastructureProvider"
+```
+
+Point `url` at a specific tag instead of `latest` to pin a version, for
+example `.../releases/download/v0.1.0-beta.1/infrastructure-components.yaml`.
+Fleet claims already-enrolled AuroraBoot nodes rather than creating machines
+on demand; see [docs/QUICKSTART_FLEET.md](QUICKSTART_FLEET.md) for the full
+provisioning model and ADR 0008 (maintained in the repository's internal
+decision records) for how it integrates with the bootstrap and control-plane
+providers in this repo.
+
 ### Install
 
 ```bash
 clusterctl init --bootstrap kairos --control-plane kairos
 ```
 
-To also initialize your infrastructure provider in the same call, add `--infrastructure <provider>` (`docker`, `vsphere`, `kubevirt`, `metal3`; see the matching quickstart in [Next steps](#next-steps) for provider-specific setup):
+To also initialize your infrastructure provider in the same call, add `--infrastructure <provider>` (`docker`, `vsphere`, `kubevirt`, `metal3`, `kairos-fleet`; see the matching quickstart in [Next steps](#next-steps) for provider-specific setup):
 
 ```bash
 clusterctl init --bootstrap kairos --control-plane kairos --infrastructure docker
+```
+
+For fleet specifically:
+
+```bash
+clusterctl init --bootstrap kairos --control-plane kairos --infrastructure kairos-fleet
 ```
 
 ### Verify
@@ -186,11 +220,12 @@ Starting with v0.1.0-alpha.2 (carried forward in v0.1.0-beta.1), the controller 
 retrieve the workload kubeconfig. Instead, control-plane nodes POST their
 kubeconfig back to a Secret in the management cluster.
 
-**Workload nodes running on non-CAPK infrastructure (CAPV / CAPM3 / Tinkerbell
-and any future provider) must have network reachability to the management
-cluster's API server URL.** This includes bare-metal nodes provisioned via
-Metal3 — they POST their kubeconfig to a Secret in the management cluster.
-Verify reachability from a sample workload node before deploying:
+**Workload nodes running on non-CAPK infrastructure (CAPV / CAPM3 / Kairos
+fleet / Tinkerbell and any future provider) must have network reachability to
+the management cluster's API server URL.** This includes bare-metal nodes
+provisioned via Metal3 and nodes claimed via the Kairos fleet provider — they
+POST their kubeconfig to a Secret in the management cluster. Verify
+reachability from a sample workload node before deploying:
 
 ```bash
 curl -k https://<mgmt-api-server-host>:6443/api
@@ -210,5 +245,6 @@ for the full configuration steps.
 - [CAPV Quickstart](QUICKSTART_CAPV.md) — create a cluster with vSphere.
 - [CAPK Quickstart](QUICKSTART_CAPK.md) — create a cluster with KubeVirt.
 - [CAPM3 Quickstart](QUICKSTART_CAPM3.md) — create a cluster on bare metal via Metal3.
+- [Fleet Quickstart](QUICKSTART_FLEET.md) — create a cluster from AuroraBoot-claimed nodes with the Kairos fleet infrastructure provider.
 
 For the current release status, breaking changes, and security caveats, read the [v0.1.0-beta.2 release notes](release-notes/v0.1.0-beta.2.md).

--- a/docs/QUICKSTART_FLEET.md
+++ b/docs/QUICKSTART_FLEET.md
@@ -1,0 +1,343 @@
+# Quick Start Guide - Fleet (Kairos fleet / AuroraBoot)
+
+Last verified against: Kairos fleet provider v0.1.0-beta.1
+(`cluster-api-provider-kairos-fleet`), this provider's fleet-support code
+(ADR 0008; unreleased at the time of writing — see the
+[v0.1.0-beta.3 release notes](release-notes/v0.1.0-beta.3.md)), Cluster API
+v1.13.4 (v1beta2 contract), Kairos v4.1.2, k3s. This walkthrough has not been
+run end to end against a live AuroraBoot instance in this repository's CI —
+it is assembled from the fleet provider's own documentation and from reading
+both controllers' source. If a step does not match your observed behavior,
+treat this page as the thing that is wrong and file an issue.
+
+This guide walks you through provisioning a single control-plane machine plus
+one worker on Kairos using Cluster API with the **Kairos fleet** infrastructure
+provider (`cluster-api-provider-kairos-fleet`, clusterctl name `kairos-fleet`).
+Fleet does not create machines on demand: it claims an already-enrolled,
+unclaimed Kairos node from a named AuroraBoot group, hands it a bootstrap
+cloud-config, and reboots it. "No capacity in a group" is an expected,
+transient state — enroll more nodes or free one up — not a failure.
+
+**Scope of this guide:**
+
+- Single control-plane machine (`replicas: 1`) plus a 1-replica worker
+  `MachineDeployment`. This is the only path exercised on fleet. HA
+  (`replicas: 3`/`5`) is mechanically reachable but **not exercised** — no
+  fleet HA sample is shipped (ADR 0008). See
+  [docs/HIGH_AVAILABILITY.md](HIGH_AVAILABILITY.md).
+- k3s is the reference / most-exercised distribution. k0s is also supported
+  and newer; see the k0s sample and the notes below.
+- The control-plane endpoint is **operator-supplied**: fleet does not
+  allocate or discover a VIP, load balancer, or DNS name. You must know the
+  node's reachable endpoint before it is claimed — the same sharp edge as
+  CAPM3's DHCP-reservation requirement.
+
+---
+
+## How fleet provisioning works
+
+Understanding the provisioning model prevents the most common failure modes:
+
+1. You enroll Kairos nodes with AuroraBoot ahead of time, into named groups
+   (for example `control-plane` and `workers`). Enrollment and grouping
+   happen in AuroraBoot, outside Cluster API.
+2. You apply a `Cluster` + `KairosFleetCluster` + `KairosControlPlane` +
+   `KairosFleetMachineTemplate` + `KairosConfigTemplate` set (plus a worker
+   `MachineDeployment` if you want workers).
+3. The `KairosFleetMachine` controller claims one unclaimed node from the
+   target group, using the Machine's UID as a stable claim key so a retried
+   reconcile finds the same node instead of claiming a second one.
+4. It fetches the bootstrap cloud-config that the Kairos bootstrap provider
+   rendered for that Machine and hands it to AuroraBoot as an apply-cloud-config
+   command. AuroraBoot stages the config to the node's `/oem` overlay. There
+   is **no install stage** — the node is already an installed Kairos system.
+5. The controller issues a reboot, then polls until the node comes back
+   `Online` with a heartbeat newer than the reboot request.
+6. Once rejoined, the controller sets `status.addresses`,
+   `spec.providerID = kairos-fleet://<node-id>`, and marks the
+   `KairosFleetMachine` `Provisioned`.
+
+This is a poor fit for on-demand elastic capacity: capacity is whatever is
+enrolled and unclaimed in a group at claim time. It is a good fit for bare
+metal and pre-provisioned edge nodes that phone home to AuroraBoot.
+
+---
+
+## Prerequisites
+
+1. **Management cluster**: a Kubernetes cluster running Cluster API core
+   v1.13.4+ (v1beta2 contract). See the version table in
+   [README.md — Target Versions](../README.md#target-versions).
+
+2. **Three providers installed**: the Kairos bootstrap provider, the Kairos
+   control-plane provider (both from this repo), and the Kairos fleet
+   infrastructure provider (`cluster-api-provider-kairos-fleet`):
+
+   ```bash
+   clusterctl init \
+     --bootstrap kairos \
+     --control-plane kairos \
+     --infrastructure kairos-fleet
+   ```
+
+   `kairos-fleet` is not in clusterctl's built-in provider list; you must
+   register it in `clusterctl.yaml` first. See
+   [INSTALL.md — Registering the Kairos fleet infrastructure provider](INSTALL.md#registering-the-kairos-fleet-infrastructure-provider)
+   for the exact entry and full install procedure.
+
+3. **An AuroraBoot instance** reachable from the management cluster, with:
+   - an admin bearer token,
+   - at least one enrolled, unclaimed node in a control-plane group (this
+     guide uses the default name `control-plane`),
+   - at least one enrolled, unclaimed node in a worker group (this guide uses
+     the default name `workers`).
+
+4. **A control-plane endpoint** (host and port) that the workload cluster's
+   API server will be reachable on. Fleet does not allocate one: use a
+   kube-vip VIP, a load balancer, or a DNS name you manage, pointed at the
+   control-plane node once it comes up.
+
+5. **Network reachability from the claimed nodes to the management cluster's
+   API server.** Like CAPV/CAPM3, fleet nodes POST their kubeconfig back to a
+   Secret in the management cluster rather than being SSHed into. See
+   [INSTALL.md — Network reachability requirement for non-CAPK infrastructure](INSTALL.md#network-reachability-requirement-for-non-capk-infrastructure).
+   For air-gapped nodes, the opt-in `SSHFallback` mechanism on
+   `KairosControlPlane` is the same escape hatch documented for CAPM3 (see
+   [QUICKSTART_CAPM3.md — Air-gapped fallback](QUICKSTART_CAPM3.md#air-gapped-fallback-sshfallback)).
+
+6. **k3s is the reference path.** k0s fleet support is newer; prefer k3s
+   unless you have a specific reason to choose k0s (see
+   [kairos_cluster_k0s_single_node.yaml](../config/samples/fleet/kairos_cluster_k0s_single_node.yaml)).
+
+---
+
+## Creating a cluster
+
+### Step 1: Create the AuroraBoot admin-token Secret
+
+`KairosFleetCluster` references a Secret holding the AuroraBoot admin bearer
+token. Create it in the namespace the cluster will live in, before applying
+the cluster manifest. Do not put the token in a manifest that gets committed
+to version control:
+
+```bash
+kubectl create secret generic auroraboot-admin-token \
+  --namespace default \
+  --from-literal=token="$AURORABOOT_ADMIN_TOKEN"
+```
+
+`$AURORABOOT_ADMIN_TOKEN` should come from your own secret store or shell
+environment.
+
+### Step 2: Create the user-password Secret
+
+```bash
+kubectl create secret generic kairos-user-password \
+  --from-literal=password=$(openssl rand -base64 32)
+```
+
+The sample manifests reference this Secret via `userPasswordSecretRef`. Do
+not set `userPassword` inline.
+
+### Step 3: Choose a sample manifest
+
+- k3s single control-plane + worker (reference path):
+  [`config/samples/fleet/kairos_cluster_k3s_single_node.yaml`](../config/samples/fleet/kairos_cluster_k3s_single_node.yaml)
+- k0s single control-plane + worker:
+  [`config/samples/fleet/kairos_cluster_k0s_single_node.yaml`](../config/samples/fleet/kairos_cluster_k0s_single_node.yaml)
+
+### Step 4: Customize the manifest
+
+Open the chosen sample and fill in every value marked `TODO`.
+
+#### KairosFleetCluster
+
+```yaml
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: KairosFleetCluster
+spec:
+  # Operator-supplied; the provider does not allocate or discover it.
+  controlPlaneEndpoint:
+    host: "TODO-CONTROL-PLANE-ENDPOINT-HOST"
+    port: 6443
+  auroraboot:
+    url: "https://auroraboot.example.com:8080"
+    adminTokenSecretRef:
+      name: auroraboot-admin-token
+```
+
+Set `spec.controlPlaneEndpoint` **only** on `KairosFleetCluster`, never also
+on `Cluster.spec.controlPlaneEndpoint` — CAPI core copies the value down
+automatically once `KairosFleetCluster` reports it. Setting it in both
+places risks the two drifting.
+
+`spec.auroraboot.url` is the base URL of the AuroraBoot fleet API.
+`adminTokenSecretRef.name` must match the Secret created in step 1.
+
+#### KairosFleetMachineTemplate group selection
+
+```yaml
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: KairosFleetMachineTemplate
+spec:
+  template:
+    spec:
+      group: control-plane   # or "workers" for the worker template
+```
+
+`spec.group` names one AuroraBoot group directly; there is no label or
+capability selector. The group must have at least one enrolled, unclaimed
+node when the `KairosFleetMachine` reconciles, or it stays
+`WaitingForCapacity`.
+
+#### KairosControlPlane and KairosConfigTemplate
+
+```yaml
+# In KairosControlPlane:
+spec:
+  replicas: 1
+  version: "v1.34.3+k3s3"
+  distribution: k3s     # explicit value always wins over the template's
+
+# In KairosConfigTemplate:
+spec:
+  template:
+    spec:
+      distribution: k3s
+      kubernetesVersion: "v1.34.3+k3s3"
+      # No install: block — AuroraBoot nodes are already installed.
+```
+
+### Step 5: Apply the manifest
+
+```bash
+kubectl apply -f config/samples/fleet/kairos_cluster_k3s_single_node.yaml
+```
+
+or for k0s:
+
+```bash
+kubectl apply -f config/samples/fleet/kairos_cluster_k0s_single_node.yaml
+```
+
+---
+
+## Watch provisioning
+
+The `KairosFleetMachine`'s `Ready` condition progresses through a sequence
+of reasons as the controller claims and configures each node:
+
+```bash
+kubectl get kairosfleetmachines -n default -w
+```
+
+| Reason | Meaning |
+| --- | --- |
+| `WaitingForBootstrapData` | Waiting for the Kairos bootstrap provider to publish the cloud-config Secret. |
+| `WaitingForClusterInfrastructure` | Waiting for the `KairosFleetCluster`'s AuroraBoot connection to become valid (admin-token Secret present and non-empty). |
+| `WaitingForCapacity` | The target group has no unclaimed nodes. Enroll more nodes in AuroraBoot or free one up. |
+| `NodeClaimed` | A node has been claimed; applying its bootstrap cloud-config next. |
+| `ApplyingCloudConfig` | The cloud-config has been handed to AuroraBoot and is being written to the node, or the controller is waiting for that write to complete. |
+| `Rebooting` | The controller has requested a reboot so the node applies the staged config. |
+| `WaitingForNodeRejoin` | Waiting for the node to come back `Online` with a heartbeat newer than the reboot request. |
+| `Provisioned` | The node is claimed, configured, and `Online`. `spec.providerID` and `status.addresses` are set. |
+
+A machine stuck at `WaitingForCapacity` needs more enrolled nodes in that
+group:
+
+```bash
+kubectl get kairosfleetmachine -n default -o jsonpath='{.items[0].spec.group}'
+```
+
+A machine that reaches `CloudConfigFailed` or `NodeMissing` has failed
+terminally (`status.failureReason` / `status.failureMessage` are set) and
+does not retry itself; inspect the AuroraBoot node's command history and
+delete and re-create the Machine.
+
+Also watch the higher-level objects, the same as any other infrastructure
+provider:
+
+```bash
+kubectl get cluster fleet-demo -w
+kubectl get kairoscontrolplane fleet-demo-control-plane
+kubectl get machines -n default
+```
+
+---
+
+## Retrieve the kubeconfig and confirm the node joined correctly
+
+```bash
+kubectl get secret fleet-demo-kubeconfig \
+  -o jsonpath='{.data.value}' | base64 -d > fleet-demo-kubeconfig.yaml
+kubectl --kubeconfig=fleet-demo-kubeconfig.yaml get nodes
+```
+
+**Node-push behavior:** the control-plane node posts its kubeconfig to a
+Secret in the management cluster at bootstrap time, the same as CAPV/CAPM3.
+If the node has no route to the management cluster's API server, enable
+`SSHFallback` on the `KairosControlPlane` (see Prerequisites above).
+
+### providerID cross-provider contract — verify the match
+
+The pass criterion for a healthy fleet Machine is that the `KairosFleetMachine`
+and the workload `Node` report the **identical** `kairos-fleet://<node-id>`
+value:
+
+```bash
+kubectl get kairosfleetmachine -n default -o jsonpath='{.items[0].spec.providerID}'
+kubectl --kubeconfig=fleet-demo-kubeconfig.yaml get nodes -o jsonpath='{.items[0].spec.providerID}'
+```
+
+Both commands must print the same value. If they do not match, the workload
+`Node` never registers against the right Machine and the Machine stays
+unhealthy. The fleet controller sets `spec.providerID` on the
+`KairosFleetMachine`; the node side of the match is a cross-provider
+contract implemented in this repo's bootstrap cloud-config rendering (see
+`internal/bootstrap/template.go`), which derives the identical
+`kairos-fleet://<node-id>` string from the Kairos phone-home agent's
+persisted credentials and injects it before the kubelet registers. Neither
+provider patches `Node.spec.providerID` directly. If the values disagree,
+confirm the node image runs the Kairos phone-home agent and has already
+phoned home (so the credentials file exists) before k3s/k0s starts, and that
+the `KairosConfigTemplate` distribution matches your Kairos image.
+
+---
+
+## Tear down
+
+```bash
+kubectl delete cluster fleet-demo -n default
+```
+
+Deleting the `Cluster` deletes its Machines, which deletes their
+`KairosFleetMachine`s; each releases its claimed node back to its AuroraBoot
+group. The node is **not wiped** — v0.1 of the fleet provider always
+releases, never resets. The next claim re-applies fresh bootstrap
+configuration onto whatever state the node was left in. A `deletePolicy`
+field to opt into a wipe-on-release reset is a planned follow-up on the
+fleet provider's own roadmap, not something this repo controls.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Action |
+| --- | --- | --- |
+| `KairosFleetMachine` stuck at `WaitingForClusterInfrastructure` | `KairosFleetCluster` cannot resolve its AuroraBoot connection | Check that the admin-token Secret exists in the same namespace with a non-empty `token` key, and that `spec.auroraboot.url` is reachable from the fleet controller pod. |
+| `KairosFleetMachine` stuck at `WaitingForCapacity` | The target group has no unclaimed nodes | Confirm the group name matches an AuroraBoot group with enrolled, unclaimed nodes. |
+| `KairosControlPlane` stuck `Available=False(WaitingForInfrastructureControlPlaneEndpoint)` | `KairosFleetCluster.spec.controlPlaneEndpoint.host` is unset or empty | Fleet does not allocate an endpoint; set it explicitly (Step 4 above). |
+| Node comes back after reboot but the machine never leaves `WaitingForNodeRejoin` | The controller requires the node's heartbeat to be newer than the recorded reboot time | Check that the AuroraBoot node's `lastHeartbeat` is advancing; a node that never phones home after reboot (agent not running, network unreachable) never satisfies the gate. |
+| Workload `Node` has no `providerID`, or it does not match `kairos-fleet://...` | The bootstrap cloud-config's fleet providerID self-discovery path did not run, or ran against the wrong distribution | Confirm the `KairosConfigTemplate` distribution matches your Kairos image, and that the node image runs the Kairos phone-home agent with persisted credentials (see "providerID cross-provider contract" above). |
+| `KubeconfigReadyCondition` stays `False(WaitingForNodePush)` | No network route from the node to the management cluster API server | Run `curl -k https://<mgmt-api-server-host>:6443/api` from the node; if it fails, open the network path or enable `SSHFallback`. |
+
+---
+
+## Next Steps
+
+- Fleet HA control planes are not yet supported end to end — see
+  [docs/HIGH_AVAILABILITY.md](HIGH_AVAILABILITY.md) for the current status.
+- Add custom Kubernetes manifests via `spec.template.spec.manifests` in
+  `KairosConfigTemplate`.
+- Scale the worker `MachineDeployment` by editing `spec.replicas`, provided
+  enough capacity is enrolled and unclaimed in the target AuroraBoot group.

--- a/docs/release-notes/v0.1.0-beta.3.md
+++ b/docs/release-notes/v0.1.0-beta.3.md
@@ -1,0 +1,162 @@
+# v0.1.0-beta.3 — Release Notes
+
+This is a pre-1.0 release. The API surface may still change before v1.0.
+
+Read the [upgrade guide](https://github.com/kairos-io/cluster-api-provider-kairos/blob/v0.1.0-beta.3/docs/UPGRADING.md)
+before installing. This release has no breaking changes and no required
+migration steps from v0.1.0-beta.2.
+
+---
+
+## Highlights
+
+- **Fleet infrastructure provider support (ADR 0008).** The Kairos fleet
+  infrastructure provider (`cluster-api-provider-kairos-fleet`, clusterctl
+  name `kairos-fleet`) is now a documented, sampled, first-class
+  infrastructure provider — a peer to CAPD, CAPV, CAPK, and CAPM3. Fleet
+  claims already-enrolled Kairos nodes from an AuroraBoot group rather than
+  creating machines on demand. New: `docs/QUICKSTART_FLEET.md`, k3s and k0s
+  single-control-plane samples under `config/samples/fleet/`, and
+  `clusterctl.yaml` registration guidance in `docs/INSTALL.md`.
+- **No API, CRD, or `go.mod` change.** Fleet support required no new fields,
+  no CRD storage-version bump, and no build-time dependency on the fleet
+  provider's Go types — the bootstrap provider already routed fleet-backed
+  Machines through the generic non-KubeVirt cloud-config templates (shipped
+  before this release), and the control-plane provider resolves fleet's
+  `KairosFleetCluster` / `KairosFleetMachine` through the same
+  contract-versioned unstructured path used for every other infrastructure
+  provider.
+
+---
+
+## Breaking Changes
+
+None in this release.
+
+---
+
+## New Features
+
+- **`KairosFleetMachine` recognized as a supported infrastructure kind
+  end to end.** The control-plane provider's `getNodeIP` extractor gained a
+  `KairosFleetMachine` case (returns `("", nil)` — no routable IP, not an
+  error, matching fleet's hostname-only address reality) so the extractor's
+  self-declared supported-provider list matches reality and can never
+  mislabel fleet "unsupported."
+- **Actionable endpoint-wait guidance for fleet operators.** The
+  `WaitingForInfrastructureControlPlaneEndpoint` condition message now names
+  `KairosFleetCluster.spec.controlPlaneEndpoint` alongside the existing
+  CAPV/CAPK/CAPD guidance, so a stalled fleet cluster tells the operator
+  which field to set.
+- **RBAC parity for fleet.** The control-plane provider's role gains
+  `create;get` on `kairosfleetmachines`, `get` on their `status`
+  subresource, and `get` on `kairosfleetmachinetemplates` — the same access
+  pattern already granted for `dockermachines`, `kubevirtmachines`,
+  `vspheremachines`, and `metal3machines`. The bootstrap provider needs no
+  new grant: it neither Gets nor Watches `KairosFleetMachine` objects.
+- **Fleet samples and quickstart.** k3s (reference path) and k0s
+  single-control-plane-plus-worker samples under `config/samples/fleet/`,
+  and a full walkthrough at `docs/QUICKSTART_FLEET.md` covering
+  prerequisites, the `KairosFleetMachine` `Ready`-reason state progression,
+  kubeconfig retrieval, the `kairos-fleet://<node-id>` providerID
+  cross-provider verification, and teardown.
+
+---
+
+## Bug Fixes
+
+None in this release.
+
+---
+
+## Known Limitations
+
+### Fleet HA is unexercised (single control plane only)
+
+Fleet's exercised path is a single control-plane machine plus a worker
+`MachineDeployment`. HA (`KairosControlPlane.spec.replicas: 3` or `5`) is
+mechanically reachable — fleet is not gated out of the HA code paths — but it
+has not been validated: no VIP-claimed-from-fleet-nodes or
+etcd-peering-across-claimed-nodes testing has been done, and shipping an HA
+sample would imply an untested guarantee. No fleet HA sample is shipped. See
+ADR 0008 ("HA scope (decision)").
+
+### The fleet + bootstrap + control-plane integration is not yet covered by
+an automated three-provider end-to-end test
+
+This release adds fleet as a documented, sampled infrastructure provider
+based on code-path analysis (the bootstrap and control-plane providers
+already handled fleet-backed Machines generically) and on the fleet
+provider's own documentation, not on a green three-provider e2e run in this
+repository's CI. The fleet provider's own `test-e2e` job is also not yet
+wired to a real AuroraBoot instance (manual-dispatch scaffold only). An
+integrated e2e exercising bootstrap + control-plane + fleet together is the
+standing proof required before promoting either provider past beta — see
+ADR 0008 ("Version / contract alignment (decision)").
+
+### Carried forward from v0.1.0-beta.2
+
+- No cosign signing or SBOM yet on release artifacts (image-digest-pinned
+  only).
+- k3s HA day-2: control-plane replacement orphans an etcd member (KD-5d).
+  k0s remains the fully-supported HA distribution. See
+  [v0.1.0-beta.2 — Known Limitations](v0.1.0-beta.2.md#known-limitations).
+
+---
+
+## Security
+
+- **No new RBAC surface beyond the enumerated fleet infra-kind grants.**
+  The control-plane role's added verbs are scoped to `kairosfleetmachines`
+  (`create`, `get`), `kairosfleetmachines/status` (`get`), and
+  `kairosfleetmachinetemplates` (`get`) — the same shape already granted for
+  every other infrastructure provider's machine/template kinds. No
+  cluster-wide or wildcard grant was added.
+- **The `kairos-fleet://<node-id>` providerID contract is a cross-repository
+  string match with no compile-time link.** A change on either side (this
+  repo's bootstrap cloud-config rendering, or the fleet provider's
+  `KairosFleetMachine` controller) can silently break node-to-Machine
+  matching. It is guarded today only by doc comments cross-referencing each
+  other and by unit tests on each side (`internal/bootstrap/fleet_providerid_test.go`
+  in this repo); the integrated e2e (see Known Limitations) is the intended
+  long-term guard.
+- **AuroraBoot admin-token handling is out of this repo's scope.** The
+  admin-token Secret referenced by `KairosFleetCluster.spec.auroraboot.adminTokenSecretRef`
+  is read and stored by the fleet provider, not this repo's controllers.
+  This repo's samples and quickstart instruct creating that Secret out of
+  band and never committing a real token, consistent with this repo's own
+  credential-handling guidance.
+
+---
+
+## Compatibility
+
+See [README — Target Versions](https://github.com/kairos-io/cluster-api-provider-kairos/blob/v0.1.0-beta.3/README.md#target-versions)
+for the current matrix. No CAPI core, Kubernetes, controller-runtime, or
+`k8s.io/*` version change since v0.1.0-beta.2 — this release is docs,
+samples, and a small control-plane-provider honesty/UX change, not a
+toolchain bump.
+
+| Component | v0.1.0-beta.2 | v0.1.0-beta.3 |
+| --- | --- | --- |
+| Cluster API core | v1.13.4 (v1beta2 contract) | v1.13.4 (unchanged) |
+| Kubernetes (management) | v1.30-v1.36 (v1.36 recommended) | v1.30-v1.36 (unchanged) |
+| Kubernetes (workload) | v1.30-v1.36 | v1.30-v1.36 (unchanged) |
+| Kairos | v4.1.2 | v4.1.2 (unchanged) |
+| controller-runtime | v0.23.3 | v0.23.3 (unchanged) |
+| k8s.io/* | v0.35.4 | v0.35.4 (unchanged) |
+| kairos-fleet (`cluster-api-provider-kairos-fleet`) | not supported | v0.1.0-beta.1+ (new) |
+
+The fleet provider is a separate release series maintained in its own
+repository; this repo takes no build-time dependency on it and does not pin
+its version beyond "v0.1.0-beta.1+, same CAPI v1.13.4 / v1beta2 contract."
+
+---
+
+## Upgrade Notes
+
+No action required for existing installs (flat manifest or `clusterctl`).
+Fleet support is additive: install the `kairos-fleet` infrastructure
+provider only if you intend to use it (see
+[docs/INSTALL.md — Registering the Kairos fleet infrastructure provider](https://github.com/kairos-io/cluster-api-provider-kairos/blob/v0.1.0-beta.3/docs/INSTALL.md#registering-the-kairos-fleet-infrastructure-provider)).
+Clusters already running on CAPD, CAPV, CAPK, or CAPM3 are unaffected.

--- a/docs/release-notes/v0.1.0-beta.3.md
+++ b/docs/release-notes/v0.1.0-beta.3.md
@@ -60,6 +60,18 @@ None in this release.
   prerequisites, the `KairosFleetMachine` `Ready`-reason state progression,
   kubeconfig retrieval, the `kairos-fleet://<node-id>` providerID
   cross-provider verification, and teardown.
+- **The control-plane provider clones `KairosFleetMachineTemplate`.** The
+  infra-machine cloner switched on the template kind and rejected
+  `KairosFleetMachineTemplate` as "unsupported infrastructure provider", so a
+  fleet-backed `KairosControlPlane` never produced its `KairosFleetMachine`.
+  It now clones fleet templates with the same verbatim-spec pattern as
+  CAPV/CAPD/CAPM3.
+- **Fleet control planes publish their kubeconfig (node-push).** The
+  in-node kubeconfig-push gate (`supportsManagementEndpoint`) now includes
+  `KairosFleetMachine` alongside CAPK/CAPV/CAPM3, so a fleet control-plane
+  node publishes its workload kubeconfig back to the management cluster and
+  the `KairosControlPlane` reaches `Initialized`. Fleet-claimed nodes are
+  bare-metal-like (routable IPs), the same rationale as CAPM3.
 
 ---
 
@@ -81,18 +93,31 @@ etcd-peering-across-claimed-nodes testing has been done, and shipping an HA
 sample would imply an untested guarantee. No fleet HA sample is shipped. See
 ADR 0008 ("HA scope (decision)").
 
-### The fleet + bootstrap + control-plane integration is not yet covered by
-an automated three-provider end-to-end test
+### The integrated three-provider path is validated manually, not yet in CI
 
-This release adds fleet as a documented, sampled infrastructure provider
-based on code-path analysis (the bootstrap and control-plane providers
-already handled fleet-backed Machines generically) and on the fleet
-provider's own documentation, not on a green three-provider e2e run in this
-repository's CI. The fleet provider's own `test-e2e` job is also not yet
-wired to a real AuroraBoot instance (manual-dispatch scaffold only). An
-integrated e2e exercising bootstrap + control-plane + fleet together is the
-standing proof required before promoting either provider past beta — see
-ADR 0008 ("Version / contract alignment (decision)").
+The bootstrap + control-plane + fleet path was validated by a manual
+end-to-end run on real hardware: all three providers installed together via
+`clusterctl`, an AuroraBoot-enrolled Kairos Hadron node (v4.1.2 / k3s
+v1.36.1) claimed from a group, configured, rebooted, and rejoined, the
+`KairosControlPlane` reaching `Initialized`, and the workload Node's
+`kairos-fleet://<node-id>` providerID matching the `KairosFleetMachine`. That
+run is what surfaced the clone and node-push fixes above. An **automated**
+three-provider e2e in this repository's CI is still pending and remains the
+standing guard required before promoting either provider past beta (the fleet
+provider's own `test-e2e` job is a manual-dispatch scaffold, not wired to a
+real AuroraBoot instance). See ADR 0008.
+
+### Requires a fixed fleet provider release
+
+The integration requires the fleet provider release that carries three fixes
+found during the validation above (all in `cluster-api-provider-kairos-fleet`,
+not this repo): the manager registered the Cluster API core scheme (the
+released v0.1.0-beta.1 controller crash-loops on a real cluster without it),
+the generated metrics Service name was shortened under the 63-character limit
+so `clusterctl init` can apply it, and the provider resolves
+`KairosFleetMachine.spec.group` by name before claiming (AuroraBoot's claim
+endpoint keys on the group ID). Use the fleet release that includes these
+(v0.1.0-beta.2 or later), not v0.1.0-beta.1.
 
 ### Carried forward from v0.1.0-beta.2
 
@@ -145,11 +170,14 @@ toolchain bump.
 | Kairos | v4.1.2 | v4.1.2 (unchanged) |
 | controller-runtime | v0.23.3 | v0.23.3 (unchanged) |
 | k8s.io/* | v0.35.4 | v0.35.4 (unchanged) |
-| kairos-fleet (`cluster-api-provider-kairos-fleet`) | not supported | v0.1.0-beta.1+ (new) |
+| kairos-fleet (`cluster-api-provider-kairos-fleet`) | not supported | v0.1.0-beta.2+ (new) |
 
 The fleet provider is a separate release series maintained in its own
 repository; this repo takes no build-time dependency on it and does not pin
-its version beyond "v0.1.0-beta.1+, same CAPI v1.13.4 / v1beta2 contract."
+its version. Use **v0.1.0-beta.2 or later** (same CAPI v1.13.4 / v1beta2
+contract): the earlier v0.1.0-beta.1 controller crash-loops on a real
+management cluster and is not clusterctl-installable — see
+[Requires a fixed fleet provider release](#requires-a-fixed-fleet-provider-release).
 
 ---
 

--- a/internal/controllers/bootstrap/kairosconfig_controller.go
+++ b/internal/controllers/bootstrap/kairosconfig_controller.go
@@ -666,9 +666,14 @@ func isKubevirtMachine(machine *clusterv1.Machine) bool {
 // supportsManagementEndpoint returns true for infrastructure kinds whose
 // control-plane Machines run the in-node kubeconfig-push block (KD-3b).
 //
-// Today: KubeVirt (CAPK), vSphere (CAPV), and Metal3 (CAPM3). Bare-metal
-// nodes have real routable IPs and real management-cluster reachability,
-// making the node-push pattern a natural fit for CAPM3.
+// Today: KubeVirt (CAPK), vSphere (CAPV), Metal3 (CAPM3), and the Kairos fleet
+// provider (KairosFleetMachine). Bare-metal and fleet-claimed nodes have real
+// routable IPs and real management-cluster reachability, making the node-push
+// pattern a natural fit — the management cluster cannot always dial the workload
+// API server directly, so the node pushes its kubeconfig back instead. Fleet is
+// treated like CAPM3 here (ADR 0008); without this, a fleet control-plane node
+// never publishes its kubeconfig and the KairosControlPlane never reaches
+// Initialized.
 //
 // KD-46 (post-alpha-2): the resolver's RBAC currently grants
 // `kubevirt.io/virtualmachineinstances:get` on every cluster that uses this
@@ -681,7 +686,7 @@ func supportsManagementEndpoint(machine *clusterv1.Machine) bool {
 		return false
 	}
 	switch machine.Spec.InfrastructureRef.Kind {
-	case "KubevirtMachine", "KubeVirtMachine", "VSphereMachine", "Metal3Machine":
+	case "KubevirtMachine", "KubeVirtMachine", "VSphereMachine", "Metal3Machine", "KairosFleetMachine":
 		return true
 	}
 	return false

--- a/internal/controllers/bootstrap/kairosconfig_controller_test.go
+++ b/internal/controllers/bootstrap/kairosconfig_controller_test.go
@@ -1262,6 +1262,7 @@ func TestSupportsManagementEndpoint(t *testing.T) {
 		{name: "KubevirtMachine (CAPK lowercase v)", machine: mkMachine("KubevirtMachine"), want: true},
 		{name: "KubeVirtMachine (CAPK uppercase V)", machine: mkMachine("KubeVirtMachine"), want: true},
 		{name: "VSphereMachine (CAPV)", machine: mkMachine("VSphereMachine"), want: true},
+		{name: "KairosFleetMachine (fleet)", machine: mkMachine("KairosFleetMachine"), want: true},
 		{name: "DockerMachine (unsupported today)", machine: mkMachine("DockerMachine"), want: false},
 		{name: "AWSMachine (unsupported today)", machine: mkMachine("AWSMachine"), want: false},
 	}

--- a/internal/controllers/controlplane/infra_lookup.go
+++ b/internal/controllers/controlplane/infra_lookup.go
@@ -44,7 +44,7 @@ import (
 
 // getNodeIP retrieves the node IP from the infrastructure provider.
 // Supports CAPD (DockerMachine), CAPV (VSphereMachine/VSphereVM), CAPK (KubevirtMachine),
-// and CAPM3 (Metal3Machine).
+// CAPM3 (Metal3Machine), and the Kairos fleet provider (KairosFleetMachine).
 func (r *KairosControlPlaneReconciler) getNodeIP(ctx context.Context, log logr.Logger, machine *clusterv1.Machine) (string, error) {
 	switch machine.Spec.InfrastructureRef.Kind {
 	case "VSphereMachine":
@@ -116,6 +116,17 @@ func (r *KairosControlPlaneReconciler) getNodeIP(ctx context.Context, log logr.L
 			return ip, nil
 		}
 		return "", fmt.Errorf("no IP address found in Metal3Machine status")
+	case "KairosFleetMachine":
+		// The Kairos fleet provider (cluster-api-provider-kairos-fleet) reports
+		// KairosFleetMachine.status.addresses as a Hostname only (no InternalIP in
+		// v0.1), and a fleet node self-discovers its providerID on-node rather than
+		// depending on an IP resolved here. There is thus no routable IP to return.
+		// Report "no IP" WITHOUT an error: the only consumer is the opt-in,
+		// non-fatal SSH-fallback path, which treats an empty address as "nothing to
+		// dial" rather than a failure. Returning a non-error empty string also keeps
+		// the switch from ever calling a supported provider "unsupported" if this
+		// helper is rewired. See ADR 0008.
+		return "", nil
 	default:
 		return "", fmt.Errorf("unsupported infrastructure provider: %s", machine.Spec.InfrastructureRef.Kind)
 	}

--- a/internal/controllers/controlplane/infra_lookup_test.go
+++ b/internal/controllers/controlplane/infra_lookup_test.go
@@ -163,3 +163,41 @@ func TestGetNodeIP_Metal3Machine(t *testing.T) {
 		})
 	}
 }
+
+// TestGetNodeIP_KairosFleetMachine pins the fleet contract: a KairosFleetMachine
+// resolves to no routable IP but is NOT an error (ADR 0008). Fleet reports a
+// Hostname-only address and self-discovers its providerID on-node, so getNodeIP
+// returns ("", nil) — the opt-in SSH-fallback consumer treats an empty address as
+// "nothing to dial", never a failure, and the switch must not fall through to the
+// "unsupported infrastructure provider" default for a provider we support.
+func TestGetNodeIP_KairosFleetMachine(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = bootstrapv1beta2.AddToScheme(scheme)
+	_ = controlplanev1beta2.AddToScheme(scheme)
+
+	machine := &clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-machine", Namespace: "default"},
+		Spec: clusterv1.MachineSpec{
+			InfrastructureRef: clusterv1.ContractVersionedObjectReference{
+				APIGroup: "infrastructure.cluster.x-k8s.io",
+				Kind:     "KairosFleetMachine",
+				Name:     "test-kfm",
+			},
+		},
+	}
+
+	// No infra object or CRD seeded: the fleet case returns before any Get, so a
+	// bare fake client is sufficient and proves the case does not depend on one.
+	r := &KairosControlPlaneReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+		Scheme: scheme,
+	}
+
+	ip, err := r.getNodeIP(context.Background(), log.Log, machine)
+	if err != nil {
+		t.Fatalf("getNodeIP(KairosFleetMachine) unexpected error: %v", err)
+	}
+	if ip != "" {
+		t.Errorf("getNodeIP(KairosFleetMachine) = %q, want empty", ip)
+	}
+}

--- a/internal/controllers/controlplane/kairoscontrolplane_controller.go
+++ b/internal/controllers/controlplane/kairoscontrolplane_controller.go
@@ -113,12 +113,15 @@ const kubeconfigReadyTimeout = controlplanev1beta2.KubeconfigReadyTimeout
 // (they cascade via the CAPI Machine's OwnerReferences — KD-11), and never
 // list/watch them (the control-plane manager registers no infra-kind watch; the
 // bootstrap controller owns the infra Watches via its own list/watch grant).
-// metal3machines/-templates added for CAPM3 (ADR 0004). Metal3Cluster and
-// BareMetalHost are deliberately absent: we never read them (CAPI core copies
-// the endpoint per KD-12; CAPM3 mediates BMH).
-//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=vspheremachines;kubevirtmachines;dockermachines;metal3machines,verbs=create;get
-//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=vspheremachines/status;kubevirtmachines/status;dockermachines/status;metal3machines/status,verbs=get
-//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=vspheremachinetemplates;kubevirtmachinetemplates;dockermachinetemplates;metal3machinetemplates,verbs=get
+// metal3machines/-templates added for CAPM3 (ADR 0004). kairosfleetmachines/-templates
+// added for the Kairos fleet provider (ADR 0008): the control-plane provider clones
+// the KairosFleetMachineTemplate and creates the per-Machine KairosFleetMachine, same
+// create;get access as the other infra kinds. Metal3Cluster, KairosFleetCluster, and
+// BareMetalHost are deliberately absent: we never read them (CAPI core copies the
+// endpoint per KD-12; CAPM3 mediates BMH; the fleet provider owns its own Cluster).
+//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=vspheremachines;kubevirtmachines;dockermachines;metal3machines;kairosfleetmachines,verbs=create;get
+//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=vspheremachines/status;kubevirtmachines/status;dockermachines/status;metal3machines/status;kairosfleetmachines/status,verbs=get
+//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=vspheremachinetemplates;kubevirtmachinetemplates;dockermachinetemplates;metal3machinetemplates;kairosfleetmachinetemplates,verbs=get
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=vspherevms,verbs=get
 // customresourcedefinitions (contract-versioned ref resolution, ADR 0006) and
 // events both live in internal/controllers/shared — both managers need them.
@@ -412,6 +415,7 @@ func (r *KairosControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.R
 		const endpointMsg = "Waiting for the infrastructure provider to populate Cluster.Spec.ControlPlaneEndpoint. " +
 			"Set VSphereCluster.spec.controlPlaneEndpoint (CAPV), " +
 			"KubevirtCluster.spec.controlPlaneServiceTemplate (CAPK), " +
+			"KairosFleetCluster.spec.controlPlaneEndpoint (Kairos fleet), " +
 			"or Cluster.spec.controlPlaneEndpoint (CAPD / direct) per the provider's contract."
 		conditions.MarkFalse(kcp, clusterv1.ReadyCondition, controlplanev1beta2.WaitingForInfrastructureControlPlaneEndpointReason, clusterv1.ConditionSeverityInfo, "%s", endpointMsg)
 		conditions.MarkFalse(kcp, controlplanev1beta2.AvailableCondition, controlplanev1beta2.WaitingForInfrastructureControlPlaneEndpointReason, clusterv1.ConditionSeverityInfo, "%s", endpointMsg)

--- a/internal/infrastructure/clone.go
+++ b/internal/infrastructure/clone.go
@@ -61,6 +61,8 @@ func CloneInfrastructureMachine(ctx context.Context, c client.Client, scheme *ru
 		return cloneKubevirtMachineTemplate(ctx, c, scheme, templateObj, machineName, namespace, labels, annotations)
 	case "Metal3MachineTemplate":
 		return cloneMetal3MachineTemplate(ctx, c, scheme, templateObj, machineName, namespace, labels, annotations)
+	case "KairosFleetMachineTemplate":
+		return cloneKairosFleetMachineTemplate(ctx, c, scheme, templateObj, machineName, namespace, labels, annotations)
 	default:
 		return nil, fmt.Errorf("unsupported infrastructure provider: %s (Group: %s, Version: %s, FullGVK: %s)",
 			kind,
@@ -170,6 +172,39 @@ func cloneMetal3MachineTemplate(ctx context.Context, c client.Client, scheme *ru
 	}
 
 	return metal3Machine, nil
+}
+
+func cloneKairosFleetMachineTemplate(ctx context.Context, c client.Client, scheme *runtime.Scheme, template *unstructured.Unstructured, machineName, namespace string, labels, annotations map[string]string) (client.Object, error) {
+	// For the Kairos fleet provider (cluster-api-provider-kairos-fleet), create a
+	// KairosFleetMachine from a KairosFleetMachineTemplate. KairosFleetMachine.spec
+	// is a verbatim copy of spec.template.spec (the AuroraBoot `group` to claim
+	// from) — the same pattern as CAPV/CAPD/CAPM3. Derive the API version from the
+	// template ref, defaulting to v1alpha1 (the fleet provider's storage version).
+	// See ADR 0008.
+	fleetMachine := &unstructured.Unstructured{}
+	version := template.GroupVersionKind().Version
+	if version == "" {
+		version = "v1alpha1"
+	}
+	fleetMachine.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "infrastructure.cluster.x-k8s.io",
+		Version: version,
+		Kind:    "KairosFleetMachine",
+	})
+
+	fleetMachine.SetName(machineName)
+	fleetMachine.SetNamespace(namespace)
+	fleetMachine.SetLabels(labels)
+	fleetMachine.SetAnnotations(annotations)
+
+	// Copy spec from template
+	if spec, ok, _ := unstructured.NestedMap(template.UnstructuredContent(), "spec", "template", "spec"); ok {
+		if err := unstructured.SetNestedMap(fleetMachine.UnstructuredContent(), spec, "spec"); err != nil {
+			return nil, fmt.Errorf("failed to set spec: %w", err)
+		}
+	}
+
+	return fleetMachine, nil
 }
 
 func cloneKubevirtMachineTemplate(ctx context.Context, c client.Client, scheme *runtime.Scheme, template *unstructured.Unstructured, machineName, namespace string, labels, annotations map[string]string) (client.Object, error) {

--- a/internal/infrastructure/clone_test.go
+++ b/internal/infrastructure/clone_test.go
@@ -129,3 +129,93 @@ func TestCloneMetal3MachineTemplate(t *testing.T) {
 		})
 	}
 }
+
+func makeKairosFleetMachineTemplate(version string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "infrastructure.cluster.x-k8s.io",
+		Version: version,
+		Kind:    "KairosFleetMachineTemplate",
+	})
+	obj.SetName("tmpl")
+	obj.SetNamespace("default")
+	_ = unstructured.SetNestedMap(obj.Object, map[string]interface{}{
+		"template": map[string]interface{}{
+			"spec": map[string]interface{}{
+				"group": "control-plane",
+			},
+		},
+	}, "spec")
+	return obj
+}
+
+func TestCloneKairosFleetMachineTemplate(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	labels := map[string]string{"cluster.x-k8s.io/cluster-name": "test-cluster"}
+	annotations := map[string]string{"test-key": "test-value"}
+
+	tests := []struct {
+		name            string
+		templateVersion string
+		wantVersion     string
+	}{
+		{
+			name:            "v1alpha1 template preserves version",
+			templateVersion: "v1alpha1",
+			wantVersion:     "v1alpha1",
+		},
+		{
+			name:            "versionless template defaults to v1alpha1",
+			templateVersion: "",
+			wantVersion:     "v1alpha1",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			template := makeKairosFleetMachineTemplate(tc.templateVersion)
+
+			// cloneKairosFleetMachineTemplate does not call the API server; it only
+			// reads the in-memory template object.
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+			got, err := cloneKairosFleetMachineTemplate(ctx, fakeClient, scheme, template, "test-machine", "default", labels, annotations)
+			if err != nil {
+				t.Fatalf("cloneKairosFleetMachineTemplate() error = %v", err)
+			}
+
+			u, ok := got.(*unstructured.Unstructured)
+			if !ok {
+				t.Fatalf("expected *unstructured.Unstructured, got %T", got)
+			}
+
+			gvk := u.GroupVersionKind()
+			if gvk.Group != "infrastructure.cluster.x-k8s.io" {
+				t.Errorf("Group = %q, want %q", gvk.Group, "infrastructure.cluster.x-k8s.io")
+			}
+			if gvk.Version != tc.wantVersion {
+				t.Errorf("Version = %q, want %q", gvk.Version, tc.wantVersion)
+			}
+			if gvk.Kind != "KairosFleetMachine" {
+				t.Errorf("Kind = %q, want %q", gvk.Kind, "KairosFleetMachine")
+			}
+
+			if u.GetName() != "test-machine" {
+				t.Errorf("Name = %q, want %q", u.GetName(), "test-machine")
+			}
+			if u.GetLabels()["cluster.x-k8s.io/cluster-name"] != "test-cluster" {
+				t.Errorf("Labels missing cluster name label")
+			}
+			if u.GetAnnotations()["test-key"] != "test-value" {
+				t.Errorf("Annotations missing test-key")
+			}
+
+			// spec.group was copied verbatim from spec.template.spec.group
+			group, _, _ := unstructured.NestedString(u.Object, "spec", "group")
+			if group != "control-plane" {
+				t.Errorf("spec.group = %q, want %q", group, "control-plane")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Makes the **Kairos fleet infrastructure provider** (`cluster-api-provider-kairos-fleet`, clusterctl name `kairos-fleet`) a first-class infrastructure provider of the Kairos bootstrap and control-plane providers — a peer to CAPD/CAPV/CAPK/CAPM3. Fleet claims already-enrolled Kairos nodes from an AuroraBoot group rather than creating machines on demand.

No API, CRD, or `go.mod` change: the bootstrap provider already routed fleet-backed Machines through the generic non-KubeVirt cloud-config templates, and the control-plane provider resolves fleet's CRDs through the same contract-versioned path used for every other infra provider. Design recorded in ADR 0008.

## Changes

- **`feat(controlplane): support KairosFleet as an infrastructure provider`** — recognize `KairosFleetMachine` in `getNodeIP` (returns `("", nil)`, matching fleet's hostname-only addresses), name `KairosFleetCluster.spec.controlPlaneEndpoint` in the endpoint-wait guidance, and grant the control-plane role `create;get` on `kairosfleetmachines` + `get` on their status/templates (same shape as the other infra kinds). Bootstrap needs no grant.
- **`docs(samples)`** — k3s (reference) and k0s single-control-plane fleet samples under `config/samples/fleet/`.
- **`docs`** — `docs/QUICKSTART_FLEET.md`, README infra matrix, HA doc, `docs/INSTALL.md` clusterctl registration.
- **`feat(controlplane): clone KairosFleetMachineTemplate into KairosFleetMachine`** — the infra-machine cloner rejected the fleet template kind, so a fleet `KairosControlPlane` never produced its InfraMachine. Adds the fleet clone case.
- **`feat(bootstrap): enable the kubeconfig node-push for fleet control planes`** — `supportsManagementEndpoint` now includes `KairosFleetMachine`, so a fleet control-plane node publishes its kubeconfig back and the `KairosControlPlane` reaches `Initialized`.
- **`docs(release-notes)`** — beta.3 notes.

## Validation

Validated by a **real integrated three-provider e2e** (not just static analysis): all three providers installed together via `clusterctl init`, an AuroraBoot-enrolled Kairos Hadron **v4.1.2 / k3s v1.36.1** node claimed from a group, configured, rebooted, and rejoined, the `KairosControlPlane` reaching `Initialized`, and the workload Node's `kairos-fleet://<node-id>` providerID matching the `KairosFleetMachine`. That run is what surfaced the clone and node-push fixes above — neither was visible from static review. Full unit suite green.

## Requires

The fixed fleet provider release (**v0.1.0-beta.2+**): the released v0.1.0-beta.1 controller crash-loops on a real cluster and is not clusterctl-installable. Companion PR: kairos-io/cluster-api-provider-kairos-fleet (scheme, clusterctl-name, and group-name-resolution fixes).
