### PR TITLE
fix: multinode worker joins for fleet control planes (status.version + k0s --single opt-in)

### DIFF
--- a/api/bootstrap/v1beta2/kairosconfig_types.go
+++ b/api/bootstrap/v1beta2/kairosconfig_types.go
@@ -159,8 +159,11 @@ type KairosConfigSpec struct {
 	// +optional
 	Pause bool `json:"pause,omitempty"`
 
-	// SingleNode indicates this is a single-node control plane cluster.
-	// When true, k0s will be configured with --single flag.
+	// SingleNode indicates this is a single-node control plane cluster
+	// (spec.replicas==1). For k0s, the rendered flag depends on K0sSingleNode:
+	// by default a single k0s control plane is a joinable, schedulable controller
+	// (--enable-worker) so workers can still join; set K0sSingleNode to true to
+	// render the standalone --single mode instead.
 	//
 	// Deprecated: SingleNode is derived by the KairosControlPlane controller
 	// from spec.replicas (true when replicas==1) and will be removed in a
@@ -170,6 +173,21 @@ type KairosConfigSpec struct {
 	// SingleNode.
 	// +optional
 	SingleNode bool `json:"singleNode,omitempty"`
+
+	// K0sSingleNode opts a single-control-plane k0s cluster into the k0s
+	// "--single" mode: a standalone all-in-one node that does NOT accept any
+	// joins. It only affects k0s control-plane machines; k3s and worker/join
+	// nodes ignore it.
+	//
+	// It is opt-in and defaults to false. When false (the default), a
+	// single-control-plane k0s node is rendered as a joinable, schedulable
+	// controller (k0s "--enable-worker"): it runs workloads itself AND accepts
+	// worker joins, so a control-plane-plus-worker (multi-node) cluster works.
+	// Setting "--single" would make k0s refuse worker joins entirely ("cannot
+	// join into a single node cluster"), so it is only appropriate for a truly
+	// standalone single node that will never gain workers.
+	// +optional
+	K0sSingleNode *bool `json:"k0sSingleNode,omitempty"`
 
 	// ControlPlaneRole is the init/join/single discriminator for this
 	// control-plane machine. Set by the KairosControlPlane controller;

--- a/api/bootstrap/v1beta2/zz_generated.deepcopy.go
+++ b/api/bootstrap/v1beta2/zz_generated.deepcopy.go
@@ -188,6 +188,11 @@ func (in *KairosConfigSpec) DeepCopyInto(out *KairosConfigSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.K0sSingleNode != nil {
+		in, out := &in.K0sSingleNode, &out.K0sSingleNode
+		*out = new(bool)
+		**out = **in
+	}
 	if in.UserPasswordSecretRef != nil {
 		in, out := &in.UserPasswordSecretRef, &out.UserPasswordSecretRef
 		*out = new(UserPasswordSecretReference)

--- a/api/controlplane/v1beta2/kairoscontrolplane_types.go
+++ b/api/controlplane/v1beta2/kairoscontrolplane_types.go
@@ -364,6 +364,15 @@ type KairosControlPlaneStatus struct {
 	// +optional
 	Replicas int32 `json:"replicas,omitempty"`
 
+	// Version is the observed version of the control plane. It is part of the
+	// Cluster API control-plane contract: CAPI core's ControlPlaneIsStable
+	// preflight reads it to decide whether the control plane is stable (versus
+	// mid-upgrade) before allowing worker MachineDeployment scale-up. The
+	// controller sets it to spec.version once at least one control-plane member
+	// is ready; it stays empty while none is ready, which reads as "not stable".
+	// +optional
+	Version string `json:"version,omitempty"`
+
 	// UpdatedReplicas is the number of control plane machines that have been updated
 	// Contract: ControlPlane MUST expose updatedReplicas
 	// A machine is considered updated when its spec matches the desired state.

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_kairosconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_kairosconfigs.yaml
@@ -314,6 +314,21 @@ spec:
                       When true, the system will reboot automatically after installation completes
                     type: boolean
                 type: object
+              k0sSingleNode:
+                description: |-
+                  K0sSingleNode opts a single-control-plane k0s cluster into the k0s
+                  "--single" mode: a standalone all-in-one node that does NOT accept any
+                  joins. It only affects k0s control-plane machines; k3s and worker/join
+                  nodes ignore it.
+
+                  It is opt-in and defaults to false. When false (the default), a
+                  single-control-plane k0s node is rendered as a joinable, schedulable
+                  controller (k0s "--enable-worker"): it runs workloads itself AND accepts
+                  worker joins, so a control-plane-plus-worker (multi-node) cluster works.
+                  Setting "--single" would make k0s refuse worker joins entirely ("cannot
+                  join into a single node cluster"), so it is only appropriate for a truly
+                  standalone single node that will never gain workers.
+                type: boolean
               k3sToken:
                 description: |-
                   K3sToken is the join token for k3s nodes (inline specification)
@@ -427,8 +442,11 @@ spec:
                 type: string
               singleNode:
                 description: |-
-                  SingleNode indicates this is a single-node control plane cluster.
-                  When true, k0s will be configured with --single flag.
+                  SingleNode indicates this is a single-node control plane cluster
+                  (spec.replicas==1). For k0s, the rendered flag depends on K0sSingleNode:
+                  by default a single k0s control plane is a joinable, schedulable controller
+                  (--enable-worker) so workers can still join; set K0sSingleNode to true to
+                  render the standalone --single mode instead.
 
                   Deprecated: SingleNode is derived by the KairosControlPlane controller
                   from spec.replicas (true when replicas==1) and will be removed in a

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_kairosconfigtemplates.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_kairosconfigtemplates.yaml
@@ -317,6 +317,21 @@ spec:
                               When true, the system will reboot automatically after installation completes
                             type: boolean
                         type: object
+                      k0sSingleNode:
+                        description: |-
+                          K0sSingleNode opts a single-control-plane k0s cluster into the k0s
+                          "--single" mode: a standalone all-in-one node that does NOT accept any
+                          joins. It only affects k0s control-plane machines; k3s and worker/join
+                          nodes ignore it.
+
+                          It is opt-in and defaults to false. When false (the default), a
+                          single-control-plane k0s node is rendered as a joinable, schedulable
+                          controller (k0s "--enable-worker"): it runs workloads itself AND accepts
+                          worker joins, so a control-plane-plus-worker (multi-node) cluster works.
+                          Setting "--single" would make k0s refuse worker joins entirely ("cannot
+                          join into a single node cluster"), so it is only appropriate for a truly
+                          standalone single node that will never gain workers.
+                        type: boolean
                       k3sToken:
                         description: |-
                           K3sToken is the join token for k3s nodes (inline specification)
@@ -433,8 +448,11 @@ spec:
                         type: string
                       singleNode:
                         description: |-
-                          SingleNode indicates this is a single-node control plane cluster.
-                          When true, k0s will be configured with --single flag.
+                          SingleNode indicates this is a single-node control plane cluster
+                          (spec.replicas==1). For k0s, the rendered flag depends on K0sSingleNode:
+                          by default a single k0s control plane is a joinable, schedulable controller
+                          (--enable-worker) so workers can still join; set K0sSingleNode to true to
+                          render the standalone --single mode instead.
 
                           Deprecated: SingleNode is derived by the KairosControlPlane controller
                           from spec.replicas (true when replicas==1) and will be removed in a

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_kairoscontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_kairoscontrolplanes.yaml
@@ -588,6 +588,15 @@ spec:
                   A machine is considered updated when its spec matches the desired state.
                 format: int32
                 type: integer
+              version:
+                description: |-
+                  Version is the observed version of the control plane. It is part of the
+                  Cluster API control-plane contract: CAPI core's ControlPlaneIsStable
+                  preflight reads it to decide whether the control plane is stable (versus
+                  mid-upgrade) before allowing worker MachineDeployment scale-up. The
+                  controller sets it to spec.version once at least one control-plane member
+                  is ready; it stays empty while none is ready, which reads as "not stable".
+                type: string
             type: object
         type: object
     served: true

--- a/docs/release-notes/v0.1.0-beta.3.md
+++ b/docs/release-notes/v0.1.0-beta.3.md
@@ -66,6 +66,13 @@ None in this release.
   fleet-backed `KairosControlPlane` never produced its `KairosFleetMachine`.
   It now clones fleet templates with the same verbatim-spec pattern as
   CAPV/CAPD/CAPM3.
+- **New `spec.k0sSingleNode` opt-in for standalone single-node k0s.** A new
+  optional `*bool` field on `KairosConfig`/`KairosConfigTemplate`. It defaults
+  to `false`, which renders a single k0s control plane as a joinable,
+  schedulable controller (`--enable-worker`; see Bug Fixes). Set it to `true`
+  only for a node meant to stay standalone forever: it renders k0s `--single`,
+  which refuses all joins. The field affects k0s control-plane machines only;
+  k3s and worker/join nodes ignore it.
 - **Fleet control planes publish their kubeconfig (node-push).** The
   in-node kubeconfig-push gate (`supportsManagementEndpoint`) now includes
   `KairosFleetMachine` alongside CAPK/CAPV/CAPM3, so a fleet control-plane
@@ -77,7 +84,21 @@ None in this release.
 
 ## Bug Fixes
 
-None in this release.
+- **A single k0s control plane now accepts workers.** A `KairosControlPlane`
+  with `spec.replicas: 1` and `distribution: k0s` rendered the k0s controller
+  with `--single`, k0s's standalone all-in-one mode that refuses every join
+  (`cannot join into a single node cluster`). A single-control-plane k0s
+  cluster could therefore never gain a worker `MachineDeployment`. The
+  default single-node k0s render is now a joinable, schedulable controller
+  (`--enable-worker`, matching k3s `--cluster-init`): it runs workloads itself
+  **and** accepts worker joins, so a control-plane-plus-worker k0s cluster
+  works out of the box. The standalone `--single` behavior is preserved as an
+  opt-in through the new `KairosConfig`/`KairosConfigTemplate` field
+  `spec.k0sSingleNode` (see New Features). This affects the generic
+  (bare-metal / fleet / vSphere / Metal3) render path; the KubeVirt (CAPK)
+  single-node render is unchanged. Validated on real hardware: a fleet-backed
+  single-control-plane k0s cluster with a joined worker, both `Node`s `Ready`
+  and providerIDs matched.
 
 ---
 

--- a/internal/bootstrap/ha_test.go
+++ b/internal/bootstrap/ha_test.go
@@ -139,9 +139,13 @@ func TestHA_WorkerIgnoresControlPlaneRole(t *testing.T) {
 
 // TestHA_InitVsSingle_K0s asserts the documented init-vs-single delta for k0s:
 // init drops --single, keeps managed etcd, and emits api.sans for the endpoint.
+// The "single" side uses the opt-in K0sSingleNode mode, which is the only path
+// that still renders the standalone --single flag (the default single control
+// plane renders --enable-worker so it can accept worker joins).
 func TestHA_InitVsSingle_K0s(t *testing.T) {
 	single := haCPData("single", false)
 	single.SingleNode = true
+	single.K0sSingleNode = true
 	single.VIP = nil // single never renders kube-vip
 	single.ManagementEndpoint = nil
 	sOut, err := RenderK0sCloudConfig(single)
@@ -149,7 +153,7 @@ func TestHA_InitVsSingle_K0s(t *testing.T) {
 		t.Fatalf("render single: %v", err)
 	}
 	if !strings.Contains(sOut, "- --single") {
-		t.Error("k0s single must contain --single")
+		t.Error("k0s single (K0sSingleNode opt-in) must contain --single")
 	}
 
 	iOut, err := RenderK0sCloudConfig(haCPData("init", false))

--- a/internal/bootstrap/template.go
+++ b/internal/bootstrap/template.go
@@ -40,16 +40,21 @@ var templateFS embed.FS
 // representation for Content automatically; per-field hand-assembly with
 // `quote` is NOT used for Files (KD-Files design).
 type TemplateData struct {
-	Role         string
-	SingleNode   bool
-	Hostname     string
-	UserName     string
-	UserPassword string
-	UserGroups   []string
-	GitHubUser   string
-	SSHPublicKey string
-	WorkerToken  string
-	Manifests    []bootstrapv1beta2.Manifest
+	Role       string
+	SingleNode bool
+	// K0sSingleNode opts a single-control-plane k0s node into "--single"
+	// (standalone, no joins). Default false renders "--enable-worker" (joinable
+	// + schedulable), so k0s control-plane-plus-worker clusters work. See
+	// KairosConfigSpec.K0sSingleNode.
+	K0sSingleNode bool
+	Hostname      string
+	UserName      string
+	UserPassword  string
+	UserGroups    []string
+	GitHubUser    string
+	SSHPublicKey  string
+	WorkerToken   string
+	Manifests     []bootstrapv1beta2.Manifest
 	// Files are additional files written to the node via write_files:. Each
 	// entry is rendered as a whole slice by toYaml — never assembled per-field.
 	// Path/Permissions/Owner are validated by validateTemplateData and the

--- a/internal/bootstrap/template_test.go
+++ b/internal/bootstrap/template_test.go
@@ -63,9 +63,14 @@ func TestRenderK0sCloudConfig_ControlPlaneSingleNode(t *testing.T) {
 		t.Error("Missing k0s enabled flag")
 	}
 
-	// Check for --single arg
-	if !strings.Contains(result, "--single") {
-		t.Error("Missing --single arg for single-node mode")
+	// A default single control plane (K0sSingleNode unset) renders as a
+	// joinable, schedulable controller (--enable-worker), NOT the standalone
+	// --single mode, so workers can still join it.
+	if !strings.Contains(result, "--enable-worker") {
+		t.Error("Missing --enable-worker arg for default single control plane")
+	}
+	if strings.Contains(result, "--single") {
+		t.Error("Default single control plane must not render --single (it refuses worker joins)")
 	}
 
 	// Check for user configuration
@@ -81,6 +86,30 @@ func TestRenderK0sCloudConfig_ControlPlaneSingleNode(t *testing.T) {
 	// Check for capk groups list
 	if !strings.Contains(result, "groups: [users, admin]") {
 		t.Error("Missing capk groups list")
+	}
+}
+
+func TestRenderK0sCloudConfig_ControlPlaneK0sSingleNodeOptIn(t *testing.T) {
+	data := TemplateData{
+		Role:          "control-plane",
+		SingleNode:    true,
+		K0sSingleNode: true,
+		Hostname:      "kairos-standalone-0",
+		UserName:      "kairos",
+	}
+
+	result, err := RenderK0sCloudConfig(data)
+	if err != nil {
+		t.Fatalf("Failed to render template: %v", err)
+	}
+
+	// Opting in (K0sSingleNode: true) renders the standalone --single mode,
+	// which refuses worker joins.
+	if !strings.Contains(result, "--single") {
+		t.Error("K0sSingleNode: true must render --single")
+	}
+	if strings.Contains(result, "--enable-worker") {
+		t.Error("K0sSingleNode: true must not render --enable-worker (standalone node)")
 	}
 }
 
@@ -949,9 +978,10 @@ func TestRenderK0sCloudConfig_ControlPlaneWithoutProviderID(t *testing.T) {
 	if strings.Contains(result, "--kubelet-extra-args=--provider-id=") {
 		t.Error("k0s args MUST NOT include --kubelet-extra-args=--provider-id= when ProviderID is empty (would emit a malformed flag)")
 	}
-	// SingleNode=true should still render --single, so the args block exists.
-	if !strings.Contains(result, "--single") {
-		t.Error("SingleNode=true must still render --single")
+	// A default single control plane renders --enable-worker, so the args block
+	// exists even though ProviderID is empty.
+	if !strings.Contains(result, "--enable-worker") {
+		t.Error("default single control plane must render --enable-worker (the args block must exist)")
 	}
 }
 

--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
@@ -74,7 +74,20 @@ k0s:
   {{- if or .SingleNode .PodCIDR .ServiceCIDR .ProviderID .IsHAControlPlane }}
   args:
   {{- if .SingleNode }}
+  {{- if .K0sSingleNode }}
+    # Opt-in standalone single node (KairosConfig spec.k0sSingleNode: true): k0s
+    # "--single" is an all-in-one node that REFUSES all joins ("cannot join into a
+    # single node cluster"), so it can never gain workers. Use only for a node
+    # that will stay standalone.
     - --single
+  {{- else }}
+    # Default single control plane: a joinable, schedulable controller
+    # (--enable-worker), matching k3s --cluster-init. The node runs workloads AND
+    # accepts worker joins, so a control-plane-plus-worker (multi-node) cluster
+    # works out of the box. (RenderKubeVIP is false for single-node, so the HA
+    # --enable-worker branch below never doubles this.)
+    - --enable-worker
+  {{- end }}
   {{- end }}
   {{- if or .PodCIDR .ServiceCIDR .IsInitControlPlane }}
     - --config /etc/k0s/k0s.yaml

--- a/internal/bootstrap/testdata/golden/k0s_capv_single.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capv_single.yaml
@@ -15,7 +15,12 @@ users:
 k0s:
   enabled: true
   args:
-    - --single
+    # Default single control plane: a joinable, schedulable controller
+    # (--enable-worker), matching k3s --cluster-init. The node runs workloads AND
+    # accepts worker joins, so a control-plane-plus-worker (multi-node) cluster
+    # works out of the box. (RenderKubeVIP is false for single-node, so the HA
+    # --enable-worker branch below never doubles this.)
+    - --enable-worker
 
 write_files:
   - path: /system/oem/12_kairos-capi-persistency.yaml

--- a/internal/controllers/bootstrap/kairosconfig_controller.go
+++ b/internal/controllers/bootstrap/kairosconfig_controller.go
@@ -990,6 +990,7 @@ func (r *KairosConfigReconciler) generateK0sCloudConfig(ctx context.Context, log
 	// 1. Explicit flag in KairosConfig.spec.singleNode
 	// 2. Or if this is a control-plane and we can check the owning KairosControlPlane
 	singleNode := kairosConfig.Spec.SingleNode
+	k0sSingleNode := kairosConfig.Spec.K0sSingleNode != nil && *kairosConfig.Spec.K0sSingleNode
 	if !singleNode && role == "control-plane" && machine != nil {
 		// Try to find the owning KairosControlPlane to check replicas
 		ownerRef := metav1.GetControllerOf(machine)
@@ -1102,6 +1103,7 @@ func (r *KairosConfigReconciler) generateK0sCloudConfig(ctx context.Context, log
 	templateData := bootstrap.TemplateData{
 		Role:                           role,
 		SingleNode:                     singleNode,
+		K0sSingleNode:                  k0sSingleNode,
 		Hostname:                       hostname,
 		UserName:                       userName,
 		UserPassword:                   userPassword,
@@ -1179,6 +1181,7 @@ func (r *KairosConfigReconciler) generateK0sCloudConfig(ctx context.Context, log
 func (r *KairosConfigReconciler) generateK3sCloudConfig(ctx context.Context, log logr.Logger, kairosConfig *bootstrapv1beta2.KairosConfig, machine *clusterv1.Machine, cluster *clusterv1.Cluster, role, serverAddress string) (string, error) {
 	// Determine single-node mode
 	singleNode := kairosConfig.Spec.SingleNode
+	k0sSingleNode := kairosConfig.Spec.K0sSingleNode != nil && *kairosConfig.Spec.K0sSingleNode
 	if !singleNode && role == "control-plane" && machine != nil {
 		ownerRef := metav1.GetControllerOf(machine)
 		if ownerRef != nil && ownerRef.Kind == "KairosControlPlane" {
@@ -1285,6 +1288,7 @@ func (r *KairosConfigReconciler) generateK3sCloudConfig(ctx context.Context, log
 	templateData := bootstrap.TemplateData{
 		Role:                           role,
 		SingleNode:                     singleNode,
+		K0sSingleNode:                  k0sSingleNode,
 		Hostname:                       hostname,
 		UserName:                       userName,
 		UserPassword:                   userPassword,

--- a/internal/controllers/bootstrap/kairosconfig_controller_test.go
+++ b/internal/controllers/bootstrap/kairosconfig_controller_test.go
@@ -106,7 +106,10 @@ func TestGenerateK0sCloudConfig_ControlPlaneSingleNode(t *testing.T) {
 	g.Expect(cloudConfig).To(ContainSubstring("#cloud-config"))
 	g.Expect(cloudConfig).To(ContainSubstring("k0s:"))
 	g.Expect(cloudConfig).To(ContainSubstring("enabled: true"))
-	g.Expect(cloudConfig).To(ContainSubstring("--single"))
+	// A default single control plane (K0sSingleNode unset) renders as a joinable,
+	// schedulable controller (--enable-worker), not the standalone --single mode.
+	g.Expect(cloudConfig).To(ContainSubstring("--enable-worker"))
+	g.Expect(cloudConfig).NotTo(ContainSubstring("--single"))
 	g.Expect(cloudConfig).NotTo(ContainSubstring("k0s-worker:"))
 }
 

--- a/internal/controllers/controlplane/kairoscontrolplane_controller.go
+++ b/internal/controllers/controlplane/kairoscontrolplane_controller.go
@@ -1105,6 +1105,18 @@ func (r *KairosControlPlaneReconciler) updateStatus(ctx context.Context, log log
 	kcp.Status.UnavailableReplicas = unavailableReplicas
 	kcp.Status.AvailableReplicas = availableReplicas
 
+	// status.version reports the observed control-plane version. It is part of the
+	// CAPI control-plane contract and is read by CAPI core's ControlPlaneIsStable
+	// preflight, which gates worker MachineDeployment scale-up: an unset (or
+	// mismatched) status.version reads as "the control plane is upgrading", so the
+	// preflight blocks every worker forever. The Kairos control plane runs at
+	// spec.version once provisioned (there is no in-place minor upgrade to track),
+	// so reflect spec.version as soon as a member is ready; leaving it empty while
+	// no member is ready correctly reads as "not yet stable".
+	if readyReplicas > 0 {
+		kcp.Status.Version = kcp.Spec.Version
+	}
+
 	selector := labels.SelectorFromSet(map[string]string{
 		clusterv1.ClusterNameLabel:         cluster.Name,
 		clusterv1.MachineControlPlaneLabel: "",

--- a/test/envtest/bootstrap_integration_test.go
+++ b/test/envtest/bootstrap_integration_test.go
@@ -260,7 +260,10 @@ func TestBootstrapIntegration(t *testing.T) {
 	g.Expect(cloudConfig).To(ContainSubstring("#cloud-config"))
 	g.Expect(cloudConfig).To(ContainSubstring("k0s:"))
 	g.Expect(cloudConfig).To(ContainSubstring("enabled: true"))
-	g.Expect(cloudConfig).To(ContainSubstring("--single"))
+	// A default single control plane (K0sSingleNode unset) renders as a joinable,
+	// schedulable controller (--enable-worker), not the standalone --single mode.
+	g.Expect(cloudConfig).To(ContainSubstring("--enable-worker"))
+	g.Expect(cloudConfig).NotTo(ContainSubstring("--single"))
 }
 
 // TestBootstrapIntegration_LatchedFailureClearsOnRecovery verifies the KD-14


### PR DESCRIPTION
## Summary

Three follow-up fixes to the fleet infrastructure provider (#88), all found and
fixed while validating **multi-node** clusters (control plane plus a worker
`MachineDeployment`) end to end on real hardware. #88 delivered and validated
the single-node fleet path; these land the fixes needed for the worker-join
path, which #88 did not exercise.

## What's here

- **`fix(controlplane)`: report `status.version` so worker MachineDeployments unblock.**
  `KairosControlPlane` never set `status.version`. CAPI core's
  `ControlPlaneIsStable` preflight reads an empty control-plane version as
  "perpetually upgrading" and blocks **every** worker `MachineDeployment` — so
  no infra provider could add workers, not just fleet. Adds
  `KairosControlPlaneStatus.Version` and sets it to `spec.version` once a
  control-plane member is ready (CRD regenerated). Invisible on single-node.

- **`feat(bootstrap)`: make k0s `--single` opt-in so a single control plane accepts workers.**
  A `replicas: 1` k0s control plane was rendered with k0s `--single`, the
  standalone all-in-one mode that refuses every join
  (`cannot join into a single node cluster`), so a single-control-plane k0s
  cluster could never gain a worker. The default single k0s control plane now
  renders `--enable-worker` (joinable + schedulable, k3s `--cluster-init`
  parity); the standalone mode is preserved as the opt-in field
  `KairosConfig`/`KairosConfigTemplate` `spec.k0sSingleNode` (`*bool`, default
  `false`). Generic/CAPV/CAPM3 render path only — the KubeVirt (CAPK)
  single-node render is unchanged by design.

- **`docs(release-notes)`:** record the above in the beta.3 notes.

## Validation

Manual end-to-end on real hardware (kind management cluster + AuroraBoot fleet
API + Hadron `v4.1.2` nodes, Kubernetes `v1.36.1`):

- **k3s** control plane + worker: both `Machine`s Ready/Running, both workload
  `Node`s Ready, `kairos-fleet://<node-id>` providerIDs match Node to
  `KairosFleetMachine`.
- **k0s** control plane + worker: control plane runs
  `k0s controller --enable-worker`; the worker joined the single control plane
  (impossible under `--single`); both `Machine`s Ready/Running, both `Node`s
  Ready, providerIDs match.

## Test plan

- `make generate manifests` — no diff (generated artifacts committed).
- `go build ./...`, `go vet ./...`.
- `go test -short ./...` — green, including new opt-in coverage and a refreshed
  `k0s_capv_single` golden.