### PR TITLE
docs(release): v0.1.1 release notes and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ This project is pre-1.0. Alpha releases may include breaking changes; those are
 called out explicitly under **Breaking changes**. Per-scenario migration steps
 live in [docs/UPGRADING.md](docs/UPGRADING.md).
 
+## [v0.1.1] — 2026-08-10
+
+A small maintenance release; no functional change to the controllers or CRDs.
+No migration steps from v0.1.0. See the
+[v0.1.1 release notes](docs/release-notes/v0.1.1.md).
+
+### Changed
+
+- The clusterctl provider identity is now `kairos-io`: the
+  `cluster.x-k8s.io/provider` label on the clusterctl bootstrap and
+  control-plane components changed from `bootstrap-kairos` /
+  `control-plane-kairos` to `bootstrap-kairos-io` / `control-plane-kairos-io`,
+  ahead of registering the provider in the upstream clusterctl built-in list as
+  `kairos-io`. Applied with `includeSelectors: false`, so Deployment selectors
+  are unchanged. The flat `kubectl apply` manifest keeps its `kairos` identity.
+- Docs: corrected stale `v0.1.0-beta.2` install references to `v0.1.0` and the
+  fleet-provider floor to `v0.1.0+`.
+
 ## [v0.1.0] — 2026-08-10
 
 The first non-beta 0.1.0 release. Adds the **Kairos fleet (AuroraBoot)
@@ -333,6 +351,7 @@ CAPD (Docker), CAPV (vSphere), and CAPK (KubeVirt). See the
 [release notes](docs/release-notes/v0.1.0-alpha.1.md) for the full feature list
 and the alpha-1 security notices.
 
+[v0.1.1]: https://github.com/kairos-io/cluster-api-provider-kairos/releases/tag/v0.1.1
 [v0.1.0]: https://github.com/kairos-io/cluster-api-provider-kairos/releases/tag/v0.1.0
 [v0.1.0-beta.2]: https://github.com/kairos-io/cluster-api-provider-kairos/releases/tag/v0.1.0-beta.2
 [v0.1.0-beta.1]: https://github.com/kairos-io/cluster-api-provider-kairos/releases/tag/v0.1.0-beta.1

--- a/docs/release-notes/v0.1.1.md
+++ b/docs/release-notes/v0.1.1.md
@@ -1,0 +1,38 @@
+# v0.1.1 — Release Notes
+
+A small maintenance release. No functional change to the controllers or CRDs.
+There are no required migration steps from v0.1.0.
+
+## Highlights
+
+- **The clusterctl provider identity is now `kairos-io`.** The
+  `cluster.x-k8s.io/provider` label on the clusterctl bootstrap and
+  control-plane components changed from `bootstrap-kairos` /
+  `control-plane-kairos` to `bootstrap-kairos-io` / `control-plane-kairos-io`,
+  in preparation for registering the provider in the upstream clusterctl
+  built-in provider list under the name `kairos-io`. Install with
+  `clusterctl init --bootstrap kairos-io --control-plane kairos-io`. The
+  controller image, CRDs, RBAC, and webhooks are unchanged; the label is
+  applied with `includeSelectors: false`, so Deployment selectors are not
+  affected and the components remain self-consistent.
+
+## Changed
+
+- Provider label to `kairos-io` (see Highlights). The flat `kubectl apply`
+  manifest keeps its existing `kairos` identity; it is not a clusterctl
+  provider and is unaffected.
+- Docs: corrected stale `v0.1.0-beta.2` install references to `v0.1.0`, and the
+  Kairos fleet provider floor to `v0.1.0+` (the fleet infrastructure provider
+  shipped v0.1.0 GA directly, without a beta.2).
+
+## Upgrade notes
+
+From v0.1.0 there are no migration steps. A `clusterctl upgrade` (or
+re-applying the release manifest) picks up the new labels. If you configured
+the provider locally under the name `kairos`, update the name to `kairos-io`.
+
+## Versions
+
+Unchanged from v0.1.0: Cluster API v1.13.4 (v1beta2 contract), management and
+workload Kubernetes v1.30 to v1.36, Kairos v4.1.2. See the full table in the
+[v0.1.0 release notes](v0.1.0.md#versions).


### PR DESCRIPTION
Adds `docs/release-notes/v0.1.1.md` (required by the release workflow) and the `[v0.1.1]` CHANGELOG entry for the upcoming v0.1.1 maintenance tag (the `kairos-io` provider-identity relabel from #93 plus the v0.1.0 doc corrections). No code change.