### PR TITLE
chore(clusterctl): set the provider identity to kairos-io (for upstream registration)

### DIFF
--- a/config/bootstrap/kustomization.yaml
+++ b/config/bootstrap/kustomization.yaml
@@ -35,7 +35,7 @@ namespace: capi-kairos-bootstrap-system
 labels:
   - includeSelectors: false
     pairs:
-      cluster.x-k8s.io/provider: bootstrap-kairos
+      cluster.x-k8s.io/provider: bootstrap-kairos-io
       app.kubernetes.io/name: capi-kairos-bootstrap
       app.kubernetes.io/component: controller-manager
 

--- a/config/control-plane/kustomization.yaml
+++ b/config/control-plane/kustomization.yaml
@@ -34,7 +34,7 @@ namespace: capi-kairos-control-plane-system
 labels:
   - includeSelectors: false
     pairs:
-      cluster.x-k8s.io/provider: control-plane-kairos
+      cluster.x-k8s.io/provider: control-plane-kairos-io
       app.kubernetes.io/name: capi-kairos-control-plane
       app.kubernetes.io/component: controller-manager
 


### PR DESCRIPTION
## Summary

Prepares the provider for registration in the upstream `clusterctl` built-in
provider list. Changes the `cluster.x-k8s.io/provider` label on the
**clusterctl bootstrap and control-plane components** from `bootstrap-kairos` /
`control-plane-kairos` to **`bootstrap-kairos-io` / `control-plane-kairos-io`**,
so the provider self-identifies under the name we will register upstream:
`kairos-io` (matching the `kairos-io` GitHub org and the org-scoped convention
other providers use, e.g. `kubeswift-io`).

## Why it's safe

The label is applied with `labels: includeSelectors: false`, so only each
component's `metadata.labels` change. Verified with `kustomize build`:

- All provider labels in `config/bootstrap` → `bootstrap-kairos-io`, in
  `config/control-plane` → `control-plane-kairos-io`.
- The manager `Deployment.spec.selector.matchLabels` stays
  `{control-plane: controller-manager}` — unchanged and still matching its pod
  template, so the Deployment remains valid.

The flat `kubectl apply` manifest (`config/default`) keeps its existing
`kairos` identity; it is not a `clusterctl` provider and is unaffected.

## Follow-up

This ships in v0.1.1. After it releases, the upstream `clusterctl` registration
(a `kubernetes-sigs/cluster-api` PR adding `kairos-io` to the built-in bootstrap
and control-plane lists) points `clusterctl init --bootstrap kairos-io
--control-plane kairos-io` at this release. The repo's own install docs will be
updated to the `kairos-io` name in a separate docs PR.