### PR TITLE
fix: support any CAPI-conformant infrastructure provider end to end

### DIFF
--- a/config/rbac/bootstrap/role.yaml
+++ b/config/rbac/bootstrap/role.yaml
@@ -109,24 +109,9 @@ rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io
   resources:
-  - dockermachines
-  - vspheremachines/status
+  - '*'
   verbs:
   - get
-- apiGroups:
-  - infrastructure.cluster.x-k8s.io
-  resources:
-  - kubevirtmachines
-  - vspheremachines
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - infrastructure.cluster.x-k8s.io
-  resources:
-  - metal3machines
-  verbs:
   - list
   - watch
 - apiGroups:

--- a/config/rbac/control-plane/role.yaml
+++ b/config/rbac/control-plane/role.yaml
@@ -107,27 +107,12 @@ rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io
   resources:
-  - dockermachines
-  - kairosfleetmachines
-  - kubevirtmachines
-  - metal3machines
-  - vspheremachines
+  - '*'
   verbs:
   - create
+  - delete
   - get
-- apiGroups:
-  - infrastructure.cluster.x-k8s.io
-  resources:
-  - dockermachines/status
-  - dockermachinetemplates
-  - kairosfleetmachines/status
-  - kairosfleetmachinetemplates
-  - kubevirtmachines/status
-  - kubevirtmachinetemplates
-  - metal3machines/status
-  - metal3machinetemplates
-  - vspheremachines/status
-  - vspheremachinetemplates
-  - vspherevms
-  verbs:
-  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -134,37 +134,14 @@ rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io
   resources:
-  - dockermachines
-  - kairosfleetmachines
+  - '*'
   verbs:
   - create
-  - get
-- apiGroups:
-  - infrastructure.cluster.x-k8s.io
-  resources:
-  - dockermachines/status
-  - dockermachinetemplates
-  - kairosfleetmachines/status
-  - kairosfleetmachinetemplates
-  - kubevirtmachines/status
-  - kubevirtmachinetemplates
-  - metal3machines/status
-  - metal3machinetemplates
-  - vspheremachines/status
-  - vspheremachinetemplates
-  - vspherevms
-  verbs:
-  - get
-- apiGroups:
-  - infrastructure.cluster.x-k8s.io
-  resources:
-  - kubevirtmachines
-  - metal3machines
-  - vspheremachines
-  verbs:
-  - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - kubevirt.io

--- a/internal/bootstrap/template_test.go
+++ b/internal/bootstrap/template_test.go
@@ -1643,3 +1643,48 @@ func TestRenderMetal3_NonMetal3RendersUnchanged(t *testing.T) {
 		})
 	}
 }
+
+// TestNoUnguardedVSphereProviderIDMint is a structural invariant, not a snapshot:
+// wherever a rendered cloud-config MINTS a providerID by reading the local DMI
+// product_uuid, that mint must be preceded by a vendor guard proving the node is
+// actually on vSphere.
+//
+// The catch-all render branch is "not Metal3, not fleet", which covers beskar7 and
+// any other third-party infrastructure provider — and every VM plus most bare
+// metal exposes a DMI product_uuid, so an unguarded mint hands those nodes
+// vsphere://<their-own-uuid>. Node.spec.providerID is immutable once the node
+// registers, so the node can never be matched to its Machine and the Machine never
+// leaves Provisioning.
+//
+// Reproduced on a beskar7 bare-metal k0s HA lab, 2026-09-08: sys_vendor "QEMU",
+// Node.spec.providerID set to vsphere://ecf16ed9-0c6a-a944-bf46-d1193f3ca762. The
+// k3s template had carried the guard since the CAPV fix; the k0s template had not,
+// which is exactly the drift this test exists to catch. It asserts the property
+// across BOTH distributions and BOTH infra variants, so a future mint added to any
+// one of the four templates cannot ship unguarded.
+func TestNoUnguardedVSphereProviderIDMint(t *testing.T) {
+	const mint = `PROVIDER_ID="vsphere://`
+	const guard = "sys_vendor"
+
+	for _, tc := range goldenCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := tc.render(tc.data)
+			if err != nil {
+				t.Fatalf("render: %v", err)
+			}
+			rest := out
+			for n := 1; ; n++ {
+				i := strings.Index(rest, mint)
+				if i < 0 {
+					return // no (more) mints in this render
+				}
+				if !strings.Contains(rest[:i], guard) {
+					t.Errorf("mint #%d of %q is not preceded by a %q vendor guard — "+
+						"a non-vSphere node would be given vsphere://<its own DMI uuid>, "+
+						"which is immutable once the Node registers", n, mint, guard)
+				}
+				rest = rest[i+len(mint):]
+			}
+		})
+	}
+}

--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
@@ -632,7 +632,20 @@ MANIFEST_EOF
       # used in the k3s CAPV template.
       export KUBECONFIG=/var/lib/k0s/pki/admin.conf
       PROVIDER_ID=""
-      if [ -f /sys/class/dmi/id/product_uuid ]; then
+      # This branch is the CATCH-ALL for every non-Metal3, non-Fleet provider, not
+      # just CAPV — so it must prove it is on vSphere before minting a vsphere://
+      # providerID. Every VM and most bare metal exposes a DMI product_uuid, so
+      # without this guard a beskar7 (or any other) node is handed
+      # vsphere://<its-own-DMI-uuid>. Node.spec.providerID is IMMUTABLE once the
+      # node registers, so a wrong value permanently breaks Machine-to-Node
+      # matching and the Machine never leaves Provisioning.
+      #
+      # Same guard as the k3s CAPV template; reproduced on a beskar7 bare-metal
+      # k0s HA lab on 2026-09-08, where this branch was the only providerID path
+      # the render produced.
+      if [ -r /sys/class/dmi/id/sys_vendor ] && ! grep -qi vmware /sys/class/dmi/id/sys_vendor; then
+        echo "not a VMware VM; leaving providerID to the infrastructure provider"
+      elif [ -f /sys/class/dmi/id/product_uuid ]; then
         RAW=$(cat /sys/class/dmi/id/product_uuid | tr -d ' \n\r')
         HEX=$(echo "$RAW" | tr -d '-' | tr '[:upper:]' '[:lower:]')
         if [ -n "$HEX" ] && [ ${#HEX} -eq 32 ]; then

--- a/internal/bootstrap/templates/k3s_kairos_cloud_config_capv.yaml.tmpl
+++ b/internal/bootstrap/templates/k3s_kairos_cloud_config_capv.yaml.tmpl
@@ -444,6 +444,23 @@ write_files:
     content: |
       #!/bin/bash
       set -e
+      # vSphere-only. This template is the DEFAULT for every infrastructure
+      # provider that is not KubeVirt, so it also renders for Metal3, CAPD and
+      # any third-party provider. Fabricating a vsphere:// providerID on those
+      # is actively harmful: Node.spec.providerID is IMMUTABLE once the node
+      # registers, so a wrong value permanently breaks Machine-to-Node matching
+      # and the Machine never leaves Provisioning.
+      if [ -r /sys/class/dmi/id/sys_vendor ] && ! grep -qi vmware /sys/class/dmi/id/sys_vendor; then
+        echo "not a VMware VM; leaving providerID to the infrastructure provider"
+        exit 0
+      fi
+      # Never clobber a providerID the controller already wrote: the bootstrap
+      # config is re-rendered once the infra provider assigns one, and this
+      # script runs on every k3s start.
+      if [ -s /etc/rancher/k3s/config.yaml.d/90-provider-id.yaml ]; then
+        echo "providerID already set; leaving it alone"
+        exit 0
+      fi
       # Read DMI product_uuid (vSphere VMs expose VM UUID here)
       # DMI uses mixed-endian for first 3 groups; vSphere expects RFC/ISO (big-endian) - convert byte order
       if [ -f /sys/class/dmi/id/product_uuid ]; then

--- a/internal/bootstrap/testdata/golden/k0s_capv_init.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capv_init.yaml
@@ -340,7 +340,20 @@ write_files:
       # used in the k3s CAPV template.
       export KUBECONFIG=/var/lib/k0s/pki/admin.conf
       PROVIDER_ID=""
-      if [ -f /sys/class/dmi/id/product_uuid ]; then
+      # This branch is the CATCH-ALL for every non-Metal3, non-Fleet provider, not
+      # just CAPV — so it must prove it is on vSphere before minting a vsphere://
+      # providerID. Every VM and most bare metal exposes a DMI product_uuid, so
+      # without this guard a beskar7 (or any other) node is handed
+      # vsphere://<its-own-DMI-uuid>. Node.spec.providerID is IMMUTABLE once the
+      # node registers, so a wrong value permanently breaks Machine-to-Node
+      # matching and the Machine never leaves Provisioning.
+      #
+      # Same guard as the k3s CAPV template; reproduced on a beskar7 bare-metal
+      # k0s HA lab on 2026-09-08, where this branch was the only providerID path
+      # the render produced.
+      if [ -r /sys/class/dmi/id/sys_vendor ] && ! grep -qi vmware /sys/class/dmi/id/sys_vendor; then
+        echo "not a VMware VM; leaving providerID to the infrastructure provider"
+      elif [ -f /sys/class/dmi/id/product_uuid ]; then
         RAW=$(cat /sys/class/dmi/id/product_uuid | tr -d ' \n\r')
         HEX=$(echo "$RAW" | tr -d '-' | tr '[:upper:]' '[:lower:]')
         if [ -n "$HEX" ] && [ ${#HEX} -eq 32 ]; then

--- a/internal/bootstrap/testdata/golden/k0s_capv_join.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capv_join.yaml
@@ -343,7 +343,20 @@ write_files:
       # used in the k3s CAPV template.
       export KUBECONFIG=/var/lib/k0s/pki/admin.conf
       PROVIDER_ID=""
-      if [ -f /sys/class/dmi/id/product_uuid ]; then
+      # This branch is the CATCH-ALL for every non-Metal3, non-Fleet provider, not
+      # just CAPV — so it must prove it is on vSphere before minting a vsphere://
+      # providerID. Every VM and most bare metal exposes a DMI product_uuid, so
+      # without this guard a beskar7 (or any other) node is handed
+      # vsphere://<its-own-DMI-uuid>. Node.spec.providerID is IMMUTABLE once the
+      # node registers, so a wrong value permanently breaks Machine-to-Node
+      # matching and the Machine never leaves Provisioning.
+      #
+      # Same guard as the k3s CAPV template; reproduced on a beskar7 bare-metal
+      # k0s HA lab on 2026-09-08, where this branch was the only providerID path
+      # the render produced.
+      if [ -r /sys/class/dmi/id/sys_vendor ] && ! grep -qi vmware /sys/class/dmi/id/sys_vendor; then
+        echo "not a VMware VM; leaving providerID to the infrastructure provider"
+      elif [ -f /sys/class/dmi/id/product_uuid ]; then
         RAW=$(cat /sys/class/dmi/id/product_uuid | tr -d ' \n\r')
         HEX=$(echo "$RAW" | tr -d '-' | tr '[:upper:]' '[:lower:]')
         if [ -n "$HEX" ] && [ ${#HEX} -eq 32 ]; then

--- a/internal/bootstrap/testdata/golden/k0s_capv_single.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capv_single.yaml
@@ -106,7 +106,20 @@ write_files:
       # used in the k3s CAPV template.
       export KUBECONFIG=/var/lib/k0s/pki/admin.conf
       PROVIDER_ID=""
-      if [ -f /sys/class/dmi/id/product_uuid ]; then
+      # This branch is the CATCH-ALL for every non-Metal3, non-Fleet provider, not
+      # just CAPV — so it must prove it is on vSphere before minting a vsphere://
+      # providerID. Every VM and most bare metal exposes a DMI product_uuid, so
+      # without this guard a beskar7 (or any other) node is handed
+      # vsphere://<its-own-DMI-uuid>. Node.spec.providerID is IMMUTABLE once the
+      # node registers, so a wrong value permanently breaks Machine-to-Node
+      # matching and the Machine never leaves Provisioning.
+      #
+      # Same guard as the k3s CAPV template; reproduced on a beskar7 bare-metal
+      # k0s HA lab on 2026-09-08, where this branch was the only providerID path
+      # the render produced.
+      if [ -r /sys/class/dmi/id/sys_vendor ] && ! grep -qi vmware /sys/class/dmi/id/sys_vendor; then
+        echo "not a VMware VM; leaving providerID to the infrastructure provider"
+      elif [ -f /sys/class/dmi/id/product_uuid ]; then
         RAW=$(cat /sys/class/dmi/id/product_uuid | tr -d ' \n\r')
         HEX=$(echo "$RAW" | tr -d '-' | tr '[:upper:]' '[:lower:]')
         if [ -n "$HEX" ] && [ ${#HEX} -eq 32 ]; then

--- a/internal/bootstrap/testdata/golden/k3s_capv_init.yaml
+++ b/internal/bootstrap/testdata/golden/k3s_capv_init.yaml
@@ -268,6 +268,23 @@ write_files:
     content: |
       #!/bin/bash
       set -e
+      # vSphere-only. This template is the DEFAULT for every infrastructure
+      # provider that is not KubeVirt, so it also renders for Metal3, CAPD and
+      # any third-party provider. Fabricating a vsphere:// providerID on those
+      # is actively harmful: Node.spec.providerID is IMMUTABLE once the node
+      # registers, so a wrong value permanently breaks Machine-to-Node matching
+      # and the Machine never leaves Provisioning.
+      if [ -r /sys/class/dmi/id/sys_vendor ] && ! grep -qi vmware /sys/class/dmi/id/sys_vendor; then
+        echo "not a VMware VM; leaving providerID to the infrastructure provider"
+        exit 0
+      fi
+      # Never clobber a providerID the controller already wrote: the bootstrap
+      # config is re-rendered once the infra provider assigns one, and this
+      # script runs on every k3s start.
+      if [ -s /etc/rancher/k3s/config.yaml.d/90-provider-id.yaml ]; then
+        echo "providerID already set; leaving it alone"
+        exit 0
+      fi
       # Read DMI product_uuid (vSphere VMs expose VM UUID here)
       # DMI uses mixed-endian for first 3 groups; vSphere expects RFC/ISO (big-endian) - convert byte order
       if [ -f /sys/class/dmi/id/product_uuid ]; then

--- a/internal/bootstrap/testdata/golden/k3s_capv_join.yaml
+++ b/internal/bootstrap/testdata/golden/k3s_capv_join.yaml
@@ -261,6 +261,23 @@ write_files:
     content: |
       #!/bin/bash
       set -e
+      # vSphere-only. This template is the DEFAULT for every infrastructure
+      # provider that is not KubeVirt, so it also renders for Metal3, CAPD and
+      # any third-party provider. Fabricating a vsphere:// providerID on those
+      # is actively harmful: Node.spec.providerID is IMMUTABLE once the node
+      # registers, so a wrong value permanently breaks Machine-to-Node matching
+      # and the Machine never leaves Provisioning.
+      if [ -r /sys/class/dmi/id/sys_vendor ] && ! grep -qi vmware /sys/class/dmi/id/sys_vendor; then
+        echo "not a VMware VM; leaving providerID to the infrastructure provider"
+        exit 0
+      fi
+      # Never clobber a providerID the controller already wrote: the bootstrap
+      # config is re-rendered once the infra provider assigns one, and this
+      # script runs on every k3s start.
+      if [ -s /etc/rancher/k3s/config.yaml.d/90-provider-id.yaml ]; then
+        echo "providerID already set; leaving it alone"
+        exit 0
+      fi
       # Read DMI product_uuid (vSphere VMs expose VM UUID here)
       # DMI uses mixed-endian for first 3 groups; vSphere expects RFC/ISO (big-endian) - convert byte order
       if [ -f /sys/class/dmi/id/product_uuid ]; then

--- a/internal/bootstrap/testdata/golden/k3s_capv_single.yaml
+++ b/internal/bootstrap/testdata/golden/k3s_capv_single.yaml
@@ -90,6 +90,23 @@ write_files:
     content: |
       #!/bin/bash
       set -e
+      # vSphere-only. This template is the DEFAULT for every infrastructure
+      # provider that is not KubeVirt, so it also renders for Metal3, CAPD and
+      # any third-party provider. Fabricating a vsphere:// providerID on those
+      # is actively harmful: Node.spec.providerID is IMMUTABLE once the node
+      # registers, so a wrong value permanently breaks Machine-to-Node matching
+      # and the Machine never leaves Provisioning.
+      if [ -r /sys/class/dmi/id/sys_vendor ] && ! grep -qi vmware /sys/class/dmi/id/sys_vendor; then
+        echo "not a VMware VM; leaving providerID to the infrastructure provider"
+        exit 0
+      fi
+      # Never clobber a providerID the controller already wrote: the bootstrap
+      # config is re-rendered once the infra provider assigns one, and this
+      # script runs on every k3s start.
+      if [ -s /etc/rancher/k3s/config.yaml.d/90-provider-id.yaml ]; then
+        echo "providerID already set; leaving it alone"
+        exit 0
+      fi
       # Read DMI product_uuid (vSphere VMs expose VM UUID here)
       # DMI uses mixed-endian for first 3 groups; vSphere expects RFC/ISO (big-endian) - convert byte order
       if [ -f /sys/class/dmi/id/product_uuid ]; then

--- a/internal/controllers/bootstrap/kairosconfig_controller.go
+++ b/internal/controllers/bootstrap/kairosconfig_controller.go
@@ -94,9 +94,11 @@ type KairosConfigReconciler struct {
 // providerID, so getProviderID has no Metal3 case (ADR 0004); the control-plane
 // getNodeIP path is what Gets Metal3Machine. No create/update/patch/delete on
 // infra Machines from this controller.
-//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=vspheremachines;kubevirtmachines;dockermachines,verbs=get
-//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=vspheremachines;kubevirtmachines;metal3machines,verbs=list;watch
-//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=vspheremachines/status,verbs=get
+// Read-only across the infrastructure group: the bootstrap controller inspects
+// whichever infra machine backs the Machine to decide whether to wait for a
+// providerID, and that kind is chosen by the user. See the note on the
+// control-plane controller's marker.
+//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=*,verbs=get;list;watch
 //+kubebuilder:rbac:groups=kubevirt.io,resources=virtualmachineinstances,verbs=get
 // Secrets: this controller writes and owns the bootstrap-data Secret (and the
 // CAPK kubeconfig-push Secret). events lives in internal/controllers/shared
@@ -261,92 +263,20 @@ func (r *KairosConfigReconciler) reconcileBootstrapData(ctx context.Context, log
 		currentProviderID = ""
 	}
 
-	// For VSphere: Only wait for providerID if VSphereMachine is Ready (VM already provisioned)
-	// If VSphereMachine is not Ready yet, allow secret creation so VM can be provisioned
-	// This avoids circular dependency: VM needs bootstrap secret to be created, but providerID is set after VM creation
-	if machine != nil && machine.Spec.InfrastructureRef.Kind == "VSphereMachine" && currentProviderID == "" {
-		vsphereMachine := &unstructured.Unstructured{}
-		vsphereMachine.SetGroupVersionKind(schema.GroupVersionKind{
-			Group:   "infrastructure.cluster.x-k8s.io",
-			Version: "v1beta1",
-			Kind:    "VSphereMachine",
-		})
-		vsphereMachineKey := types.NamespacedName{
-			Name:      machine.Spec.InfrastructureRef.Name,
-			Namespace: machine.Namespace,
-		}
-
-		if err := r.Get(ctx, vsphereMachineKey, vsphereMachine); err == nil {
-			// Check if VSphereMachine is Ready (VM provisioned)
-			// Look for Ready condition in status.conditions array
-			conditions, found, _ := unstructured.NestedSlice(vsphereMachine.Object, "status", "conditions")
-			isReady := false
-			if found {
-				for _, cond := range conditions {
-					condMap, ok := cond.(map[string]interface{})
-					if ok {
-						condType, _ := condMap["type"].(string)
-						condStatus, _ := condMap["status"].(string)
-						if condType == "Ready" && condStatus == "True" {
-							isReady = true
-							break
-						}
-					}
-				}
-			}
-
-			// Only wait for providerID if VM is already Ready (provisioned)
-			// If VM is not Ready yet, proceed with secret creation (VM needs bootstrap secret to be created first)
-			if isReady {
-				log.V(4).Info("VSphereMachine is Ready but providerID not yet set, waiting briefly for CAPV to set it",
-					"machine", machine.Name,
-					"vsphereMachine", vsphereMachineKey.Name)
-				return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-			}
-			// If VM is not Ready yet, proceed with secret creation - this allows VM to be provisioned
-			log.V(5).Info("VSphereMachine not Ready yet, proceeding with bootstrap secret creation",
-				"machine", machine.Name,
-				"vsphereMachine", vsphereMachineKey.Name)
-		}
-	}
-
-	// For CAPK: Only wait for providerID if KubevirtMachine is Ready (VM already provisioned)
-	// If KubevirtMachine is not Ready yet, allow secret creation so VM can be provisioned
-	if machine != nil && (machine.Spec.InfrastructureRef.Kind == "KubevirtMachine" || machine.Spec.InfrastructureRef.Kind == "KubeVirtMachine") && currentProviderID == "" {
-		kubevirtMachine, err := external.GetObjectFromContractVersionedRef(ctx, r.Client, machine.Spec.InfrastructureRef, machine.Namespace)
-		if err == nil {
-			isReady := false
-			if ready, found, _ := unstructured.NestedBool(kubevirtMachine.Object, "status", "ready"); found && ready {
-				isReady = true
-			}
-			if !isReady {
-				conditions, found, _ := unstructured.NestedSlice(kubevirtMachine.Object, "status", "conditions")
-				if found {
-					for _, cond := range conditions {
-						condMap, ok := cond.(map[string]interface{})
-						if ok {
-							condType, _ := condMap["type"].(string)
-							condStatus, _ := condMap["status"].(string)
-							if condType == "Ready" && condStatus == "True" {
-								isReady = true
-								break
-							}
-						}
-					}
-				}
-			}
-
-			if isReady {
-				log.V(4).Info("KubevirtMachine is Ready but providerID not yet set, waiting briefly for CAPK to set it",
-					"machine", machine.Name,
-					"kubevirtMachine", machine.Spec.InfrastructureRef.Name)
-				return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-			}
-
-			log.V(5).Info("KubevirtMachine not Ready yet, proceeding with bootstrap secret creation",
-				"machine", machine.Name,
-				"kubevirtMachine", machine.Spec.InfrastructureRef.Name)
-		}
+	// Wait briefly for the infrastructure provider to publish a providerID, for
+	// ANY provider rather than a hardcoded list of kinds.
+	//
+	// The rule is a property of the CAPI contract, not of a particular provider:
+	// while the infra machine is not Ready the bootstrap secret must be created,
+	// because the machine cannot be provisioned without it — waiting there would
+	// deadlock. Once the infra machine IS Ready the providerID is imminent, so a
+	// short requeue avoids baking a config that lacks it.
+	//
+	// Gating this on kind meant third-party providers skipped the wait entirely
+	// and rendered a config with no providerID, which is exactly the window in
+	// which a stale or fabricated value can win on the node.
+	if res, wait := r.waitForInfraProviderID(ctx, log, machine, currentProviderID); wait {
+		return res, nil
 	}
 
 	// If Machine has a bootstrap dataSecretName that differs from status, align to Machine to avoid duplicates.
@@ -663,6 +593,72 @@ func isKubevirtMachine(machine *clusterv1.Machine) bool {
 	return machine.Spec.InfrastructureRef.Kind == "KubevirtMachine" || machine.Spec.InfrastructureRef.Kind == "KubeVirtMachine"
 }
 
+// waitForInfraProviderID reports whether to requeue while the infrastructure
+// provider finishes publishing a providerID.
+//
+// It returns (result, true) to requeue, or (zero, false) to proceed. Proceeding
+// is the default: the infra machine cannot become Ready until the bootstrap
+// secret exists, so blocking on a providerID that only appears after
+// provisioning would deadlock.
+//
+// Metal3 and the Kairos fleet provider are exempt because they deliberately do
+// not embed a providerID in the secret at all — CAPM3 owns Node.spec.providerID
+// (ADR 0004) and a fleet node self-discovers it (ADR 0008) — so waiting for one
+// would never terminate.
+func (r *KairosConfigReconciler) waitForInfraProviderID(ctx context.Context, log logr.Logger, machine *clusterv1.Machine, currentProviderID string) (ctrl.Result, bool) {
+	if machine == nil || currentProviderID != "" {
+		return ctrl.Result{}, false
+	}
+	if isMetal3Machine(machine) || isFleetMachine(machine) {
+		return ctrl.Result{}, false
+	}
+
+	infraMachine, err := external.GetObjectFromContractVersionedRef(ctx, r.Client, machine.Spec.InfrastructureRef, machine.Namespace)
+	if err != nil {
+		// Not yet created, or not readable. Proceed — the secret is a
+		// precondition for it existing at all.
+		return ctrl.Result{}, false
+	}
+
+	if !infraMachineReady(infraMachine) {
+		log.V(5).Info("Infrastructure machine not Ready yet, proceeding with bootstrap secret creation",
+			"machine", machine.Name,
+			"infrastructureKind", machine.Spec.InfrastructureRef.Kind,
+			"infrastructureMachine", machine.Spec.InfrastructureRef.Name)
+		return ctrl.Result{}, false
+	}
+
+	log.V(4).Info("Infrastructure machine is Ready but providerID not yet set, waiting briefly for the provider to set it",
+		"machine", machine.Name,
+		"infrastructureKind", machine.Spec.InfrastructureRef.Kind,
+		"infrastructureMachine", machine.Spec.InfrastructureRef.Name)
+	return ctrl.Result{RequeueAfter: 5 * time.Second}, true
+}
+
+// infraMachineReady reports readiness from either status.ready or a Ready
+// condition. Both are in use across providers, so check both.
+func infraMachineReady(infraMachine *unstructured.Unstructured) bool {
+	if ready, found, _ := unstructured.NestedBool(infraMachine.Object, "status", "ready"); found && ready {
+		return true
+	}
+	conditions, found, _ := unstructured.NestedSlice(infraMachine.Object, "status", "conditions")
+	if !found {
+		return false
+	}
+	for _, cond := range conditions {
+		condMap, ok := cond.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if t, _ := condMap["type"].(string); t == "Ready" {
+			if st, _ := condMap["status"].(string); st == "True" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // supportsManagementEndpoint returns true for infrastructure kinds whose
 // control-plane Machines run the in-node kubeconfig-push block (KD-3b).
 //
@@ -685,11 +681,33 @@ func supportsManagementEndpoint(machine *clusterv1.Machine) bool {
 	if machine == nil {
 		return false
 	}
-	switch machine.Spec.InfrastructureRef.Kind {
-	case "KubevirtMachine", "KubeVirtMachine", "VSphereMachine", "Metal3Machine", "KairosFleetMachine":
-		return true
+	// Opt-out, not an allowlist. The rationale above — a node with a routable
+	// address pushing its kubeconfig back because the management cluster cannot
+	// always dial the workload API server — is a property of the topology, not of
+	// any particular infrastructure provider, and it is if anything MORE true for
+	// bare-metal providers on isolated provisioning networks.
+	//
+	// An allowlist silently withheld the push block from every provider not named
+	// here, so their control-plane nodes never published a kubeconfig and the
+	// KairosControlPlane never reached Initialized — with no error to explain it.
+	// Defaulting to enabled is safe because the resolver may return (nil, nil) as
+	// a "disabled" signal, which is already handled as "no push block".
+	//
+	// An absent kind means there is no infrastructure ref to reason about; do not
+	// enable the push block on the strength of a blank.
+	if machine.Spec.InfrastructureRef.Kind == "" {
+		return false
 	}
-	return false
+
+	// List a kind here only if it is known NOT to support the push block.
+	switch machine.Spec.InfrastructureRef.Kind {
+	case "DockerMachine":
+		// CAPD containers share the management cluster's network namespace only
+		// incidentally, and the docker provider is a test harness rather than a
+		// deployment target; keep its previous behaviour.
+		return false
+	}
+	return true
 }
 
 // isMetal3Machine reports whether machine is backed by CAPM3 (Metal3Machine).

--- a/internal/controllers/bootstrap/kairosconfig_controller_test.go
+++ b/internal/controllers/bootstrap/kairosconfig_controller_test.go
@@ -22,11 +22,15 @@ import (
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/cluster-api/util/contract"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -1242,11 +1246,15 @@ func TestReconcile_SuccessClearsFailureFields(t *testing.T) {
 	g.Expect(got.Status.ObservedGeneration).To(Equal(int64(5)))
 }
 
-// TestSupportsManagementEndpoint exhaustively pins the truth table for the
-// gate that decides whether a control-plane Machine's render gets a
-// kubeconfig-push block. The matrix is small and explicit on purpose: a new
-// infrastructure kind needs an entry here as well as in the templates, and
-// the test surfaces the omission.
+// TestSupportsManagementEndpoint pins the truth table for the gate that decides
+// whether a control-plane Machine's render gets a kubeconfig-push block.
+//
+// The gate is an OPT-OUT: an unknown infrastructure kind gets the push block.
+// It used to be an allowlist, which silently withheld the block from every
+// provider not named in it — their control-plane nodes never published a
+// kubeconfig and the KairosControlPlane never reached Initialized, with nothing
+// in the logs to explain why. A kind belongs in the exclusion list only when it
+// is known NOT to support the block.
 func TestSupportsManagementEndpoint(t *testing.T) {
 	mkMachine := func(kind string) *clusterv1.Machine {
 		return &clusterv1.Machine{
@@ -1266,8 +1274,12 @@ func TestSupportsManagementEndpoint(t *testing.T) {
 		{name: "KubeVirtMachine (CAPK uppercase V)", machine: mkMachine("KubeVirtMachine"), want: true},
 		{name: "VSphereMachine (CAPV)", machine: mkMachine("VSphereMachine"), want: true},
 		{name: "KairosFleetMachine (fleet)", machine: mkMachine("KairosFleetMachine"), want: true},
-		{name: "DockerMachine (unsupported today)", machine: mkMachine("DockerMachine"), want: false},
-		{name: "AWSMachine (unsupported today)", machine: mkMachine("AWSMachine"), want: false},
+		{name: "Metal3Machine (CAPM3)", machine: mkMachine("Metal3Machine"), want: true},
+		{name: "DockerMachine (explicitly excluded)", machine: mkMachine("DockerMachine"), want: false},
+		// The point of the opt-out: providers this package has never heard of are
+		// enabled rather than silently skipped.
+		{name: "AWSMachine (unknown kind -> enabled)", machine: mkMachine("AWSMachine"), want: true},
+		{name: "Beskar7Machine (unknown kind -> enabled)", machine: mkMachine("Beskar7Machine"), want: true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1459,4 +1471,112 @@ func TestBootstrapSecretBelongsTo(t *testing.T) {
 	kcNoUID := &bootstrapv1beta2.KairosConfig{ObjectMeta: metav1.ObjectMeta{Name: "cp-0", Namespace: "ns"}}
 	g.Expect(bootstrapSecretBelongsTo(secretWith("", ""), kcNoUID, clusterName)).To(BeFalse())
 	g.Expect(bootstrapSecretBelongsTo(secretWith("", clusterName), kcNoUID, clusterName)).To(BeTrue())
+}
+
+// mkInfraMachine builds an infra machine of an arbitrary kind, optionally Ready.
+func mkInfraMachine(kind, name, namespace string, ready bool) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "infrastructure.cluster.x-k8s.io",
+		Version: "v1beta1",
+		Kind:    kind,
+	})
+	obj.SetName(name)
+	obj.SetNamespace(namespace)
+	if ready {
+		_ = unstructured.SetNestedField(obj.Object, true, "status", "ready")
+	}
+	return obj
+}
+
+// TestWaitForInfraProviderID_AnyProvider pins the generalized wait. It used to
+// be gated on Kind == VSphereMachine / KubevirtMachine, so a third-party
+// provider skipped it entirely and rendered a bootstrap config with no
+// providerID — the window in which a stale or fabricated value can win on the
+// node.
+func TestWaitForInfraProviderID_AnyProvider(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = apiextensionsv1.AddToScheme(scheme)
+
+	cases := []struct {
+		name        string
+		kind        string
+		ready       bool
+		providerID  string
+		seedInfra   bool
+		wantRequeue bool
+	}{
+		{
+			// The regression: an unknown provider, infra Ready, providerID not yet
+			// published. Must wait rather than render a config without it.
+			name: "unknown provider, ready, no providerID -> wait",
+			kind: "Beskar7Machine", ready: true, seedInfra: true, wantRequeue: true,
+		},
+		{
+			// Must NOT wait, or we deadlock: the infra machine cannot become Ready
+			// until the bootstrap secret it needs exists.
+			name: "unknown provider, not ready -> proceed",
+			kind: "Beskar7Machine", ready: false, seedInfra: true, wantRequeue: false,
+		},
+		{
+			name: "providerID already known -> proceed",
+			kind: "Beskar7Machine", ready: true, providerID: "b7://ns/host", seedInfra: true, wantRequeue: false,
+		},
+		{
+			name: "infra machine absent -> proceed",
+			kind: "Beskar7Machine", ready: true, seedInfra: false, wantRequeue: false,
+		},
+		{
+			// Metal3 and fleet deliberately never embed a providerID, so waiting
+			// for one would never terminate.
+			name: "Metal3 is exempt -> proceed",
+			kind: "Metal3Machine", ready: true, seedInfra: true, wantRequeue: false,
+		},
+		{
+			name: "fleet is exempt -> proceed",
+			kind: "KairosFleetMachine", ready: true, seedInfra: true, wantRequeue: false,
+		},
+		{
+			// The kinds that used to be the entire allowlist must still behave.
+			name: "vSphere still waits",
+			kind: "VSphereMachine", ready: true, seedInfra: true, wantRequeue: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			machine := &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{Name: "m", Namespace: "default"},
+				Spec: clusterv1.MachineSpec{
+					InfrastructureRef: clusterv1.ContractVersionedObjectReference{
+						APIGroup: "infrastructure.cluster.x-k8s.io",
+						Kind:     tc.kind,
+						Name:     "infra",
+					},
+				},
+			}
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+			if tc.seedInfra {
+				builder = builder.WithObjects(
+					makeInfraCRDForBootstrap("infrastructure.cluster.x-k8s.io", tc.kind, "v1beta1"),
+					mkInfraMachine(tc.kind, "infra", "default", tc.ready),
+				)
+			}
+			r := &KairosConfigReconciler{Client: builder.Build(), Scheme: scheme}
+
+			_, wait := r.waitForInfraProviderID(context.Background(), log.Log, machine, tc.providerID)
+			g.Expect(wait).To(Equal(tc.wantRequeue))
+		})
+	}
+}
+
+// makeInfraCRDForBootstrap seeds the CRD that GetObjectFromContractVersionedRef
+// consults to resolve the ref's apiVersion from the contract label.
+func makeInfraCRDForBootstrap(group, kind, contractAPIVersion string) *unstructured.Unstructured {
+	crd := &unstructured.Unstructured{}
+	crd.SetGroupVersionKind(apiextensionsv1.SchemeGroupVersion.WithKind("CustomResourceDefinition"))
+	crd.SetName(contract.CalculateCRDName(group, kind))
+	crd.SetLabels(map[string]string{clusterv1.GroupVersion.String(): contractAPIVersion})
+	return crd
 }

--- a/internal/controllers/controlplane/infra_lookup.go
+++ b/internal/controllers/controlplane/infra_lookup.go
@@ -128,7 +128,22 @@ func (r *KairosControlPlaneReconciler) getNodeIP(ctx context.Context, log logr.L
 		// helper is rewired. See ADR 0008.
 		return "", nil
 	default:
-		return "", fmt.Errorf("unsupported infrastructure provider: %s", machine.Spec.InfrastructureRef.Kind)
+		// Any other CAPI-conformant infrastructure provider. status.addresses is
+		// contract-mandated on an infra machine and uses the standard
+		// MachineAddresses shape, so the generic extractor already understands it —
+		// there is nothing provider-specific left to special-case.
+		//
+		// Report "no IP" WITHOUT an error when nothing is published, for the same
+		// reason as KairosFleetMachine above: the only consumer is the opt-in,
+		// non-fatal SSH-fallback path, which treats an empty address as "nothing to
+		// dial". Providers whose nodes self-discover their providerID on-node (the
+		// Kairos fleet provider, Beskar7) legitimately publish no routable address,
+		// and that must not be reported as a failure.
+		infraMachine, err := external.GetObjectFromContractVersionedRef(ctx, r.Client, machine.Spec.InfrastructureRef, machine.Namespace)
+		if err != nil {
+			return "", fmt.Errorf("failed to get %s: %w", machine.Spec.InfrastructureRef.Kind, err)
+		}
+		return r.extractIPFromUnstructured(infraMachine), nil
 	}
 }
 

--- a/internal/controllers/controlplane/infra_lookup_test.go
+++ b/internal/controllers/controlplane/infra_lookup_test.go
@@ -201,3 +201,83 @@ func TestGetNodeIP_KairosFleetMachine(t *testing.T) {
 		t.Errorf("getNodeIP(KairosFleetMachine) = %q, want empty", ip)
 	}
 }
+
+// makeThirdPartyInfraMachine builds an infra machine for a provider getNodeIP has
+// no case for. Beskar7 is the concrete example: a bare-metal provider whose nodes
+// self-discover their providerID on-node.
+func makeThirdPartyInfraMachine(kind, name, namespace string, addresses []map[string]interface{}) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "infrastructure.cluster.x-k8s.io",
+		Version: "v1beta1",
+		Kind:    kind,
+	})
+	obj.SetName(name)
+	obj.SetNamespace(namespace)
+	if len(addresses) > 0 {
+		addrs := make([]interface{}, len(addresses))
+		for i, a := range addresses {
+			addrs[i] = a
+		}
+		_ = unstructured.SetNestedSlice(obj.Object, addrs, "status", "addresses")
+	}
+	return obj
+}
+
+// An infrastructure provider with no case of its own must go through the generic
+// contract path: read the contract-mandated status.addresses, and report "no IP"
+// without an error when there is none. Previously this returned "unsupported
+// infrastructure provider", which turned a healthy control plane into a failure.
+func TestGetNodeIP_UnknownProviderUsesContractAddresses(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = bootstrapv1beta2.AddToScheme(scheme)
+	_ = controlplanev1beta2.AddToScheme(scheme)
+	_ = apiextensionsv1.AddToScheme(scheme)
+
+	for _, tc := range []struct {
+		name      string
+		addresses []map[string]interface{}
+		wantIP    string
+	}{
+		{
+			name:      "InternalIP is returned",
+			addresses: []map[string]interface{}{{"type": "InternalIP", "address": "192.168.190.60"}},
+			wantIP:    "192.168.190.60",
+		},
+		{
+			// The self-discovering case: Beskar7 injects the providerID on-node, so
+			// a host that publishes no address is normal, not broken.
+			name:      "no addresses is not an error",
+			addresses: nil,
+			wantIP:    "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			machine := &clusterv1.Machine{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-machine", Namespace: "default"},
+				Spec: clusterv1.MachineSpec{
+					InfrastructureRef: clusterv1.ContractVersionedObjectReference{
+						APIGroup: "infrastructure.cluster.x-k8s.io",
+						Kind:     "Beskar7Machine",
+						Name:     "test-b7m",
+					},
+				},
+			}
+			infra := makeThirdPartyInfraMachine("Beskar7Machine", "test-b7m", "default", tc.addresses)
+			crd := makeInfraCRD("infrastructure.cluster.x-k8s.io", "Beskar7Machine", "v1beta1")
+
+			r := &KairosControlPlaneReconciler{
+				Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(crd, infra).Build(),
+				Scheme: scheme,
+			}
+
+			ip, err := r.getNodeIP(context.Background(), log.Log, machine)
+			if err != nil {
+				t.Fatalf("getNodeIP(Beskar7Machine) unexpected error: %v", err)
+			}
+			if ip != tc.wantIP {
+				t.Errorf("getNodeIP(Beskar7Machine) = %q, want %q", ip, tc.wantIP)
+			}
+		})
+	}
+}

--- a/internal/controllers/controlplane/kairoscontrolplane_controller.go
+++ b/internal/controllers/controlplane/kairoscontrolplane_controller.go
@@ -119,10 +119,15 @@ const kubeconfigReadyTimeout = controlplanev1beta2.KubeconfigReadyTimeout
 // create;get access as the other infra kinds. Metal3Cluster, KairosFleetCluster, and
 // BareMetalHost are deliberately absent: we never read them (CAPI core copies the
 // endpoint per KD-12; CAPM3 mediates BMH; the fleet provider owns its own Cluster).
-//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=vspheremachines;kubevirtmachines;dockermachines;metal3machines;kairosfleetmachines,verbs=create;get
-//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=vspheremachines/status;kubevirtmachines/status;dockermachines/status;metal3machines/status;kairosfleetmachines/status,verbs=get
-//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=vspheremachinetemplates;kubevirtmachinetemplates;dockermachinetemplates;metal3machinetemplates;kairosfleetmachinetemplates,verbs=get
-//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=vspherevms,verbs=get
+// Infrastructure resources are granted by GROUP, not by an enumerated list of
+// resource names. A control-plane provider has to clone a machine template and
+// read the machine for whichever infrastructure provider the user picked, and
+// that set is open-ended: enumerating it meant every new provider was denied at
+// the API server until this line was edited, with the failure surfacing only as
+// an opaque "is forbidden" on the KairosControlPlane. Cluster API's own core
+// controller grants the infrastructure group the same way and for the same
+// reason. Verbs stay minimal — this is a wildcard over resources, not verbs.
+//+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=*,verbs=get;list;watch;create;update;patch;delete
 // customresourcedefinitions (contract-versioned ref resolution, ADR 0006) and
 // events both live in internal/controllers/shared — both managers need them.
 // services;endpoints: the control-plane manager owns the LB Service and reads

--- a/internal/infrastructure/clone.go
+++ b/internal/infrastructure/clone.go
@@ -19,6 +19,7 @@ package infrastructure
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -64,12 +65,63 @@ func CloneInfrastructureMachine(ctx context.Context, c client.Client, scheme *ru
 	case "KairosFleetMachineTemplate":
 		return cloneKairosFleetMachineTemplate(ctx, c, scheme, templateObj, machineName, namespace, labels, annotations)
 	default:
-		return nil, fmt.Errorf("unsupported infrastructure provider: %s (Group: %s, Version: %s, FullGVK: %s)",
-			kind,
-			templateRef.GroupVersionKind().Group,
-			templateRef.GroupVersionKind().Version,
-			templateRef.GroupVersionKind().String())
+		// Any other CAPI-conformant infrastructure provider. The provider contract
+		// requires <Kind>MachineTemplate.spec.template.spec to be the spec of the
+		// <Kind>Machine it produces, which is exactly what the cases above do, so a
+		// kind we have never heard of needs no bespoke code. Erroring here instead
+		// meant every new infrastructure provider was locked out until this switch
+		// was edited — the same defect that blocked KairosFleetMachineTemplate in
+		// v0.1.0 and, before this change, Beskar7MachineTemplate.
+		//
+		// The named cases stay because they carry behaviour this cannot infer: a
+		// fallback apiVersion for templates fetched without one, and KubeVirt's
+		// cloud-init filtering.
+		logger.Info("Cloning via the generic template contract", "kind", kind)
+		return cloneGenericMachineTemplate(ctx, c, scheme, templateObj, machineName, namespace, labels, annotations)
 	}
+}
+
+// cloneGenericMachineTemplate clones any <Kind>MachineTemplate into the
+// <Kind>Machine the CAPI contract pairs it with, by stripping the "Template"
+// suffix and copying spec.template.spec verbatim.
+//
+// Group and version come from the template object itself rather than a hardcoded
+// default: for an unknown provider we have no basis to guess a version, and the
+// object we were handed is authoritative.
+func cloneGenericMachineTemplate(ctx context.Context, c client.Client, scheme *runtime.Scheme, template *unstructured.Unstructured, machineName, namespace string, labels, annotations map[string]string) (client.Object, error) {
+	gvk := template.GroupVersionKind()
+
+	machineKind, ok := strings.CutSuffix(gvk.Kind, "Template")
+	if !ok || machineKind == "" {
+		return nil, fmt.Errorf("cannot derive an infrastructure machine kind from %q: "+
+			"the CAPI contract requires the template kind to be the machine kind plus a %q suffix", gvk.Kind, "Template")
+	}
+	if gvk.Version == "" {
+		return nil, fmt.Errorf("infrastructure template %s/%s has no apiVersion; cannot determine the machine apiVersion", namespace, template.GetName())
+	}
+
+	machine := &unstructured.Unstructured{}
+	machine.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   gvk.Group,
+		Version: gvk.Version,
+		Kind:    machineKind,
+	})
+	machine.SetName(machineName)
+	machine.SetNamespace(namespace)
+	machine.SetLabels(labels)
+	machine.SetAnnotations(annotations)
+
+	// Copy spec from template. An absent spec.template.spec is left alone rather
+	// than treated as an error, matching the named cases: some providers have a
+	// legitimately empty machine spec and take everything from the template's
+	// metadata or from the claimed host.
+	if spec, ok, _ := unstructured.NestedMap(template.UnstructuredContent(), "spec", "template", "spec"); ok {
+		if err := unstructured.SetNestedMap(machine.UnstructuredContent(), spec, "spec"); err != nil {
+			return nil, fmt.Errorf("failed to set spec: %w", err)
+		}
+	}
+
+	return machine, nil
 }
 
 func getTemplateObject(ctx context.Context, c client.Client, ref corev1.ObjectReference) (*unstructured.Unstructured, error) {

--- a/internal/infrastructure/clone_test.go
+++ b/internal/infrastructure/clone_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -217,5 +219,115 @@ func TestCloneKairosFleetMachineTemplate(t *testing.T) {
 				t.Errorf("spec.group = %q, want %q", group, "control-plane")
 			}
 		})
+	}
+}
+
+// makeThirdPartyMachineTemplate builds a template for an infrastructure provider
+// this package has never heard of. Beskar7 (a bare-metal provider) is used as the
+// concrete example because it is what exposed the defect.
+func makeThirdPartyMachineTemplate(kind, version string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "infrastructure.cluster.x-k8s.io",
+		Version: version,
+		Kind:    kind,
+	})
+	obj.SetName("tmpl")
+	obj.SetNamespace("default")
+	_ = unstructured.SetNestedMap(obj.Object, map[string]interface{}{
+		"template": map[string]interface{}{
+			"spec": map[string]interface{}{
+				"inspectionImageURL": "http://boot.example:8090",
+				"targetImageURL":     "http://boot.example:8090/os.raw",
+				"targetImageDigest":  "sha256:deadbeef",
+			},
+		},
+	}, "spec")
+	return obj
+}
+
+// An infrastructure provider with no case in the switch must still clone, via the
+// generic template->machine contract. Before this, CloneInfrastructureMachine
+// returned "unsupported infrastructure provider" and no third-party provider
+// could back a KairosControlPlane.
+func TestCloneInfrastructureMachine_UnknownProviderUsesGenericContract(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		kind        string
+		version     string
+		wantKind    string
+		wantVersion string
+	}{
+		{"beskar7 v1beta1", "Beskar7MachineTemplate", "v1beta1", "Beskar7Machine", "v1beta1"},
+		{"version is taken from the template, not guessed", "Beskar7MachineTemplate", "v1beta2", "Beskar7Machine", "v1beta2"},
+		{"any other provider", "AcmeMachineTemplate", "v1alpha7", "AcmeMachine", "v1alpha7"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpl := makeThirdPartyMachineTemplate(tc.kind, tc.version)
+			c := fake.NewClientBuilder().WithRuntimeObjects(tmpl).Build()
+
+			obj, err := CloneInfrastructureMachine(context.Background(), c, runtime.NewScheme(),
+				templateRef(tc.kind, tc.version), "test-machine", "default",
+				map[string]string{"cluster.x-k8s.io/cluster-name": "test-cluster"},
+				map[string]string{"test-key": "test-value"})
+			if err != nil {
+				t.Fatalf("CloneInfrastructureMachine() error = %v, want nil", err)
+			}
+
+			u, ok := obj.(*unstructured.Unstructured)
+			if !ok {
+				t.Fatalf("got %T, want *unstructured.Unstructured", obj)
+			}
+			gvk := u.GroupVersionKind()
+			if gvk.Kind != tc.wantKind {
+				t.Errorf("Kind = %q, want %q", gvk.Kind, tc.wantKind)
+			}
+			if gvk.Version != tc.wantVersion {
+				t.Errorf("Version = %q, want %q — the template's version must be preserved", gvk.Version, tc.wantVersion)
+			}
+			if gvk.Group != "infrastructure.cluster.x-k8s.io" {
+				t.Errorf("Group = %q, want infrastructure.cluster.x-k8s.io", gvk.Group)
+			}
+			if u.GetName() != "test-machine" || u.GetNamespace() != "default" {
+				t.Errorf("name/namespace = %q/%q, want test-machine/default", u.GetName(), u.GetNamespace())
+			}
+			if u.GetLabels()["cluster.x-k8s.io/cluster-name"] != "test-cluster" {
+				t.Errorf("labels not propagated")
+			}
+			if u.GetAnnotations()["test-key"] != "test-value" {
+				t.Errorf("annotations not propagated")
+			}
+
+			// spec.template.spec copied verbatim to spec.
+			got, _, _ := unstructured.NestedString(u.Object, "spec", "targetImageURL")
+			if got != "http://boot.example:8090/os.raw" {
+				t.Errorf("spec.targetImageURL = %q, want the value from spec.template.spec", got)
+			}
+			if _, found, _ := unstructured.NestedMap(u.Object, "spec", "template"); found {
+				t.Errorf("spec.template must not be carried onto the machine")
+			}
+		})
+	}
+}
+
+// A kind that is not <Something>Template cannot be mapped to a machine kind, and
+// must fail loudly rather than producing a nonsense object.
+func TestCloneInfrastructureMachine_KindWithoutTemplateSuffix(t *testing.T) {
+	tmpl := makeThirdPartyMachineTemplate("Beskar7Machine", "v1beta1") // not a Template
+	c := fake.NewClientBuilder().WithRuntimeObjects(tmpl).Build()
+
+	_, err := CloneInfrastructureMachine(context.Background(), c, runtime.NewScheme(),
+		templateRef("Beskar7Machine", "v1beta1"), "test-machine", "default", nil, nil)
+	if err == nil {
+		t.Fatal("expected an error for a kind without a Template suffix, got nil")
+	}
+}
+
+func templateRef(kind, version string) corev1.ObjectReference {
+	return corev1.ObjectReference{
+		APIVersion: "infrastructure.cluster.x-k8s.io/" + version,
+		Kind:       kind,
+		Name:       "tmpl",
+		Namespace:  "default",
 	}
 }


### PR DESCRIPTION
## Summary

A `KairosControlPlane` backed by an infrastructure provider without an explicit case was rejected outright:

```
unsupported infrastructure provider: Beskar7MachineTemplate (Group: infrastructure.cluster.x-k8s.io, Version: v1beta1, ...)
```

and three further allow-lists each failed *silently* once that was fixed. This makes the provider work with **any CAPI-conformant infrastructure provider** by treating the CAPI contract as the default and keeping the named cases only where they carry behaviour the contract cannot infer.

Four commits, each self-contained:

1. **Generic infra-machine clone and node-IP lookup.** The `<Kind>MachineTemplate → <Kind>Machine` cloner derives the machine kind by stripping `Template` and copies `spec.template.spec` verbatim, taking group/version from the template object itself. `getNodeIP` reads the contract-mandated `status.addresses`; a provider that publishes none yields `("", nil)`, matching the documented reasoning for the fleet provider (the only consumer is the opt-in, non-fatal SSH fallback). Named cases for Docker, vSphere and KubeVirt stay, since they carry a fallback apiVersion and volume filtering. A kind that is not `<Something>Template` still fails loudly.
2. **k3s: never mint `vsphere://<DMI uuid>` on non-VMware hardware.** The CAPV template is the *default* for every non-KubeVirt provider, and its providerID self-discovery script hardcodes a `vsphere://` prefix from `product_uuid`. `Node.spec.providerID` is immutable, so the node became permanently unmatchable. Guarded on `sys_vendor` = VMware, and never clobbers a value the controller already wrote.
3. **End to end:** RBAC grants infrastructure resources by **group** (as CAPI core does) instead of a name list — wildcard over resources, not verbs, bootstrap stays read-only; the providerID wait is a property of the contract, not of `Kind == VSphereMachine|KubevirtMachine` (Metal3 and fleet stay exempt because they deliberately never embed one); `supportsManagementEndpoint` becomes opt-out (`""` and `DockerMachine` excluded), so an unnamed provider's control-plane node actually pushes its kubeconfig and the KCP can reach `Initialized`.
4. **k0s: the same vendor guard** the k3s template got in (2), plus `TestNoUnguardedVSphereProviderIDMint`, a structural invariant over every distribution × infra × role render: any DMI-derived `vsphere://` mint must be preceded by a `sys_vendor` guard, so the two templates cannot drift apart again.

## Evidence

Observed on a Beskar7 bare-metal lab (`infrastructure.cluster.x-k8s.io/v1beta1`, QEMU-backed hosts): without (1) the control plane could not create the infra machine at all; without (2)/(4) nodes registered as `vsphere://949d0b66-…` derived from their QEMU DMI UUID and the Machines never left `Provisioned`; without (3) the rendered config had no providerID and the kubeconfig secret had to be created by hand. With all four: `Beskar7MachineTemplate` clones, nodes register as `b7://<ns>/<host>`, Machines reach `Running` with `nodeRef` set, `Cluster.Available=True`; a three-replica k3s `KairosControlPlane` formed and survived a leader kill.

## Behaviour change for existing providers

None intended. Named cloners are kept; `DockerMachine` is listed as an explicit exclusion in `supportsManagementEndpoint`; vSphere still waits for its providerID. RBAC manifests regenerated with `make manifests` (no diff on re-run).

## Tests

Generic clone (version preservation, label/annotation propagation, non-Template kind), `getNodeIP` with and without addresses, the generalized providerID wait (unknown provider ready / not-ready / providerID-known / infra-absent, Metal3 and fleet exemptions, vSphere still waits), the management-endpoint truth table, and the template invariant. All confirmed to fail with the change reverted.

Follow-up, not changed here: `cloneDockerMachineTemplate` and `cloneVSphereMachineTemplate` hardcode `Version: v1beta1` instead of deriving it from the template, unlike the Metal3, fleet and KubeVirt cloners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
