### PR TITLE
docs(release): prepare v0.1.0 GA docs and fleet samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,218 @@ This project is pre-1.0. Alpha releases may include breaking changes; those are
 called out explicitly under **Breaking changes**. Per-scenario migration steps
 live in [docs/UPGRADING.md](docs/UPGRADING.md).
 
+## [v0.1.0] — 2026-08-10
+
+The first non-beta 0.1.0 release. Adds the **Kairos fleet (AuroraBoot)
+infrastructure provider** as a first-class peer to CAPD/CAPV/CAPK/CAPM3, and
+fixes two multi-node bugs found by an integrated real-hardware end-to-end
+run: worker `MachineDeployment`s never scaled up on any infrastructure
+provider, and a single k0s control plane refused all worker joins. See the
+[v0.1.0 release notes](docs/release-notes/v0.1.0.md) for full detail.
+
+### Breaking changes
+
+None in this release.
+
+### Added
+
+- **Kairos fleet infrastructure provider support** (ADR 0008). Fleet claims
+  already-enrolled Kairos nodes from a named AuroraBoot group rather than
+  creating machines on demand. New: `docs/QUICKSTART_FLEET.md`, k3s and k0s
+  control-plane-plus-worker samples
+  (`config/samples/fleet/kairos_cluster_{k0s,k3s}_with_workers.yaml`), a
+  standalone-single-node k0s sample
+  (`kairos_cluster_k0s_single_node.yaml`), and `clusterctl.yaml`
+  registration guidance in `docs/INSTALL.md`. Requires fleet provider
+  `v0.1.0-beta.2` or later — `v0.1.0-beta.1` crash-loops on a real
+  management cluster.
+- **`KairosFleetMachine` recognized as a supported infrastructure kind end
+  to end**: `getNodeIP` extractor support, actionable endpoint-wait
+  guidance, RBAC parity (`create;get` on `kairosfleetmachines`, `get` on
+  their `status` and on `kairosfleetmachinetemplates`), template cloning,
+  and node-push kubeconfig support.
+- **`KairosConfig`/`KairosConfigTemplate.spec.k0sSingleNode`** (`*bool`,
+  default `false`). Opts a single-node k0s control plane on the generic /
+  CAPV / CAPM3 / fleet render path into the standalone k0s `--single` mode
+  (refuses all joins), instead of the new default `--enable-worker`
+  (joinable, schedulable). k0s control-plane machines only; k3s and
+  worker/join nodes ignore it. CAPK is unchanged (always `--single` for
+  single-node).
+- **`KairosControlPlaneStatus.Version`**, part of the CAPI control-plane
+  contract. Set once at least one control-plane member is ready.
+
+### Fixed
+
+- **Worker `MachineDeployment`s now scale up, on every infrastructure
+  provider.** `status.version` was never set, so CAPI core's
+  `ControlPlaneIsStable` preflight read every Kairos control plane as
+  perpetually provisioning and refused to create worker Machines. Fixed by
+  the new `status.version` field above. Found by the integrated multi-node
+  e2e on real hardware — single-node kind runs never exercised a worker
+  `MachineDeployment`, so the gap was invisible there.
+- **A single k0s control plane now accepts workers.** It rendered k0s
+  `--single` unconditionally, refusing every join. The generic / CAPV /
+  CAPM3 / fleet render path now defaults to `--enable-worker`; the
+  standalone behavior is preserved via the opt-in `spec.k0sSingleNode`
+  field above. Validated on real hardware: a fleet-backed k0s cluster with
+  a joined worker, both `Node`s `Ready` and providerIDs matched.
+
+### Security
+
+- **No new RBAC surface beyond the enumerated fleet infra-kind grants** —
+  the same shape already granted for every other infrastructure provider's
+  machine/template kinds; no cluster-wide or wildcard grant added.
+- **The `kairos-fleet://<node-id>` providerID contract is a
+  cross-repository string match with no compile-time link**, guarded today
+  by cross-referencing doc comments and unit tests on each side; an
+  integrated e2e is the intended long-term guard (tracked, not yet in CI).
+- **AuroraBoot admin-token handling is out of this repo's scope.** The
+  token Secret referenced by
+  `KairosFleetCluster.spec.auroraboot.adminTokenSecretRef` is read and
+  stored by the fleet provider. Samples and quickstart instruct creating it
+  out of band and never committing a real token.
+
+### Known limitations
+
+- Fleet HA (`replicas: 3`/`5`) is mechanically reachable but not exercised
+  — no fleet HA sample is shipped (ADR 0008).
+- The integrated three-provider (bootstrap + control-plane + fleet) path is
+  validated manually on real hardware, not yet in this repository's CI.
+- No cosign signing or SBOM yet on release artifacts (carried forward from
+  v0.1.0-beta.2).
+- k3s HA day-2: control-plane replacement orphans an etcd member (KD-5d).
+  k0s remains the fully-supported HA distribution.
+
+## [v0.1.0-beta.2] — 2026-08-09
+
+Beta-2 adds **`clusterctl`-installable packaging** (ADR 0007): one image,
+packaged as two `clusterctl` providers (`bootstrap-kairos`,
+`control-plane-kairos`), alongside the existing flat `kubectl apply`
+manifest. Baseline moves to Kubernetes v1.36 (validated/recommended across
+the CAPI v1.13 management band) and CAPI core v1.13.4. See the
+[v0.1.0-beta.2 release notes](docs/release-notes/v0.1.0-beta.2.md) for full
+detail.
+
+### Breaking changes
+
+- **The `clusterctl` install path uses new namespaces and labels, and is
+  mutually exclusive with the flat manifest.** `clusterctl` providers use
+  `capi-kairos-bootstrap-system`/`bootstrap-kairos` and
+  `capi-kairos-control-plane-system`/`control-plane-kairos`, distinct from
+  the flat manifest's `kairos-capi-system`/`kairos`. Because
+  `Deployment.spec.selector` and `ClusterRoleBinding.roleRef` are
+  immutable, applying one path over the other does not upgrade it in place
+  — it stands up a second, independent set of controllers/webhooks
+  watching the same CRDs, which is unsupported. **If you stay on the flat
+  manifest, no action is required.** See
+  [docs/UPGRADING.md — Moving from the flat install to clusterctl packaging](docs/UPGRADING.md#moving-from-the-flat-install-to-clusterctl-packaging).
+
+### Added
+
+- **Two `clusterctl` providers from one image** (ADR 0007), selected via a
+  new `--controllers=bootstrap|control-plane|all` flag; a role-specific
+  `LeaderElectionID` and `--namespace` flag bring single-namespace-watch
+  compliance. A release now publishes `bootstrap-components.yaml`,
+  `control-plane-components.yaml`, and `metadata.yaml` (digest-pinned)
+  alongside `kairos-capi-provider.yaml`.
+- **Per-provider least-privilege RBAC.** RBAC is split into two
+  per-namespace sets; five dead cluster-wide grants are removed, including
+  an unused `webhookconfigurations` `patch` permission.
+- **CA injection via standard cert-manager `inject-ca-from`.**
+  `hack/post-install-webhook-ca-injection.sh` is retired.
+- **`clusterctl` plumbing fixed.** `config/clusterctl/metadata.yaml`
+  reshaped to a valid `Metadata` document; the stray `provider.yaml`
+  deleted.
+
+### Changed
+
+- Kubernetes v1.36 validated/recommended across the CAPI v1.13 management
+  band (v1.30-v1.36); CAPI core v1.13.3 → v1.13.4; Kairos v3.6.0+ → v4.1.2;
+  e2e stack moves to KubeVirt v1.9 / kindest/node v1.36.1 / k3s v1.36.1.
+
+### Fixed
+
+- **SSH-fallback `KubeconfigReady` condition no longer flaps** (#85). The
+  condition is now written deterministically instead of racing a
+  contention-sensitive worker round-trip.
+
+### Security
+
+- **RBAC reduction as attack-surface reduction**: five dead cluster-wide
+  grants removed, including the unused webhook-config `patch` primitive.
+- **Supply chain: digest-pinned, not yet signed.** Release artifacts remain
+  image-digest-pinned but are not cosign-signed and ship no SBOM.
+
+## [v0.1.0-beta.1] — 2026-07-04
+
+Beta-1 adds **highly-available control planes**: `spec.replicas` accepts
+`1` (single-node), `3`, or `5` on CAPK, CAPV, and CAPM3, for both k0s and
+k3s. CAPI core dependency moves to v1.13.3, adopting the v1beta2
+contract-versioned object-reference model (ADR 0006). See
+[docs/UPGRADING.md](docs/UPGRADING.md#v010-alpha2--v010-beta1) for the
+per-scenario upgrade impact.
+
+### Breaking changes
+
+- **`spec.replicas` validation changed.** Now accepts `1`, `3`, or `5`; the
+  validating webhook rejects even counts (worse etcd fault tolerance per
+  quorum cost than the next-lower odd count) and values above `5`. Existing
+  `replicas: 1` deployments are unaffected. (KD-5b, ADR 0005)
+- **CAPI core v1.13.3 / v1beta2 contract required.** The management-side
+  CAPI dependency moves from v1.8 to v1.13.3, adopting
+  `ContractVersionedObjectReference`/`MachineNodeReference` in place of
+  v1beta1 pointer-based references (commit `736aeb3`, ADR 0006). Deploy
+  this provider's CRDs via kustomize or `clusterctl`, never raw `kubectl
+  apply -f config/crd/bases/` — the contract label is required for CAPI
+  core to resolve object references. RBAC gains `get;list;watch` on
+  `customresourcedefinitions.apiextensions.k8s.io` (commit `b31083f`).
+- **`KairosControlPlane.spec.machineTemplate.metadata` is now a pointer**
+  (commit `58bc284`), so an empty value is omitted from the API payload
+  instead of round-tripping as `{}` — required by CAPI v1beta2's
+  `ObjectMeta` `MinProperties=1` schema. No operator action needed unless
+  external tooling depends on the Go field being a value type.
+
+### Added
+
+- **Highly-available control planes** (ADR 0005, Phases 1-4 + CAPK/CAPM3
+  extension). `spec.replicas: 3` or `5` provisions a multi-node k0s or k3s
+  control plane with etcd quorum. Endpoint mechanism is provider-specific:
+  `spec.ha.vip` (kube-vip) on CAPV/CAPM3; CAPK's own LoadBalancer Service on
+  CAPK (do not set `spec.ha.vip` there). CAPK control-plane VMs gain a
+  routable secondary NIC for etcd peering, since KubeVirt's masquerade
+  interface gives every VM the same self-address.
+- **`EtcdHealthy` condition** on `KairosControlPlane`, derived from
+  per-cluster node-reported etcd member health.
+- **Quorum-safe replacement.** The controller refuses a rollout or
+  scale-down delete that would drop etcd below `(N/2)+1` healthy voting
+  members.
+- **Clean etcd member eviction on k0s.** A CAPI pre-terminate hook pauses
+  termination after drain; the departing node runs `k0s etcd leave` and
+  acknowledges before the controller lets the delete finish.
+- New samples: `config/samples/{capk,capv,capm3}/*_ha.yaml`. New quickstart
+  sections for CAPK/CAPV/CAPM3 HA.
+
+### Fixed
+
+- **`KairosControlPlane.spec.distribution` now inherits from the
+  referenced `KairosConfigTemplate` when unset**, instead of silently
+  defaulting to `k0s` and overriding the template's distribution. A
+  `DistributionOverride` warning Event fires if an explicit value disagrees
+  with the template's.
+
+### Security
+
+- **KD-51**: HA etcd health/leave signals are node-self-reported over
+  vanilla RBAC and forgeable by a compromised control-plane node. Not a
+  privilege escalation (a compromised node already holds
+  cluster-admin-equivalent access) and cannot force an unsafe deletion —
+  the quorum-safety decision is made independently of any node signal.
+- `spec.ha.vip.address` and `spec.ha.vip.interface` are validated at
+  admission and shell-quoted at render time before being written into the
+  kube-vip DaemonSet manifest.
+- Controller RBAC gains a read-only, cluster-scoped `get;list;watch` on
+  `customresourcedefinitions.apiextensions.k8s.io`.
+
 ## [v0.1.0-alpha.2] — 2026-06-18
 
 Alpha-2 adds **Metal3 (CAPM3) bare-metal infrastructure support** and resolves
@@ -121,5 +333,8 @@ CAPD (Docker), CAPV (vSphere), and CAPK (KubeVirt). See the
 [release notes](docs/release-notes/v0.1.0-alpha.1.md) for the full feature list
 and the alpha-1 security notices.
 
+[v0.1.0]: https://github.com/kairos-io/cluster-api-provider-kairos/releases/tag/v0.1.0
+[v0.1.0-beta.2]: https://github.com/kairos-io/cluster-api-provider-kairos/releases/tag/v0.1.0-beta.2
+[v0.1.0-beta.1]: https://github.com/kairos-io/cluster-api-provider-kairos/releases/tag/v0.1.0-beta.1
 [v0.1.0-alpha.2]: https://github.com/kairos-io/cluster-api-provider-kairos/releases/tag/v0.1.0-alpha.2
 [v0.1.0-alpha.1]: https://github.com/kairos-io/cluster-api-provider-kairos/releases/tag/v0.1.0-alpha.1

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ This project provides two Cluster API (CAPI) providers for managing Kubernetes c
 
 ## Status
 
-**Latest release**: [`v0.1.0-beta.2`](https://github.com/kairos-io/cluster-api-provider-kairos/releases/tag/v0.1.0-beta.2) — pre-1.0; API surface may still change before v1.0.
+**Latest release**: [`v0.1.0`](https://github.com/kairos-io/cluster-api-provider-kairos/releases/tag/v0.1.0) — pre-1.0; API surface may still change before v1.0.
 
 Supports single-node and highly-available k0s and k3s clusters with CAPD, CAPV, CAPK, and CAPM3 (Metal3 bare metal), plus single-control-plane clusters with the Kairos fleet infrastructure provider (AuroraBoot-claimed nodes; ADR 0008, maintained in the repository's internal decision records). HA control planes (`spec.replicas: 3` or `5`) are supported on CAPK, CAPV, and CAPM3 for both k0s and k3s. CAPD is dev-only; HA is not exercised on CAPD. Fleet HA is not yet exercised — fleet is single-control-plane only today. `KairosControlPlane.spec.replicas` accepts `1` (single-node), `3`, or `5`; even counts and values above `5` are webhook-rejected. See [High-Availability control planes](#high-availability-control-planes) below. k0s is the fully-supported HA distribution; k3s HA has a known day-2 limitation (KD-5d).
 
-Read the [v0.1.0-beta.2 release notes](docs/release-notes/v0.1.0-beta.2.md) before installing. This release adds a second, `clusterctl`-native install path — if you run `clusterctl` on your management cluster, the Breaking Changes section is required reading: the `clusterctl` and flat-manifest paths are mutually exclusive and cannot be swapped in place. Additional infrastructure providers (Tinkerbell, hyperscalers) are on the roadmap.
+Read the [v0.1.0 release notes](docs/release-notes/v0.1.0.md) before installing. If you run `clusterctl` on your management cluster, the Breaking Changes section is required reading: the `clusterctl` and flat-manifest install paths are mutually exclusive and cannot be swapped in place. Additional infrastructure providers (Tinkerbell, hyperscalers) are on the roadmap.
 
 ## Install (released version)
 
@@ -26,7 +26,7 @@ Read the [v0.1.0-beta.2 release notes](docs/release-notes/v0.1.0-beta.2.md) befo
 The provider ships two ways; pick one per management cluster, they are mutually exclusive:
 
 - **clusterctl (recommended)**: register the provider, then run `clusterctl init --bootstrap kairos --control-plane kairos`.
-- **Flat manifest**: `kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-beta.2/kairos-capi-provider.yaml`.
+- **Flat manifest**: `kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0/kairos-capi-provider.yaml`.
 
 See the [install guide](docs/INSTALL.md) for provider registration, the full procedure for both paths, and why they cannot be mixed on one management cluster.
 
@@ -50,7 +50,7 @@ Provide node credentials via `userPasswordSecretRef` (recommended) or `sshPublic
 | CAPV | v1.11.x+ |
 | CAPK | KubeVirt v1.9.x / CAPK v0.1.x |
 | CAPM3 | v1.13+; BMO/Ironic v0.13+ |
-| kairos-fleet | v0.1.0-beta.1+ (`cluster-api-provider-kairos-fleet`); AuroraBoot |
+| kairos-fleet | v0.1.0-beta.2+ (`cluster-api-provider-kairos-fleet`); AuroraBoot — do not use v0.1.0-beta.1, it crash-loops on a real management cluster |
 | k0s | ~v1.36.1+k0s |
 | k3s | ~v1.36.1+k3s1 |
 | Kairos | v4.1.2 (standard and Hadron images) |

--- a/config/samples/fleet/kairos_cluster_k0s_with_workers.yaml
+++ b/config/samples/fleet/kairos_cluster_k0s_with_workers.yaml
@@ -1,21 +1,15 @@
 # ============================================================================
-# Fleet Sample: Standalone Single-Node k0s Cluster on Kairos OS
+# Fleet Sample: k0s Control Plane + Worker on Kairos OS
 # (Kairos fleet / AuroraBoot infrastructure provider)
 # ============================================================================
 #
-# This is the opt-in counterpart to kairos_cluster_k0s_with_workers.yaml in
-# this directory. A default single-node k0s control plane is joinable and
-# schedulable (k0s "--enable-worker"), so it can accept a worker
-# MachineDeployment. This manifest instead sets
-# KairosConfigTemplate.spec.template.spec.k0sSingleNode: true, which renders
-# k0s "--single" — a standalone all-in-one node that REFUSES all joins
-# ("cannot join into a single node cluster"). Use this only for a node that
-# is meant to stay standalone forever; do not add a worker MachineDeployment
-# to a cluster built from this file.
-#
-# k0sSingleNode is k0s-only: k3s has no equivalent field, because k3s
-# single-node mode already accepts worker joins by default (see
-# kairos_cluster_k3s_with_workers.yaml).
+# NOTE: k0s uses the identical fleet claim/apply/reboot flow as the k3s
+# variant (kairos_cluster_k3s_with_workers.yaml); only spec.distribution,
+# spec.version/kubernetesVersion, and the worker join-token field differ. k3s
+# is the reference / most-exercised fleet distribution; k0s fleet support is
+# newer. Prefer k3s if you do not have a specific reason to choose k0s. Read
+# the k3s sample's header comments in full before using this file — all
+# prerequisites and constraints described there apply equally here.
 #
 # PREREQUISITES (all must be satisfied before applying this manifest):
 #
@@ -27,9 +21,10 @@
 #          --infrastructure kairos-fleet
 #      See docs/QUICKSTART_FLEET.md and docs/INSTALL.md.
 #
-#   3. An AuroraBoot instance reachable from the management cluster, with an
-#      admin bearer token and at least one enrolled, unclaimed node in the
-#      "control-plane" group. No "workers" group is needed for this file.
+#   3. An AuroraBoot instance reachable from the management cluster, with:
+#        - an admin bearer token
+#        - at least one enrolled, unclaimed node in the "control-plane" group
+#        - at least one enrolled, unclaimed node in the "workers" group
 #
 #   4. A control-plane endpoint (host:port) that you manage: a kube-vip VIP,
 #      a load balancer, or a DNS name, pointed at the control-plane node once
@@ -48,15 +43,21 @@
 #      shell environment, not a hard-coded value.
 #
 # APPLY:
-#   kubectl apply -f config/samples/fleet/kairos_cluster_k0s_single_node.yaml
+#   kubectl apply -f config/samples/fleet/kairos_cluster_k0s_with_workers.yaml
 #
 # ============================================================================
 #
-# SCOPE: a single, standalone control-plane machine (replicas: 1), no worker
-# MachineDeployment. Fleet HA (KairosControlPlane.spec.replicas: 3 or 5) is
-# mechanically reachable but is NOT exercised on fleet — no fleet HA sample
-# is shipped (ADR 0008, "HA scope (decision)"). See
-# docs/HIGH_AVAILABILITY.md.
+# SCOPE: a single control-plane machine (replicas: 1) plus a worker
+# MachineDeployment — fleet's validated topology. Fleet HA
+# (KairosControlPlane.spec.replicas: 3 or 5) is mechanically reachable but is
+# NOT exercised on fleet — no fleet HA sample is shipped (ADR 0008, "HA scope
+# (decision)"). See docs/HIGH_AVAILABILITY.md.
+#
+# The worker below can join because a single-node k0s control plane defaults
+# to k0s "--enable-worker" (joinable, schedulable) rather than the standalone
+# "--single" mode. For a node that must never accept a worker join, see the
+# sibling sample kairos_cluster_k0s_single_node.yaml, which sets
+# KairosConfigTemplate.spec.template.spec.k0sSingleNode: true.
 #
 # NO install: block anywhere below. AuroraBoot nodes are already enrolled and
 # installed; the bootstrap cloud-config is staged to the node's existing
@@ -67,7 +68,8 @@
 # IMPORTANT: replace `password:` below with a strong value before applying.
 # `openssl rand -base64 32` generates a suitable value. Inline userPassword
 # in KairosConfig is deprecated; this Secret pattern is the recommended way
-# to provide it.
+# to provide it. Both KairosConfigTemplates (control plane and worker) below
+# reference this Secret.
 apiVersion: v1
 kind: Secret
 metadata:
@@ -136,8 +138,8 @@ metadata:
   name: fleet-demo-control-plane
   namespace: default
 spec:
-  # Single, standalone control plane. Fleet HA (replicas: 3/5) is unexercised
-  # — see the header comment above and docs/HIGH_AVAILABILITY.md. Do not set
+  # Single control-plane only. Fleet HA (replicas: 3/5) is unexercised — see
+  # the header comment above and docs/HIGH_AVAILABILITY.md. Do not set
   # spec.ha.vip here: it is unnecessary for a single control-plane node and
   # setHAConditions is a no-op at replicas <= 1.
   replicas: 1
@@ -179,12 +181,6 @@ spec:
       distribution: k0s
       kubernetesVersion: "v1.34.1+k0s.1"
       # NO install: block — see the header comment above.
-      # Renders k0s "--single": a standalone all-in-one node that refuses all
-      # worker joins. This is the field this sample exists to demonstrate; see
-      # the header comment above. Omit (or set false) for the default
-      # joinable, schedulable "--enable-worker" behavior — see
-      # kairos_cluster_k0s_with_workers.yaml.
-      k0sSingleNode: true
       userName: kairos
       # Password comes from the Secret defined at the top of this file.
       # Alternative: set sshPublicKey: and omit userPasswordSecretRef.
@@ -196,3 +192,79 @@ spec:
       # sshPublicKey: "ssh-rsa AAAAB3NzaC1yc2E..."
       # Optional: import SSH public keys from a GitHub user's profile.
       # githubUser: "your-github-username"
+---
+# k0s workers join using this token (k0s calls it a worker token). Create it
+# out of band from an existing k0s controller:
+#   k0s token create --role=worker
+# Do not commit a real token to version control.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: fleet-demo-worker-token
+  namespace: default
+type: Opaque
+stringData:
+  token: "REPLACE-WITH-K0S-WORKER-TOKEN"
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachineDeployment
+metadata:
+  name: fleet-demo-md-0
+  namespace: default
+spec:
+  clusterName: fleet-demo
+  replicas: 1
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: fleet-demo
+      cluster.x-k8s.io/deployment-name: fleet-demo-md-0
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: fleet-demo
+        cluster.x-k8s.io/deployment-name: fleet-demo-md-0
+    spec:
+      clusterName: fleet-demo
+      version: "v1.34.1+k0s.1"
+      bootstrap:
+        configRef:
+          apiGroup: bootstrap.cluster.x-k8s.io
+          kind: KairosConfigTemplate
+          name: fleet-demo-md-0
+      infrastructureRef:
+        apiGroup: infrastructure.cluster.x-k8s.io
+        kind: KairosFleetMachineTemplate
+        name: fleet-demo-md-0
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: KairosFleetMachineTemplate
+metadata:
+  name: fleet-demo-md-0
+  namespace: default
+spec:
+  template:
+    spec:
+      # AuroraBoot group worker machines are claimed from. Must have at
+      # least one enrolled, unclaimed node per desired worker replica.
+      group: workers
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+kind: KairosConfigTemplate
+metadata:
+  name: fleet-demo-md-0
+  namespace: default
+spec:
+  template:
+    spec:
+      role: worker
+      distribution: k0s
+      kubernetesVersion: "v1.34.1+k0s.1"
+      # NO install: block — see the header comment above.
+      workerTokenSecretRef:
+        name: fleet-demo-worker-token
+        key: token
+      userName: kairos
+      userPasswordSecretRef:
+        name: kairos-user-password
+      userGroups:
+        - admin

--- a/config/samples/fleet/kairos_cluster_k3s_with_workers.yaml
+++ b/config/samples/fleet/kairos_cluster_k3s_with_workers.yaml
@@ -1,5 +1,5 @@
 # ============================================================================
-# Fleet Sample: Single Control-Plane k3s Cluster on Kairos OS
+# Fleet Sample: k3s Control Plane + Worker on Kairos OS
 # (Kairos fleet / AuroraBoot infrastructure provider)
 # ============================================================================
 #
@@ -12,9 +12,12 @@
 # cloud-config, and reboots it. See ADR 0008 and docs/QUICKSTART_FLEET.md.
 #
 # k3s is the reference / most-exercised fleet distribution. k0s is also
-# supported and newer; see kairos_cluster_k0s_single_node.yaml in this
+# supported and newer; see kairos_cluster_k0s_with_workers.yaml in this
 # directory for the k0s variant (identical shape; only distribution and
-# version fields differ).
+# version fields differ). k3s has no k0sSingleNode equivalent — k3s single-node
+# mode already accepts worker joins by default; see
+# kairos_cluster_k0s_single_node.yaml for the standalone-node case, which is
+# k0s-only.
 #
 # PREREQUISITES (all must be satisfied before applying this manifest):
 #
@@ -49,11 +52,12 @@
 #      shell environment, not a hard-coded value.
 #
 # APPLY:
-#   kubectl apply -f config/samples/fleet/kairos_cluster_k3s_single_node.yaml
+#   kubectl apply -f config/samples/fleet/kairos_cluster_k3s_with_workers.yaml
 #
 # ============================================================================
 #
-# SCOPE: single control plane only (replicas: 1) plus one worker. Fleet HA
+# SCOPE: a single control-plane machine (replicas: 1) plus a worker
+# MachineDeployment — fleet's validated topology. Fleet HA
 # (KairosControlPlane.spec.replicas: 3 or 5) is mechanically reachable but is
 # NOT exercised on fleet — no fleet HA sample is shipped (ADR 0008, "HA scope
 # (decision)"). See docs/HIGH_AVAILABILITY.md.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # API Reference
 
-Last verified against: Kairos v3.6.0+, CAPI v1.13.4 (v1beta2 contract), provider v0.1.0-beta.2.
+Last verified against: Kairos v3.6.0+, CAPI v1.13.4 (v1beta2 contract), provider v0.1.0.
 
 This document provides a reference for all Custom Resource Definitions (CRDs) provided by the Kairos CAPI Provider. See [Install guide](INSTALL.md) for development install. Quickstarts: [CAPD](QUICKSTART_CAPD.md), [CAPV](QUICKSTART_CAPV.md), [CAPK](QUICKSTART_CAPK.md), [CAPM3](QUICKSTART_CAPM3.md).
 
@@ -30,7 +30,8 @@ This document provides a reference for all Custom Resource Definitions (CRDs) pr
 | `role` | `string` | Yes | `"worker"` | Node role: `"control-plane"` or `"worker"`. |
 | `distribution` | `string` | No | `"k0s"` | Kubernetes distribution: `"k0s"` or `"k3s"`. |
 | `kubernetesVersion` | `string` | Yes | — | Kubernetes version string (e.g., `"v1.34.1+k0s.1"`). The value is informational — the actual version is pinned in the Kairos image at build time and cannot be changed by this field. See KD-24. |
-| `singleNode` | `bool` | No | `false` | Signals single-node mode to the cloud-config renderer. For k0s, this adds `--single`; for k3s, it enables cluster-init mode. The KairosControlPlane controller derives this from `replicas==1`, so manual overrides are typically unnecessary. Applies to both k0s and k3s distributions. Tracked as a deprecation candidate in KD-39. |
+| `singleNode` | `bool` | No | `false` | Signals single-node mode to the cloud-config renderer. The KairosControlPlane controller derives this from `replicas==1`, so manual overrides are typically unnecessary. What single-node mode renders is distribution- and infrastructure-specific: for k3s it enables cluster-init mode on every infrastructure provider; for k0s on CAPK it renders `--single`; for k0s on the generic / CAPV / CAPM3 / fleet render path it renders `--enable-worker` by default, or `--single` when `k0sSingleNode` is also `true` (see `k0sSingleNode` below). Tracked as a deprecation candidate in KD-39. |
+| `k0sSingleNode` | `*bool` | No | `false` | For a single-node k0s control plane (`singleNode: true`, `distribution: k0s`) on the generic / CAPV / CAPM3 / fleet render path, selects which k0s single-node flag is rendered. `false` (the default) renders `--enable-worker`: a joinable, schedulable controller that runs workloads itself and accepts worker joins, so a control-plane-plus-worker cluster works out of the box. `true` renders `--single`: a standalone all-in-one node that refuses all joins ("cannot join into a single node cluster") — use this only for a node that will never gain workers. Ignored by k3s and by worker/join nodes, and has no effect on CAPK, which always renders `--single` for single-node k0s. |
 | `userName` | `string` | No | `"kairos"` | Username for the default OS user. |
 | `userPassword` | `string` | No | — | Password for the default OS user, specified inline. Inline values are stored in the resource and visible to anyone with read access to KairosConfig objects. Prefer `userPasswordSecretRef`. At least one of `userPassword`, `userPasswordSecretRef`, `sshPublicKey`, or `githubUser` must be set; the validating webhook enforces this. If both `userPassword` and `userPasswordSecretRef` are set, `userPasswordSecretRef` takes precedence. |
 | `userPasswordSecretRef` | `UserPasswordSecretReference` | No | — | Reference to a Secret containing the OS user password. The Secret must have a key matching `userPasswordSecretRef.key` (default: `"password"`). Preferred over inline `userPassword`. |
@@ -497,7 +498,15 @@ The controller fails reconciliation if no token is provided for a worker.
 
 ### Single-Node Mode
 
-When `KairosControlPlane.spec.replicas == 1`, the controller automatically sets `KairosConfig.spec.singleNode = true` on the created control-plane Machine's config. For k0s this adds the `--single` flag; for k3s it enables single-node cluster-init mode. The `singleNode` field applies to both distributions. Setting it manually on a `KairosConfigTemplate` is unnecessary when managed by `KairosControlPlane`.
+When `KairosControlPlane.spec.replicas == 1`, the controller automatically sets `KairosConfig.spec.singleNode = true` on the created control-plane Machine's config. Setting it manually on a `KairosConfigTemplate` is unnecessary when managed by `KairosControlPlane`.
+
+`singleNode` decides *whether* single-node mode applies; for k0s, `k0sSingleNode` separately decides *which* k0s flag single-node mode renders:
+
+- **k3s**, on every infrastructure provider: `singleNode` enables single-node cluster-init mode. `k0sSingleNode` has no effect.
+- **k0s on CAPK**: `singleNode` renders `--single`, unconditionally. `k0sSingleNode` has no effect.
+- **k0s on the generic / CAPV / CAPM3 / fleet render path**: `singleNode` alone renders `--enable-worker` — a joinable, schedulable controller, so a control-plane-plus-worker cluster works with no further configuration. Setting `k0sSingleNode: true` renders `--single` instead: a standalone all-in-one node that refuses all worker joins. Use `k0sSingleNode: true` only for a node that is meant to stay standalone forever.
+
+See the `k0sSingleNode` row above for the field reference, and `config/samples/fleet/kairos_cluster_k0s_single_node.yaml` for a worked standalone-node example.
 
 ### Multi-Node Control Planes
 

--- a/docs/HIGH_AVAILABILITY.md
+++ b/docs/HIGH_AVAILABILITY.md
@@ -1,6 +1,6 @@
 # High-Availability Control Planes
 
-Last verified against: provider v0.1.0-beta.2, CAPI v1.13.4.
+Last verified against: provider v0.1.0, CAPI v1.13.4.
 
 This page covers `KairosControlPlane` HA configuration (`spec.replicas` and
 `spec.ha.vip`) and the day-2 etcd health and quorum-safe replacement

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,12 +1,13 @@
 # Install Guide
 
 Last verified against: Kairos v3.6.0+, CAPI v1.13.4, cert-manager v1.15+,
-provider v0.1.0-beta.2. The "Registering the Kairos fleet infrastructure
+provider v0.1.0. The "Registering the Kairos fleet infrastructure
 provider" section below documents `cluster-api-provider-kairos-fleet`
-v0.1.0-beta.1's own `clusterctl.yaml` entry; it has not been re-verified by
+v0.1.0-beta.2's own `clusterctl.yaml` entry; it has not been re-verified by
 running `clusterctl init --infrastructure kairos-fleet` in this repository's
 CI — see [docs/QUICKSTART_FLEET.md](QUICKSTART_FLEET.md) for the same
-caveat.
+caveat. Do not use fleet provider `v0.1.0-beta.1`: it crash-loops on a real
+management cluster and is not clusterctl-installable.
 
 Three install paths: `clusterctl` (recommended), the released flat artifact (`kubectl apply`), and a developer install from source. Path 1 and Path 2 are mutually exclusive on one management cluster: see [Path 1 and Path 2 are mutually exclusive](#path-1-and-path-2-are-mutually-exclusive) below before picking one.
 
@@ -57,11 +58,13 @@ providers:
 ```
 
 Point `url` at a specific tag instead of `latest` to pin a version, for
-example `.../releases/download/v0.1.0-beta.1/infrastructure-components.yaml`.
-Fleet claims already-enrolled AuroraBoot nodes rather than creating machines
-on demand; see [docs/QUICKSTART_FLEET.md](QUICKSTART_FLEET.md) for the full
-provisioning model and ADR 0008 (maintained in the repository's internal
-decision records) for how it integrates with the bootstrap and control-plane
+example `.../releases/download/v0.1.0-beta.2/infrastructure-components.yaml`.
+Do not pin `v0.1.0-beta.1`: that release crash-loops on a real management
+cluster and is not clusterctl-installable. Fleet claims already-enrolled
+AuroraBoot nodes rather than creating machines on demand; see
+[docs/QUICKSTART_FLEET.md](QUICKSTART_FLEET.md) for the full provisioning
+model and ADR 0008 (maintained in the repository's internal decision
+records) for how it integrates with the bootstrap and control-plane
 providers in this repo.
 
 ### Install
@@ -126,7 +129,7 @@ Use this if you want a single `kubectl apply -f` without configuring `clusterctl
 ### Install
 
 ```bash
-kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-beta.2/kairos-capi-provider.yaml
+kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0/kairos-capi-provider.yaml
 ```
 
 This applies the all-in-one provider manifest: CRDs, RBAC, webhook configurations, and the controller Deployment in the `kairos-capi-system` namespace, labeled `cluster.x-k8s.io/provider: kairos`. It is not a `clusterctl` artifact. Do not run `clusterctl init --bootstrap kairos` against a management cluster installed this way; see [Path 1 and Path 2 are mutually exclusive](#path-1-and-path-2-are-mutually-exclusive).
@@ -148,7 +151,7 @@ Expected: one Deployment `kairos-capi-controller-manager` in `kairos-capi-system
 ### Uninstall
 
 ```bash
-kubectl delete -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-beta.2/kairos-capi-provider.yaml
+kubectl delete -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0/kairos-capi-provider.yaml
 ```
 
 **Re-install note**: if you are re-installing across a name-prefix change or a previous failed install, stale `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration` objects from the previous install may point at a webhook Service that no longer exists. Delete them before re-installing:
@@ -247,4 +250,4 @@ for the full configuration steps.
 - [CAPM3 Quickstart](QUICKSTART_CAPM3.md) — create a cluster on bare metal via Metal3.
 - [Fleet Quickstart](QUICKSTART_FLEET.md) — create a cluster from AuroraBoot-claimed nodes with the Kairos fleet infrastructure provider.
 
-For the current release status, breaking changes, and security caveats, read the [v0.1.0-beta.2 release notes](release-notes/v0.1.0-beta.2.md).
+For the current release status, breaking changes, and security caveats, read the [v0.1.0 release notes](release-notes/v0.1.0.md).

--- a/docs/QUICKSTART_CAPD.md
+++ b/docs/QUICKSTART_CAPD.md
@@ -1,6 +1,6 @@
 # Quick Start Guide - CAPD (Docker)
 
-Last verified against: Kairos v3.6.0+, CAPI v1.13.4, provider v0.1.0-beta.2.
+Last verified against: Kairos v3.6.0+, CAPI v1.13.4, provider v0.1.0.
 
 This guide walks you through creating a single-node k0s cluster on Kairos using Cluster API with the Docker provider (CAPD).
 

--- a/docs/QUICKSTART_CAPK.md
+++ b/docs/QUICKSTART_CAPK.md
@@ -1,6 +1,6 @@
 # Quickstart: CAPK (KubeVirt)
 
-Last verified against: Kairos v4.1.2, CAPI v1.13.4, KubeVirt v1.9, CAPK v0.1.x, provider v0.1.0-beta.2.
+Last verified against: Kairos v4.1.2, CAPI v1.13.4, KubeVirt v1.9, CAPK v0.1.x, provider v0.1.0.
 
 This guide covers two paths:
 

--- a/docs/QUICKSTART_CAPM3.md
+++ b/docs/QUICKSTART_CAPM3.md
@@ -1,6 +1,6 @@
 # Quick Start Guide - CAPM3 (Metal3 / bare metal)
 
-Last verified against: Kairos v3.6.0+, Kairos Hadron v0.0.4, CAPI v1.13.4, CAPM3 v1.13.0, BMO v0.13.0, provider v0.1.0-beta.2. Verified on emulated bare metal (sushy-tools Redfish BMC + libvirt/KVM) and on physical hardware (Hadron whole-disk deploy to bare metal); the same flow applies to physical hardware with a Redfish/IPMI BMC.
+Last verified against: Kairos v3.6.0+, Kairos Hadron v0.0.4, CAPI v1.13.4, CAPM3 v1.13.0, BMO v0.13.0, provider v0.1.0. Verified on emulated bare metal (sushy-tools Redfish BMC + libvirt/KVM) and on physical hardware (Hadron whole-disk deploy to bare metal); the same flow applies to physical hardware with a Redfish/IPMI BMC.
 
 This guide walks you through creating a single-node k3s or k0s cluster on Kairos using Cluster API with the Metal3 infrastructure provider (CAPM3). k0s and k3s use the identical flow and differ only in distribution and version fields. For a 3-node HA control plane, see [High-Availability control plane](#high-availability-control-plane) below.
 

--- a/docs/QUICKSTART_CAPV.md
+++ b/docs/QUICKSTART_CAPV.md
@@ -1,6 +1,6 @@
 # Quick Start Guide - CAPV (vSphere)
 
-Last verified against: Kairos v3.6.0+, CAPI v1.13.4, CAPV v1.11.x+, provider v0.1.0-beta.2.
+Last verified against: Kairos v3.6.0+, CAPI v1.13.4, CAPV v1.11.x+, provider v0.1.0.
 
 This guide walks you through creating a single-node k0s or k3s cluster on Kairos using Cluster API with the vSphere provider (CAPV). For a 3-node highly-available k0s control plane, see [High-Availability: 3-node k0s control plane](#high-availability-3-node-k0s-control-plane) below.
 

--- a/docs/QUICKSTART_FLEET.md
+++ b/docs/QUICKSTART_FLEET.md
@@ -1,32 +1,41 @@
 # Quick Start Guide - Fleet (Kairos fleet / AuroraBoot)
 
-Last verified against: Kairos fleet provider v0.1.0-beta.1
-(`cluster-api-provider-kairos-fleet`), this provider's fleet-support code
-(ADR 0008; unreleased at the time of writing — see the
-[v0.1.0-beta.3 release notes](release-notes/v0.1.0-beta.3.md)), Cluster API
-v1.13.4 (v1beta2 contract), Kairos v4.1.2, k3s. This walkthrough has not been
-run end to end against a live AuroraBoot instance in this repository's CI —
-it is assembled from the fleet provider's own documentation and from reading
+Last verified against: Kairos fleet provider v0.1.0-beta.2+
+(`cluster-api-provider-kairos-fleet`; do not use `v0.1.0-beta.1`, it
+crash-loops on a real management cluster), this repository's fleet-support
+code (ADR 0008, shipped in v0.1.0 — see the
+[v0.1.0 release notes](release-notes/v0.1.0.md)), Cluster API v1.13.4
+(v1beta2 contract), Kairos v4.1.2, k3s. This walkthrough has not been run
+end to end against a live AuroraBoot instance in this repository's CI — it
+is assembled from the fleet provider's own documentation and from reading
 both controllers' source. If a step does not match your observed behavior,
 treat this page as the thing that is wrong and file an issue.
 
 This guide walks you through provisioning a single control-plane machine plus
-one worker on Kairos using Cluster API with the **Kairos fleet** infrastructure
-provider (`cluster-api-provider-kairos-fleet`, clusterctl name `kairos-fleet`).
-Fleet does not create machines on demand: it claims an already-enrolled,
-unclaimed Kairos node from a named AuroraBoot group, hands it a bootstrap
-cloud-config, and reboots it. "No capacity in a group" is an expected,
-transient state — enroll more nodes or free one up — not a failure.
+a worker `MachineDeployment` on Kairos using Cluster API with the **Kairos
+fleet** infrastructure provider (`cluster-api-provider-kairos-fleet`,
+clusterctl name `kairos-fleet`). Fleet does not create machines on demand: it
+claims an already-enrolled, unclaimed Kairos node from a named AuroraBoot
+group, hands it a bootstrap cloud-config, and reboots it. "No capacity in a
+group" is an expected, transient state — enroll more nodes or free one up —
+not a failure.
 
 **Scope of this guide:**
 
 - Single control-plane machine (`replicas: 1`) plus a 1-replica worker
-  `MachineDeployment`. This is the only path exercised on fleet. HA
-  (`replicas: 3`/`5`) is mechanically reachable but **not exercised** — no
+  `MachineDeployment` (`kairos_cluster_{k0s,k3s}_with_workers.yaml`). This is
+  the validated, exercised topology on fleet. A standalone single node with
+  no workers (`kairos_cluster_k0s_single_node.yaml`) is also covered below.
+  HA (`replicas: 3`/`5`) is mechanically reachable but **not exercised** — no
   fleet HA sample is shipped (ADR 0008). See
   [docs/HIGH_AVAILABILITY.md](HIGH_AVAILABILITY.md).
 - k3s is the reference / most-exercised distribution. k0s is also supported
-  and newer; see the k0s sample and the notes below.
+  and newer; see the k0s samples and the notes below. A default single-node
+  k0s control plane is joinable and schedulable (`--enable-worker`), so the
+  shipped worker `MachineDeployment` can join it; set
+  `spec.k0sSingleNode: true` on the `KairosConfigTemplate` instead for a
+  standalone node that never gains workers — see
+  [kairos_cluster_k0s_single_node.yaml](../config/samples/fleet/kairos_cluster_k0s_single_node.yaml).
 - The control-plane endpoint is **operator-supplied**: fleet does not
   allocate or discover a VIP, load balancer, or DNS name. You must know the
   node's reachable endpoint before it is claimed — the same sharp edge as
@@ -107,7 +116,7 @@ metal and pre-provisioned edge nodes that phone home to AuroraBoot.
 
 6. **k3s is the reference path.** k0s fleet support is newer; prefer k3s
    unless you have a specific reason to choose k0s (see
-   [kairos_cluster_k0s_single_node.yaml](../config/samples/fleet/kairos_cluster_k0s_single_node.yaml)).
+   [kairos_cluster_k0s_with_workers.yaml](../config/samples/fleet/kairos_cluster_k0s_with_workers.yaml)).
 
 ---
 
@@ -141,9 +150,11 @@ not set `userPassword` inline.
 
 ### Step 3: Choose a sample manifest
 
-- k3s single control-plane + worker (reference path):
-  [`config/samples/fleet/kairos_cluster_k3s_single_node.yaml`](../config/samples/fleet/kairos_cluster_k3s_single_node.yaml)
-- k0s single control-plane + worker:
+- k3s control-plane + worker `MachineDeployment` (reference path):
+  [`config/samples/fleet/kairos_cluster_k3s_with_workers.yaml`](../config/samples/fleet/kairos_cluster_k3s_with_workers.yaml)
+- k0s control-plane + worker `MachineDeployment`:
+  [`config/samples/fleet/kairos_cluster_k0s_with_workers.yaml`](../config/samples/fleet/kairos_cluster_k0s_with_workers.yaml)
+- k0s standalone single node, no workers (`spec.k0sSingleNode: true`):
   [`config/samples/fleet/kairos_cluster_k0s_single_node.yaml`](../config/samples/fleet/kairos_cluster_k0s_single_node.yaml)
 
 ### Step 4: Customize the manifest
@@ -211,10 +222,16 @@ spec:
 ### Step 5: Apply the manifest
 
 ```bash
-kubectl apply -f config/samples/fleet/kairos_cluster_k3s_single_node.yaml
+kubectl apply -f config/samples/fleet/kairos_cluster_k3s_with_workers.yaml
 ```
 
-or for k0s:
+or for k0s with a worker:
+
+```bash
+kubectl apply -f config/samples/fleet/kairos_cluster_k0s_with_workers.yaml
+```
+
+or for a standalone k0s node with no workers:
 
 ```bash
 kubectl apply -f config/samples/fleet/kairos_cluster_k0s_single_node.yaml

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,6 +1,6 @@
 # Testing
 
-Last verified against: Go toolchain 1.26.3, provider v0.1.0-beta.2.
+Last verified against: Go toolchain 1.26.3, provider v0.1.0.
 
 See [Install guide](INSTALL.md) for development install.
 
@@ -45,9 +45,9 @@ This is the highest-confidence gate but requires Docker and a host with enough m
 
 After the cluster is `Available=true`, drain a node via `kubectl drain <node> --ignore-daemonsets --delete-emptydir-data`, restart the underlying VM (`virtctl restart <vm>` for CAPK; vSphere "Restart Guest OS" for CAPV), uncordon, and verify `kubectl get nodes` shows `Ready` within 5 minutes. This validates KD-23's persistence injection — k0s/k3s state, SSH host keys, and CNI config must survive the reboot.
 
-## Supported configurations (v0.1.0-beta.2)
+## Supported configurations (v0.1.0)
 
-Single-node and 3-node HA control planes are supported on CAPK, CAPV, and CAPM3, for both k0s and k3s. CAPD is dev-only (single-node); HA is not exercised on CAPD. CAPD is tested via unit/envtest rather than a live e2e run.
+Single-node and 3-node HA control planes are supported on CAPK, CAPV, and CAPM3, for both k0s and k3s. CAPD is dev-only (single-node); HA is not exercised on CAPD. CAPD is tested via unit/envtest rather than a live e2e run. Fleet (Kairos fleet / AuroraBoot) supports a single control plane plus a worker `MachineDeployment`; HA is not exercised on fleet.
 
 | Infrastructure | Distribution | Single-node | HA (3-node) |
 |---|---|---|---|
@@ -58,5 +58,7 @@ Single-node and 3-node HA control planes are supported on CAPK, CAPV, and CAPM3,
 | CAPK | k0s | Supported | Supported |
 | CAPK | k3s | Supported | Supported (KD-5d day-2 caveat) |
 | CAPD | k0s | Supported (dev only) | Not exercised |
+| Fleet | k0s | Supported: control plane + worker `MachineDeployment`, validated on real hardware (Hadron v4.1.2, Kubernetes v1.36.1) | Not exercised |
+| Fleet | k3s | Supported: control plane + worker `MachineDeployment`, validated on real hardware (Hadron v4.1.2, Kubernetes v1.36.1) | Not exercised |
 
 Hadron is the musl-libc-based next-generation Kairos OS; it is exercised alongside standard (glibc) Kairos images to confirm compatibility with both targets.

--- a/docs/release-notes/v0.1.0.md
+++ b/docs/release-notes/v0.1.0.md
@@ -1,8 +1,8 @@
-# v0.1.0-beta.3 — Release Notes
+# v0.1.0 — Release Notes
 
 This is a pre-1.0 release. The API surface may still change before v1.0.
 
-Read the [upgrade guide](https://github.com/kairos-io/cluster-api-provider-kairos/blob/v0.1.0-beta.3/docs/UPGRADING.md)
+Read the [upgrade guide](https://github.com/kairos-io/cluster-api-provider-kairos/blob/v0.1.0/docs/UPGRADING.md)
 before installing. This release has no breaking changes and no required
 migration steps from v0.1.0-beta.2.
 
@@ -16,16 +16,35 @@ migration steps from v0.1.0-beta.2.
   infrastructure provider — a peer to CAPD, CAPV, CAPK, and CAPM3. Fleet
   claims already-enrolled Kairos nodes from an AuroraBoot group rather than
   creating machines on demand. New: `docs/QUICKSTART_FLEET.md`, k3s and k0s
-  single-control-plane samples under `config/samples/fleet/`, and
+  control-plane-plus-worker samples under `config/samples/fleet/`, and
   `clusterctl.yaml` registration guidance in `docs/INSTALL.md`.
-- **No API, CRD, or `go.mod` change.** Fleet support required no new fields,
-  no CRD storage-version bump, and no build-time dependency on the fleet
-  provider's Go types — the bootstrap provider already routed fleet-backed
-  Machines through the generic non-KubeVirt cloud-config templates (shipped
-  before this release), and the control-plane provider resolves fleet's
-  `KairosFleetCluster` / `KairosFleetMachine` through the same
-  contract-versioned unstructured path used for every other infrastructure
-  provider.
+- **Worker `MachineDeployment`s now scale up on Kairos control planes, on
+  every infrastructure provider.** `KairosControlPlane.status.version` was
+  never set, so CAPI core's `ControlPlaneIsStable` preflight read every
+  Kairos control plane as perpetually provisioning and refused to create any
+  worker Machine. A control-plane-plus-worker (multi-node) cluster could
+  therefore never gain workers, on CAPD, CAPV, CAPK, CAPM3, or fleet alike.
+  Fixed by adding `status.version` per the CAPI control-plane contract (see
+  Bug Fixes). Both k0s and k3s control-plane-plus-worker clusters are now
+  validated on real hardware (Hadron v4.1.2, Kubernetes v1.36.1).
+- **A single k0s control plane defaults to joinable, not standalone.** A
+  `KairosControlPlane` with `replicas: 1` and `distribution: k0s` used to
+  render k0s `--single`, which refuses all worker joins. It now defaults to
+  `--enable-worker` on the generic / CAPV / CAPM3 / fleet render path, so a
+  control-plane-plus-worker k0s cluster works without extra configuration.
+  The standalone behavior is preserved as an opt-in via the new
+  `spec.k0sSingleNode` field (see New Features and Bug Fixes). CAPK is
+  unchanged.
+- **Two new CRD fields.** `KairosConfig`/`KairosConfigTemplate` gain
+  `spec.k0sSingleNode`, and `KairosControlPlane` gains `status.version`
+  (part of the CAPI control-plane contract). No storage-version bump, no
+  `go.mod` change, and no build-time dependency on the fleet provider's Go
+  types — fleet support itself required no new fields, since the bootstrap
+  provider already routed fleet-backed Machines through the generic
+  non-KubeVirt cloud-config templates, and the control-plane provider
+  resolves fleet's `KairosFleetCluster` / `KairosFleetMachine` through the
+  same contract-versioned unstructured path used for every other
+  infrastructure provider.
 
 ---
 
@@ -55,8 +74,11 @@ None in this release.
   `vspheremachines`, and `metal3machines`. The bootstrap provider needs no
   new grant: it neither Gets nor Watches `KairosFleetMachine` objects.
 - **Fleet samples and quickstart.** k3s (reference path) and k0s
-  single-control-plane-plus-worker samples under `config/samples/fleet/`,
-  and a full walkthrough at `docs/QUICKSTART_FLEET.md` covering
+  control-plane-plus-worker samples
+  (`kairos_cluster_{k0s,k3s}_with_workers.yaml`) under
+  `config/samples/fleet/`, plus a standalone-single-node k0s sample
+  (`kairos_cluster_k0s_single_node.yaml`) demonstrating `k0sSingleNode:
+  true`, and a full walkthrough at `docs/QUICKSTART_FLEET.md` covering
   prerequisites, the `KairosFleetMachine` `Ready`-reason state progression,
   kubeconfig retrieval, the `kairos-fleet://<node-id>` providerID
   cross-provider verification, and teardown.
@@ -84,6 +106,19 @@ None in this release.
 
 ## Bug Fixes
 
+- **Worker `MachineDeployment`s now scale up — on every infrastructure
+  provider, not just fleet.** `KairosControlPlaneStatus` had no `version`
+  field, so `status.version` was never set. CAPI core's `ControlPlaneIsStable`
+  preflight reads the control plane's `status.version` to decide whether it
+  is stable or mid-upgrade, and gates worker `MachineDeployment` scale-up on
+  it. With `status.version` unset, the preflight read every Kairos control
+  plane as perpetually provisioning and never created a worker Machine — so
+  a control-plane-plus-worker (multi-node) cluster could never add workers,
+  on CAPD, CAPV, CAPK, CAPM3, or fleet. Added `KairosControlPlaneStatus.Version`
+  (part of the CAPI control-plane contract), set to `spec.version` once at
+  least one control-plane member is ready. Found by the integrated multi-node
+  e2e on real hardware — single-node kind runs never exercised a worker
+  `MachineDeployment`, so the gap was invisible there.
 - **A single k0s control plane now accepts workers.** A `KairosControlPlane`
   with `spec.replicas: 1` and `distribution: k0s` rendered the k0s controller
   with `--single`, k0s's standalone all-in-one mode that refuses every join
@@ -177,13 +212,14 @@ endpoint keys on the group ID). Use the fleet release that includes these
 
 ## Compatibility
 
-See [README — Target Versions](https://github.com/kairos-io/cluster-api-provider-kairos/blob/v0.1.0-beta.3/README.md#target-versions)
+See [README — Target Versions](https://github.com/kairos-io/cluster-api-provider-kairos/blob/v0.1.0/README.md#target-versions)
 for the current matrix. No CAPI core, Kubernetes, controller-runtime, or
-`k8s.io/*` version change since v0.1.0-beta.2 — this release is docs,
-samples, and a small control-plane-provider honesty/UX change, not a
-toolchain bump.
+`k8s.io/*` version change since v0.1.0-beta.2 — this is not a toolchain bump.
+It adds Fleet infrastructure-provider support, a new opt-in `KairosConfig`
+field (`k0sSingleNode`), and a `KairosControlPlane` status field (`version`)
+— see Highlights, New Features, and Bug Fixes above.
 
-| Component | v0.1.0-beta.2 | v0.1.0-beta.3 |
+| Component | v0.1.0-beta.2 | v0.1.0 |
 | --- | --- | --- |
 | Cluster API core | v1.13.4 (v1beta2 contract) | v1.13.4 (unchanged) |
 | Kubernetes (management) | v1.30-v1.36 (v1.36 recommended) | v1.30-v1.36 (unchanged) |
@@ -207,5 +243,9 @@ management cluster and is not clusterctl-installable — see
 No action required for existing installs (flat manifest or `clusterctl`).
 Fleet support is additive: install the `kairos-fleet` infrastructure
 provider only if you intend to use it (see
-[docs/INSTALL.md — Registering the Kairos fleet infrastructure provider](https://github.com/kairos-io/cluster-api-provider-kairos/blob/v0.1.0-beta.3/docs/INSTALL.md#registering-the-kairos-fleet-infrastructure-provider)).
-Clusters already running on CAPD, CAPV, CAPK, or CAPM3 are unaffected.
+[docs/INSTALL.md — Registering the Kairos fleet infrastructure provider](https://github.com/kairos-io/cluster-api-provider-kairos/blob/v0.1.0/docs/INSTALL.md#registering-the-kairos-fleet-infrastructure-provider)).
+Clusters already running on CAPD, CAPV, CAPK, or CAPM3 are unaffected. If you
+run a control-plane-plus-worker cluster on any infrastructure provider and
+workers previously never scaled up, this release's `status.version` fix
+(see Bug Fixes) resolves it on the next `KairosControlPlane` reconcile — no
+manifest changes required.


### PR DESCRIPTION
## Summary

Documentation and sample prep for the v0.1.0 GA cut, folding the merged fleet
(#88) and multi-node fixes (#89) into the docs. No code, controllers,
templates, CRDs, or generated files are touched — docs and `config/samples/`
only. Driven by a docs audit; every item below is a correctness or
completeness fix, not cosmetic churn.

## Correctness fixes (were factually wrong post-#89)

- **`docs/API_REFERENCE.md`** — the `singleNode` row and "Single-Node Mode"
  note claimed k0s single-node always renders `--single`. That is no longer
  true on the generic / CAPV / CAPM3 / fleet path (now defaults to
  `--enable-worker`). Rewritten to be distribution- and
  infrastructure-accurate.
- **`README.md` / `docs/INSTALL.md` / `docs/QUICKSTART_FLEET.md`** — fleet
  provider floor corrected to `v0.1.0-beta.2+` (`beta.1` crash-loops on a
  real management cluster), and the "fleet support is unreleased" claim
  removed.

## New field coverage: `spec.k0sSingleNode`

- Documented in `docs/API_REFERENCE.md` (new row plus a `SingleNode` vs
  `K0sSingleNode` clarification) and `docs/QUICKSTART_FLEET.md`.
- New `config/samples/fleet/kairos_cluster_k0s_single_node.yaml` — a true
  standalone single node that sets `k0sSingleNode: true` (the field's only
  sample coverage).

## Samples

- The two fleet samples actually ship a control plane **plus** a worker
  `MachineDeployment`, but were named `*_single_node.yaml` with a
  contradictory "single control plane only" header. Renamed to
  `kairos_cluster_{k0s,k3s}_with_workers.yaml` with corrected headers; all
  doc references updated.

## Completeness and versioning

- **`CHANGELOG.md`** — backfilled the missing `v0.1.0-beta.1` and
  `v0.1.0-beta.2` entries and added the `v0.1.0` GA entry (fleet support,
  `k0sSingleNode`, and the `status.version` worker-scale-up fix).
- **`docs/TESTING.md`** — added a Fleet row to the supported-configurations
  table (control plane + worker validated on real hardware; HA not
  exercised).
- Renamed the never-tagged `v0.1.0-beta.3` release notes to `v0.1.0.md` and
  bumped every "Last verified against" header and install/release reference
  to `v0.1.0`.

## Validation

- All touched sample YAML parses as well-formed multi-document YAML.
- No `§` character, no emoji; all internal doc links and sample paths
  resolve.