### PR TITLE
docs: point bug reports at kairos-io/kairos

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 **Repository:** [github.com/kairos-io/cluster-api-provider-kairos](https://github.com/kairos-io/cluster-api-provider-kairos)
 
+> **Found a bug, or want to request a feature?** Open it on
+> [kairos-io/kairos](https://github.com/kairos-io/kairos/issues), including
+> issues about this repository. Every Kairos issue lives in one place, so you
+> never have to work out which repository to file against.
+
 ## Overview
 
 This project provides two Cluster API (CAPI) providers for managing Kubernetes clusters on Kairos:


### PR DESCRIPTION
Adds the reporting pointer to the README, same wording already used on AuroraBoot, hadron and kairos-docs. Every Kairos issue lives in kairos-io/kairos now, whichever repository it is about.

Refs kairos-io/kairos#4364