### PR TITLE
ci(release): publish a clean vX.Y.Z tag as a full release (v0.1.0 GA prep)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -104,7 +104,11 @@ jobs:
           name: ${{ github.ref_name }}
           tag_name: ${{ github.ref_name }}
           body_path: docs/release-notes/${{ github.ref_name }}.md
-          prerelease: true
+          # Pre-release tags carry a suffix (-alpha.N, -beta.N, -rc.N) and publish
+          # as GitHub pre-releases; a clean vX.Y.Z tag (e.g. the v0.1.0 GA) publishes
+          # as a full release so it surfaces as "Latest release" instead of being
+          # hidden as a preview.
+          prerelease: ${{ contains(github.ref_name, '-') }}
           draft: false
           files: |
             dist/bootstrap-components.yaml

--- a/Makefile
+++ b/Makefile
@@ -226,6 +226,9 @@ GOLANGCI_LINT_VERSION ?= v1.60.0
 # Pinned so `make test-envtest` is reproducible (rule 4: no unpinned @latest / floating envtest assets).
 # ENVTEST_K8S_VERSION is the Kubernetes API-server/etcd binary version the controllers are tested
 # against; 1.36 is the top of Cluster API v1.13's supported management-cluster band. Bump deliberately.
+# NOTE: the k8s.io/* CLIENT libraries in go.mod are v0.35.x (Kubernetes 1.35) — the version Cluster
+# API v1.13.4 itself pins. Testing against a 1.36 apiserver here is intentional, supported client/server
+# skew (one minor), NOT a mismatch to "fix" by bumping go.mod: MVS would revert it to CAPI's requirement.
 SETUP_ENVTEST_VERSION ?= v0.24.1
 ENVTEST_K8S_VERSION ?= 1.36.2
 


### PR DESCRIPTION
## Summary

Release-mechanics prep for the v0.1.0 GA tag. Two small changes; no provider
code, CRDs, or generated files touched.

- **`.github/workflows/release.yaml`** — the release workflow hardcoded
  `prerelease: true`, so tagging `v0.1.0` would publish the GA as a GitHub
  **pre-release** (hidden from "Latest release"). Made it conditional:
  `prerelease: ${{ contains(github.ref_name, '-') }}` — a clean `vX.Y.Z` tag
  publishes as a full release; `-alpha.N` / `-beta.N` / `-rc.N` tags stay
  pre-releases.
- **`Makefile`** — documented, next to `ENVTEST_K8S_VERSION`, that the
  `k8s.io/*` client libraries in `go.mod` (`v0.35.x` / Kubernetes 1.35) are
  intentionally one minor below the 1.36 apiserver envtest tests against:
  1.35 is exactly what Cluster API `v1.13.4` pins, so this is supported
  client/server skew, not a mismatch to reconcile by bumping `go.mod`.

## Why the rest of the release path needs no change

Verified by a local `make release-manifests` dry-run:

- `dist/` is `.gitignore`d and fully **regenerated** by the release workflow
  on tag push — the stale local `dist/*` files are not shipped.
- The workflow builds the image, resolves its digest, and renders all four
  shipped artifacts (`bootstrap-components.yaml`,
  `control-plane-components.yaml`, `kairos-capi-provider.yaml`,
  `metadata.yaml`) digest-pinned, then **fails the release if any image ref
  is not `@sha256`-pinned**.
- `sha256sums.txt` covers all four artifacts (the current `release-manifests`
  target hashes them all).
- `dist/metadata.yaml` is copied from `config/clusterctl/metadata.yaml`,
  which is already a valid `v1alpha3` document with the `0.1` / `v1beta2`
  release series.

## Release sequence (after this + the docs PR merge)

Tagging `v0.1.0` on `main` triggers the workflow, which requires
`docs/release-notes/v0.1.0.md` on the tagged commit (added by the GA docs PR).