### PR TITLE
docs: point install/version references at the v0.1.0 GA release

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Provide node credentials via `userPasswordSecretRef` (recommended) or `sshPublic
 | CAPV | v1.11.x+ |
 | CAPK | KubeVirt v1.9.x / CAPK v0.1.x |
 | CAPM3 | v1.13+; BMO/Ironic v0.13+ |
-| kairos-fleet | v0.1.0-beta.2+ (`cluster-api-provider-kairos-fleet`); AuroraBoot — do not use v0.1.0-beta.1, it crash-loops on a real management cluster |
+| kairos-fleet | v0.1.0+ (`cluster-api-provider-kairos-fleet`); AuroraBoot — do not use v0.1.0-beta.1, it crash-loops on a real management cluster |
 | k0s | ~v1.36.1+k0s |
 | k3s | ~v1.36.1+k3s1 |
 | Kairos | v4.1.2 (standard and Hadron images) |

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -3,7 +3,7 @@
 Last verified against: Kairos v3.6.0+, CAPI v1.13.4, cert-manager v1.15+,
 provider v0.1.0. The "Registering the Kairos fleet infrastructure
 provider" section below documents `cluster-api-provider-kairos-fleet`
-v0.1.0-beta.2's own `clusterctl.yaml` entry; it has not been re-verified by
+v0.1.0's own `clusterctl.yaml` entry; it has not been re-verified by
 running `clusterctl init --infrastructure kairos-fleet` in this repository's
 CI — see [docs/QUICKSTART_FLEET.md](QUICKSTART_FLEET.md) for the same
 caveat. Do not use fleet provider `v0.1.0-beta.1`: it crash-loops on a real
@@ -58,7 +58,7 @@ providers:
 ```
 
 Point `url` at a specific tag instead of `latest` to pin a version, for
-example `.../releases/download/v0.1.0-beta.2/infrastructure-components.yaml`.
+example `.../releases/download/v0.1.0/infrastructure-components.yaml`.
 Do not pin `v0.1.0-beta.1`: that release crash-loops on a real management
 cluster and is not clusterctl-installable. Fleet claims already-enrolled
 AuroraBoot nodes rather than creating machines on demand; see

--- a/docs/QUICKSTART_CAPD.md
+++ b/docs/QUICKSTART_CAPD.md
@@ -28,7 +28,7 @@ Install CAPI and CAPD using your preferred method. See the [Cluster API book](ht
 **Recommended (released artifact):**
 
 ```bash
-kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-beta.2/kairos-capi-provider.yaml
+kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0/kairos-capi-provider.yaml
 ```
 
 **Developer install (from source):**

--- a/docs/QUICKSTART_CAPK.md
+++ b/docs/QUICKSTART_CAPK.md
@@ -167,7 +167,7 @@ This walkthrough uses the flat manifest (`kubectl apply -f kairos-capi-provider.
   - A LoadBalancer implementation (MetalLB or equivalent)
 - Kairos CAPI provider installed:
   ```bash
-  kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-beta.2/kairos-capi-provider.yaml
+  kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0/kairos-capi-provider.yaml
   ```
 - A Kairos image uploaded to CDI as a DataVolume named `kairos-rootdisk` (for k0s) or `kairos-k3s-rootdisk` (for k3s) in namespace `default`. The image must be a Kairos live-installer image — not a pre-installed disk image.
 

--- a/docs/QUICKSTART_CAPM3.md
+++ b/docs/QUICKSTART_CAPM3.md
@@ -206,7 +206,7 @@ The k3s or k0s version is fixed at image-build time. `KairosControlPlane.spec.ve
    kubectl get crd metal3clusters.infrastructure.cluster.x-k8s.io
    ```
 
-5. **Kairos CAPI Provider**: v0.1.0-beta.2+ installed (see [INSTALL.md](INSTALL.md)).
+5. **Kairos CAPI Provider**: v0.1.0+ installed (see [INSTALL.md](INSTALL.md)).
 
 6. **Fully-installed Kairos disk image**: See "Building the disk image" above.
 
@@ -221,7 +221,7 @@ The k3s or k0s version is fixed at image-build time. `KairosControlPlane.spec.ve
 Install CAPM3 using `clusterctl` or the upstream manifests. Refer to the [Metal3 documentation](https://book.metal3.io/capm3/introduction) for the current install procedure. The Kairos CAPI provider is installed separately:
 
 ```bash
-kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-beta.2/kairos-capi-provider.yaml
+kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0/kairos-capi-provider.yaml
 ```
 
 See [INSTALL.md](INSTALL.md) for the full provider install and verification steps.

--- a/docs/QUICKSTART_CAPV.md
+++ b/docs/QUICKSTART_CAPV.md
@@ -69,7 +69,7 @@ kubectl label namespace default vsphere-identity=allowed
 **Recommended (released artifact):**
 
 ```bash
-kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0-beta.2/kairos-capi-provider.yaml
+kubectl apply -f https://github.com/kairos-io/cluster-api-provider-kairos/releases/download/v0.1.0/kairos-capi-provider.yaml
 ```
 
 **Developer install (from source):**

--- a/docs/QUICKSTART_FLEET.md
+++ b/docs/QUICKSTART_FLEET.md
@@ -1,6 +1,6 @@
 # Quick Start Guide - Fleet (Kairos fleet / AuroraBoot)
 
-Last verified against: Kairos fleet provider v0.1.0-beta.2+
+Last verified against: Kairos fleet provider v0.1.0+
 (`cluster-api-provider-kairos-fleet`; do not use `v0.1.0-beta.1`, it
 crash-loops on a real management cluster), this repository's fleet-support
 code (ADR 0008, shipped in v0.1.0 — see the

--- a/docs/release-notes/v0.1.0.md
+++ b/docs/release-notes/v0.1.0.md
@@ -173,7 +173,7 @@ the generated metrics Service name was shortened under the 63-character limit
 so `clusterctl init` can apply it, and the provider resolves
 `KairosFleetMachine.spec.group` by name before claiming (AuroraBoot's claim
 endpoint keys on the group ID). Use the fleet release that includes these
-(v0.1.0-beta.2 or later), not v0.1.0-beta.1.
+(v0.1.0 or later), not v0.1.0-beta.1.
 
 ### Carried forward from v0.1.0-beta.2
 
@@ -227,11 +227,11 @@ field (`k0sSingleNode`), and a `KairosControlPlane` status field (`version`)
 | Kairos | v4.1.2 | v4.1.2 (unchanged) |
 | controller-runtime | v0.23.3 | v0.23.3 (unchanged) |
 | k8s.io/* | v0.35.4 | v0.35.4 (unchanged) |
-| kairos-fleet (`cluster-api-provider-kairos-fleet`) | not supported | v0.1.0-beta.2+ (new) |
+| kairos-fleet (`cluster-api-provider-kairos-fleet`) | not supported | v0.1.0+ (new) |
 
 The fleet provider is a separate release series maintained in its own
 repository; this repo takes no build-time dependency on it and does not pin
-its version. Use **v0.1.0-beta.2 or later** (same CAPI v1.13.4 / v1beta2
+its version. Use **v0.1.0 or later** (same CAPI v1.13.4 / v1beta2
 contract): the earlier v0.1.0-beta.1 controller crash-loops on a real
 management cluster and is not clusterctl-installable — see
 [Requires a fixed fleet provider release](#requires-a-fixed-fleet-provider-release).


### PR DESCRIPTION
## Summary

Post-GA doc cleanup: correct references that still pointed at a pre-release now
that both providers have shipped `v0.1.0` GA. Docs only.

- **The per-provider quickstarts (CAPD, CAPK, CAPM3, CAPV) still installed the
  `v0.1.0-beta.2` flat manifest** — a reader following a quickstart would
  install the superseded beta instead of the GA. Bumped those `kubectl apply`
  URLs (and CAPM3's `v0.1.0-beta.2+ installed` prerequisite) to `v0.1.0`.
- **The fleet infrastructure provider shipped `v0.1.0` GA directly** (there is
  no fleet `v0.1.0-beta.2`), so the "fleet floor `v0.1.0-beta.2+`" references
  in README, INSTALL, QUICKSTART_FLEET, and the `v0.1.0` release notes (three
  spots) now read `v0.1.0+`. The do-not-use-`beta.1` warning stays.

Historical `v0.1.0-beta.2` references are intentionally left untouched:
UPGRADING's `beta.1 → beta.2` section, the `beta.2` release-notes file, and
the `v0.1.0` notes' own `beta.2 → v0.1.0` comparison table.