### PR TITLE
fix: pin k3s HA datastore flags in config.yaml.d, not just k3s.args

### DIFF
--- a/internal/bootstrap/ha_test.go
+++ b/internal/bootstrap/ha_test.go
@@ -1096,3 +1096,111 @@ func TestHA_CapkK3sSingleHasNoNodeIP(t *testing.T) {
 		t.Error("k3s CAPK single must NOT render the k3s.service ExecStartPre drop-in (HA-only)")
 	}
 }
+
+// TestHA_K3sDatastoreFlagsPinnedInConfigDir is the regression guard for the
+// init-ordering bug measured on the beskar7/CAPV HA lab (2026-09-07).
+//
+// provider-kairos delivers `k3s.args:` as a systemd drop-in
+// (/etc/systemd/system/k3s.service.d/override.conf). On an instrumented run that
+// file landed at 23:10:16 — three seconds AFTER k3s.service had already been
+// started at 23:10:13. k3s selects its datastore on its FIRST start and never
+// migrates, so it came up as a plain `k3s server` on SQLite with a random server
+// token; --cluster-init / --server / --token-file were ignored for the life of
+// the node. The failure is silent: the init node reports "etcd disabled" and
+// every joiner forms its OWN single-node cluster.
+//
+// The boot-stage write_files, by contrast, landed at 23:10:13.318 — BEFORE the
+// first start — and k3s re-reads config.yaml.d on every start. So the flags that
+// must be right on the first start are pinned there too. This test asserts the
+// drop-in exists with the correct content for init and join on both infra
+// flavours, and that it is absent for single-node and workers (which have no
+// datastore choice to get wrong).
+func TestHA_K3sDatastoreFlagsPinnedInConfigDir(t *testing.T) {
+	const path = "/etc/rancher/k3s/config.yaml.d/93-ha-datastore.yaml"
+	const tokenLine = "token-file: /etc/rancher/k3s/server-token"
+
+	for _, kv := range []bool{false, true} { // CAPV, CAPK
+		infra := "capv"
+		if kv {
+			infra = "capk"
+		}
+
+		t.Run(infra+"/init", func(t *testing.T) {
+			d := haCPData("init", kv)
+			d.JoinToken = "K10shared::server:tokenvalue"
+			out, err := RenderK3sCloudConfig(d)
+			if err != nil {
+				t.Fatalf("render: %v", err)
+			}
+			content := extractWriteFile(t, out, path)
+			if content == "" {
+				t.Fatalf("init render missing %q — --cluster-init would arrive too late to pick the datastore", path)
+			}
+			if !strings.Contains(content, "cluster-init: true") {
+				t.Errorf("init %s missing cluster-init: true, got:\n%s", path, content)
+			}
+			if !strings.Contains(content, tokenLine) {
+				t.Errorf("init %s missing %q — init would generate a random server token, got:\n%s", path, tokenLine, content)
+			}
+			if strings.Contains(content, "server:") {
+				t.Errorf("init %s must not set server: (it bootstraps, it does not join), got:\n%s", path, content)
+			}
+		})
+
+		t.Run(infra+"/join", func(t *testing.T) {
+			d := haCPData("join", kv)
+			out, err := RenderK3sCloudConfig(d)
+			if err != nil {
+				t.Fatalf("render: %v", err)
+			}
+			content := extractWriteFile(t, out, path)
+			if content == "" {
+				t.Fatalf("join render missing %q — --server would arrive too late and the node would form its own cluster", path)
+			}
+			// The join URL must be the same stable endpoint the k3s.args --server
+			// uses, so the late override is a no-op when it finally lands.
+			endpoint := d.ManagementEndpoint.ControlPlaneEndpointHost
+			if kv {
+				endpoint = d.ControlPlaneLBEndpoint
+			}
+			want := "server: https://" + endpoint + ":6443"
+			if !strings.Contains(content, want) {
+				t.Errorf("join %s missing %q, got:\n%s", path, want, content)
+			}
+			if !strings.Contains(content, tokenLine) {
+				t.Errorf("join %s missing %q, got:\n%s", path, tokenLine, content)
+			}
+			if strings.Contains(content, "cluster-init") {
+				t.Errorf("join %s must not set cluster-init (it joins, it does not bootstrap), got:\n%s", path, content)
+			}
+			if !strings.Contains(out, "--server=https://"+endpoint+":6443") {
+				t.Errorf("join k3s.args --server must match the config.yaml.d server: value (%s)", endpoint)
+			}
+		})
+
+		t.Run(infra+"/single", func(t *testing.T) {
+			d := haCPData("single", kv)
+			out, err := RenderK3sCloudConfig(d)
+			if err != nil {
+				t.Fatalf("render: %v", err)
+			}
+			if strings.Contains(out, path) {
+				t.Errorf("single-node render must not write %q — it has no HA datastore to pin", path)
+			}
+		})
+
+		t.Run(infra+"/worker", func(t *testing.T) {
+			d := haCPData("init", kv)
+			d.Role = "worker"
+			d.K3sServerURL = "https://192.168.1.240:6443"
+			d.K3sToken = "K10worker::server:token"
+			out, err := RenderK3sCloudConfig(d)
+			if err != nil {
+				t.Fatalf("render: %v", err)
+			}
+			if strings.Contains(out, path) {
+				t.Errorf("worker render must not write %q — agents hold no datastore", path)
+			}
+		})
+	}
+}

--- a/internal/bootstrap/templates/k3s_kairos_cloud_config_capk.yaml.tmpl
+++ b/internal/bootstrap/templates/k3s_kairos_cloud_config_capk.yaml.tmpl
@@ -79,6 +79,10 @@ k3s:
     # file the joiners read (written below for every HA role). Without it
     # --cluster-init auto-generates a random token the joiners can never match.
     # (ADR 0005 Phase 3, BLOCKER-1.)
+    #
+    # NOTE: these args arrive via a systemd override written ~3s AFTER
+    # k3s.service first starts — too late to choose the datastore.
+    # 93-ha-datastore.yaml (write_files, below) pins them in config.yaml.d.
     - --cluster-init
     - --token-file=/etc/rancher/k3s/server-token
   {{- else if .IsJoinControlPlane }}
@@ -260,6 +264,31 @@ write_files:
     group: root
     content: |
       {{ .JoinToken }}
+  {{- end }}
+  {{- if .IsHAControlPlane }}
+  # ADR 0005 (HA) datastore/join flags on CAPK — INIT-ORDERING (bare-metal
+  # lab, 2026-09-07).
+  # Same root cause as the CAPV template: k3s selects its datastore on its FIRST
+  # start and never migrates, but provider-kairos writes the `k3s.args:` systemd
+  # override ~3s AFTER k3s.service has already started. k3s therefore comes up as
+  # a plain `k3s server` on SQLite with a random server token, and --cluster-init
+  # / --server / --token-file are ignored for the life of the node: the init node
+  # reports "etcd disabled" and every joiner forms its own single-node cluster.
+  #
+  # config.yaml.d is read on EVERY start and write_files lands before the first
+  # one, so the datastore/join flags are pinned here too. Values match the
+  # k3s.args ones exactly, so the late override is a no-op when it arrives.
+  - path: /etc/rancher/k3s/config.yaml.d/93-ha-datastore.yaml
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      {{- if .IsInitControlPlane }}
+      cluster-init: true
+      {{- else if .ControlPlaneLBEndpoint }}
+      server: {{ printf "https://%s:6443" .ControlPlaneLBEndpoint | quote }}
+      {{- end }}
+      token-file: /etc/rancher/k3s/server-token
   {{- end }}
   {{- if and (ne .Role "control-plane") .K3sToken }}
   - path: /etc/rancher/k3s/token

--- a/internal/bootstrap/templates/k3s_kairos_cloud_config_capv.yaml.tmpl
+++ b/internal/bootstrap/templates/k3s_kairos_cloud_config_capv.yaml.tmpl
@@ -94,6 +94,11 @@ k3s:
     # Without this, k3s --cluster-init auto-generates a random server token that
     # the joiners can never match, so the cluster never forms. (ADR 0005 Phase 3,
     # BLOCKER-1.)
+    #
+    # NOTE: these args reach the node via a systemd override that
+    # provider-kairos writes ~3s AFTER k3s.service first starts, which is too
+    # late to choose the datastore. 93-ha-datastore.yaml (write_files, below)
+    # pins the same flags in config.yaml.d, which k3s reads on every start.
     - --cluster-init
     - --token-file=/etc/rancher/k3s/server-token
     {{- if and .ManagementEndpoint .ManagementEndpoint.ControlPlaneEndpointHost }}
@@ -185,6 +190,36 @@ write_files:
     group: root
     content: |
       {{ .JoinToken }}
+  {{- end }}
+  {{- if .IsHAControlPlane }}
+  # ADR 0005 (HA) datastore/join flags — INIT-ORDERING (bare-metal lab,
+  # 2026-09-07).
+  # k3s picks its datastore on its FIRST start and never migrates. On an
+  # instrumented HA run the boot-stage write_files landed at 23:10:13.318 and
+  # k3s.service started at 23:10:13 — but provider-kairos only wrote the
+  # `k3s.args:` systemd override at 23:10:16, THREE SECONDS TOO LATE. k3s had
+  # already come up as a plain `k3s server`, created a SQLite datastore and
+  # generated a random server token; --cluster-init / --server / --token-file
+  # were silently ignored on every restart after that. The failure is silent and
+  # unrecoverable: the init node reports "etcd disabled" and each joiner forms
+  # its OWN single-node cluster.
+  #
+  # config.yaml.d is read by k3s on EVERY start and write_files delivers it
+  # BEFORE the first one, so the datastore/join flags are pinned here as well as
+  # in k3s.args — the same belt-and-braces the kubelet-arg (90) and tls-san (91)
+  # drop-ins above already rely on. Values are identical to the k3s.args ones, so
+  # when the override finally lands the two agree and nothing changes.
+  - path: /etc/rancher/k3s/config.yaml.d/93-ha-datastore.yaml
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      {{- if .IsInitControlPlane }}
+      cluster-init: true
+      {{- else if and .ManagementEndpoint .ManagementEndpoint.ControlPlaneEndpointHost }}
+      server: {{ printf "https://%s:6443" .ManagementEndpoint.ControlPlaneEndpointHost | quote }}
+      {{- end }}
+      token-file: /etc/rancher/k3s/server-token
   {{- end }}
   {{- if .RenderKubeVIP }}
   # ADR 0005 § D.1 (HA) kube-vip DaemonSet + RBAC (CAPV/CAPM3 only; CAPK uses its

--- a/internal/bootstrap/testdata/golden/k3s_capk_init.yaml
+++ b/internal/bootstrap/testdata/golden/k3s_capk_init.yaml
@@ -27,6 +27,10 @@ k3s:
     # file the joiners read (written below for every HA role). Without it
     # --cluster-init auto-generates a random token the joiners can never match.
     # (ADR 0005 Phase 3, BLOCKER-1.)
+    #
+    # NOTE: these args arrive via a systemd override written ~3s AFTER
+    # k3s.service first starts — too late to choose the datastore.
+    # 93-ha-datastore.yaml (write_files, below) pins them in config.yaml.d.
     - --cluster-init
     - --token-file=/etc/rancher/k3s/server-token
     - --tls-san=10.96.0.10
@@ -173,6 +177,25 @@ write_files:
     group: root
     content: |
       
+  # ADR 0005 (HA) datastore/join flags on CAPK — INIT-ORDERING (bare-metal
+  # lab, 2026-09-07).
+  # Same root cause as the CAPV template: k3s selects its datastore on its FIRST
+  # start and never migrates, but provider-kairos writes the `k3s.args:` systemd
+  # override ~3s AFTER k3s.service has already started. k3s therefore comes up as
+  # a plain `k3s server` on SQLite with a random server token, and --cluster-init
+  # / --server / --token-file are ignored for the life of the node: the init node
+  # reports "etcd disabled" and every joiner forms its own single-node cluster.
+  #
+  # config.yaml.d is read on EVERY start and write_files lands before the first
+  # one, so the datastore/join flags are pinned here too. Values match the
+  # k3s.args ones exactly, so the late override is a no-op when it arrives.
+  - path: /etc/rancher/k3s/config.yaml.d/93-ha-datastore.yaml
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      cluster-init: true
+      token-file: /etc/rancher/k3s/server-token
   - path: /usr/local/etc/hostname
     permissions: "0644"
     owner: root

--- a/internal/bootstrap/testdata/golden/k3s_capk_join.yaml
+++ b/internal/bootstrap/testdata/golden/k3s_capk_join.yaml
@@ -168,6 +168,25 @@ write_files:
     group: root
     content: |
       K10aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa::server:bbbbbbbbbbbbbbbbbbbbbbbb
+  # ADR 0005 (HA) datastore/join flags on CAPK — INIT-ORDERING (bare-metal
+  # lab, 2026-09-07).
+  # Same root cause as the CAPV template: k3s selects its datastore on its FIRST
+  # start and never migrates, but provider-kairos writes the `k3s.args:` systemd
+  # override ~3s AFTER k3s.service has already started. k3s therefore comes up as
+  # a plain `k3s server` on SQLite with a random server token, and --cluster-init
+  # / --server / --token-file are ignored for the life of the node: the init node
+  # reports "etcd disabled" and every joiner forms its own single-node cluster.
+  #
+  # config.yaml.d is read on EVERY start and write_files lands before the first
+  # one, so the datastore/join flags are pinned here too. Values match the
+  # k3s.args ones exactly, so the late override is a no-op when it arrives.
+  - path: /etc/rancher/k3s/config.yaml.d/93-ha-datastore.yaml
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      server: https://10.96.0.10:6443
+      token-file: /etc/rancher/k3s/server-token
   - path: /usr/local/etc/hostname
     permissions: "0644"
     owner: root

--- a/internal/bootstrap/testdata/golden/k3s_capv_init.yaml
+++ b/internal/bootstrap/testdata/golden/k3s_capv_init.yaml
@@ -31,6 +31,11 @@ k3s:
     # Without this, k3s --cluster-init auto-generates a random server token that
     # the joiners can never match, so the cluster never forms. (ADR 0005 Phase 3,
     # BLOCKER-1.)
+    #
+    # NOTE: these args reach the node via a systemd override that
+    # provider-kairos writes ~3s AFTER k3s.service first starts, which is too
+    # late to choose the datastore. 93-ha-datastore.yaml (write_files, below)
+    # pins the same flags in config.yaml.d, which k3s reads on every start.
     - --cluster-init
     - --token-file=/etc/rancher/k3s/server-token
     - --tls-san=192.168.1.240
@@ -85,6 +90,30 @@ write_files:
     group: root
     content: |
       
+  # ADR 0005 (HA) datastore/join flags — INIT-ORDERING (bare-metal lab,
+  # 2026-09-07).
+  # k3s picks its datastore on its FIRST start and never migrates. On an
+  # instrumented HA run the boot-stage write_files landed at 23:10:13.318 and
+  # k3s.service started at 23:10:13 — but provider-kairos only wrote the
+  # `k3s.args:` systemd override at 23:10:16, THREE SECONDS TOO LATE. k3s had
+  # already come up as a plain `k3s server`, created a SQLite datastore and
+  # generated a random server token; --cluster-init / --server / --token-file
+  # were silently ignored on every restart after that. The failure is silent and
+  # unrecoverable: the init node reports "etcd disabled" and each joiner forms
+  # its OWN single-node cluster.
+  #
+  # config.yaml.d is read by k3s on EVERY start and write_files delivers it
+  # BEFORE the first one, so the datastore/join flags are pinned here as well as
+  # in k3s.args — the same belt-and-braces the kubelet-arg (90) and tls-san (91)
+  # drop-ins above already rely on. Values are identical to the k3s.args ones, so
+  # when the override finally lands the two agree and nothing changes.
+  - path: /etc/rancher/k3s/config.yaml.d/93-ha-datastore.yaml
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      cluster-init: true
+      token-file: /etc/rancher/k3s/server-token
   # ADR 0005 § D.1 (HA) kube-vip DaemonSet + RBAC (CAPV/CAPM3 only; CAPK uses its
   # built-in LoadBalancer Service per OQ-5 and never reaches this block).
   # k3s auto-applies manifests under /var/lib/rancher/k3s/server/manifests at

--- a/internal/bootstrap/testdata/golden/k3s_capv_join.yaml
+++ b/internal/bootstrap/testdata/golden/k3s_capv_join.yaml
@@ -78,6 +78,30 @@ write_files:
     group: root
     content: |
       K10aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa::server:bbbbbbbbbbbbbbbbbbbbbbbb
+  # ADR 0005 (HA) datastore/join flags — INIT-ORDERING (bare-metal lab,
+  # 2026-09-07).
+  # k3s picks its datastore on its FIRST start and never migrates. On an
+  # instrumented HA run the boot-stage write_files landed at 23:10:13.318 and
+  # k3s.service started at 23:10:13 — but provider-kairos only wrote the
+  # `k3s.args:` systemd override at 23:10:16, THREE SECONDS TOO LATE. k3s had
+  # already come up as a plain `k3s server`, created a SQLite datastore and
+  # generated a random server token; --cluster-init / --server / --token-file
+  # were silently ignored on every restart after that. The failure is silent and
+  # unrecoverable: the init node reports "etcd disabled" and each joiner forms
+  # its OWN single-node cluster.
+  #
+  # config.yaml.d is read by k3s on EVERY start and write_files delivers it
+  # BEFORE the first one, so the datastore/join flags are pinned here as well as
+  # in k3s.args — the same belt-and-braces the kubelet-arg (90) and tls-san (91)
+  # drop-ins above already rely on. Values are identical to the k3s.args ones, so
+  # when the override finally lands the two agree and nothing changes.
+  - path: /etc/rancher/k3s/config.yaml.d/93-ha-datastore.yaml
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      server: https://192.168.1.240:6443
+      token-file: /etc/rancher/k3s/server-token
   # ADR 0005 § D.1 (HA) kube-vip DaemonSet + RBAC (CAPV/CAPM3 only; CAPK uses its
   # built-in LoadBalancer Service per OQ-5 and never reaches this block).
   # k3s auto-applies manifests under /var/lib/rancher/k3s/server/manifests at


### PR DESCRIPTION
## Summary

Pins the k3s HA datastore flags in `/etc/rancher/k3s/config.yaml.d/93-ha-datastore.yaml` as well as in `k3s.args`, because the systemd override that delivers `k3s.args` can land **after** k3s has already started.

## Why

On an instrumented HA run on bare metal (2026-09-07) the `k3s.service.d/override.conf` written from `k3s.args` landed at 23:10:16 — three seconds after `k3s.service` started at 23:10:13. k3s selects its datastore on its **first** start and never migrates, so the node came up as a plain `k3s server`: SQLite, random token, no `--server`. Once the override arrived, `--cluster-init` / `--server` / `--token-file` were ignored for the life of the node.

The failure is silent and unrecoverable: the init node reports "etcd disabled", every joiner bootstraps its **own** single-node cluster with its own CA, and a three-replica `KairosControlPlane` comes up as three unrelated clusters, each `Ready`, with no quorum anywhere.

## What changes

The boot-stage `write_files` landed at 23:10:13.318 on the same run — before the first start — and k3s re-reads `config.yaml.d/*.yaml` on every start. So the flags that must be correct on the first start are pinned there too:

- init: `cluster-init: true` + `token-file`
- join: `server: https://<endpoint>:6443` + `token-file`

Same belt-and-braces the existing `90-provider-id` and `91-tls-san` drop-ins use, for the same reason. Values are identical to the `k3s.args` ones, so the late override is a no-op when it lands. Rendered only for `IsHAControlPlane`, on both the CAPV and CAPK k3s templates; single-node servers and agents hold no datastore choice that can go wrong. k0s is not touched here.

## Verification

- `TestHA_K3sDatastoreFlagsPinnedInConfigDir` over the HA goldens.
- Rebuilt a three-node k3s HA cluster from wiped disks on the same lab: all three replicas joined one embedded etcd, verified through a leader kill and a write during the failover.

Independent of the other PRs in this series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
