### PR TITLE
fix: retry the k0s join-token push and etcd-status report instead of giving up once

### DIFF
--- a/internal/bootstrap/ha_test.go
+++ b/internal/bootstrap/ha_test.go
@@ -1204,3 +1204,81 @@ func TestHA_K3sDatastoreFlagsPinnedInConfigDir(t *testing.T) {
 		})
 	}
 }
+
+// TestHA_K0sJoinTokenPushRetries guards the k0s HA deadlock found on the
+// bare-metal lab (2026-09-08).
+//
+// initMachineJoinable blocks every k0s joiner until the per-cluster
+// controller-join Secret is non-empty, and only the init node can fill it. The
+// push ran in a oneshot unit that made ONE attempt at `k0s token create`, four
+// seconds after k0s started. The bootstrap-token machinery was not serving yet,
+// create returned empty, and the script logged "will retry on next boot" — but
+// nothing reboots the node, so the unit stayed `active (exited)` and the gate
+// held for 45 minutes. The identical command run by hand afterwards returned a
+// 1738-byte token, so the failure was purely a startup race with a permanent
+// consequence.
+//
+// Both steps must retry: an empty create and a failed PATCH strand the cluster
+// identically. The sibling providerID patch in the same script already retries
+// 30x/5s and node registration waits 300s; this asserts the token path is no
+// longer the one step that gives up immediately.
+func TestHA_K0sJoinTokenPushRetries(t *testing.T) {
+	for _, kv := range []bool{false, true} { // CAPV, CAPK — both carry the block
+		infra := "capv"
+		if kv {
+			infra = "capk"
+		}
+		t.Run(infra, func(t *testing.T) { assertK0sJoinTokenRetries(t, kv) })
+	}
+}
+
+func assertK0sJoinTokenRetries(t *testing.T, kubevirt bool) {
+	t.Helper()
+	d := haCPData("init", kubevirt)
+	d.ManagementEndpoint.JoinTokenSecretName = "ha-cluster-control-plane-join-token"
+	out, err := RenderK0sCloudConfig(d)
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+
+	if !strings.Contains(out, "k0s token create --role=controller") {
+		t.Fatal("k0s init render lost the controller-join token creation entirely")
+	}
+
+	// The message that described behaviour which does not exist must be gone.
+	// Scoped to the token create: an identically-worded message on the
+	// etcd-status reporter is a separate concern and deliberately untouched here.
+	if strings.Contains(out, "k0s token create returned empty; will retry on next boot") {
+		t.Error("the token create still claims it 'will retry on next boot' — nothing reboots " +
+			"the node, so a single failed create strands every joiner")
+	}
+
+	for _, want := range []string{
+		// create is retried rather than attempted once
+		"for i in {1..60}; do",
+		"k0s token create not ready yet, retrying in 5 seconds...",
+		"still empty after 60 attempts",
+		// the PATCH is retried too
+		"for i in {1..30}; do",
+		"join-token push returned",
+		"after 30 attempts",
+		// a failed curl yields an empty status; the 2xx test must tolerate it
+		// rather than run an arithmetic comparison on "".
+		"2[0-9][0-9]) pushed=yes ;;",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("k0s init render missing %q", want)
+		}
+	}
+
+	// The token must still never be echoed, only enveloped (TOKEN-INV).
+	for _, forbidden := range []string{
+		`echo "${jt}"`,
+		"echo ${jt}",
+		`echo "token: ${jt}"`,
+	} {
+		if strings.Contains(out, forbidden) {
+			t.Errorf("join token is logged via %q — it must only ever be base64-enveloped", forbidden)
+		}
+	}
+}

--- a/internal/bootstrap/ha_test.go
+++ b/internal/bootstrap/ha_test.go
@@ -1282,3 +1282,87 @@ func assertK0sJoinTokenRetries(t *testing.T, kubevirt bool) {
 		}
 	}
 }
+
+// extractShellFunc returns the body of a rendered shell function `name() { ... }`,
+// matching the closing brace at the same indentation as the opening line.
+func extractShellFunc(out, name string) (string, bool) {
+	marker := name + "() {"
+	i := strings.Index(out, marker)
+	if i < 0 {
+		return "", false
+	}
+	lineStart := strings.LastIndex(out[:i], "\n") + 1
+	indent := out[lineStart:i]
+	closer := "\n" + indent + "}"
+	j := strings.Index(out[i:], closer)
+	if j < 0 {
+		return "", false
+	}
+	return out[i : i+j], true
+}
+
+// TestHA_NodePushStepsRetry is a structural invariant over every HA render: the
+// post-bootstrap script's pushes to the MANAGEMENT cluster must retry, not give
+// up after one attempt.
+//
+// Both pushes gate HA formation. initMachineJoinable holds every joiner until
+// the controller-join Secret is non-empty AND (on k0s) the init node's etcd
+// member is reported healthy and voting. The script runs in a oneshot unit with
+// no timer behind it, so a single failed attempt strands the cluster
+// permanently — the old "will retry on next boot" message described a reboot
+// that never happens.
+//
+// Observed for the join token on a bare-metal k0s HA lab (2026-09-08): create
+// returned empty at T+4s, the joiner gate then held for 45 minutes. The
+// etcd-status reporter is the same shape and is covered here so it cannot drift
+// back. Asserting the property rather than the wording means a third push added
+// later is covered on the day it is written.
+func TestHA_NodePushStepsRetry(t *testing.T) {
+	pushFns := []string{"push_join_token", "push_etcd_status"}
+
+	for _, tc := range goldenCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := tc.render(tc.data)
+			if err != nil {
+				t.Fatalf("render: %v", err)
+			}
+
+			if strings.Contains(out, "will retry on next boot") {
+				t.Error("a push still claims it 'will retry on next boot' — the post-bootstrap " +
+					"unit is a oneshot and nothing reboots the node, so that retry never happens")
+			}
+
+			seen := 0
+			for _, fn := range pushFns {
+				body, ok := extractShellFunc(out, fn)
+				if !ok {
+					continue // not rendered for this role/infra combination
+				}
+				seen++
+				if !strings.Contains(body, "for i in {1..") {
+					t.Errorf("%s() makes a single attempt — a transient failure strands every joiner", fn)
+				}
+				// An empty status from a failed curl must not reach an arithmetic
+				// comparison; the 2xx check has to be a glob.
+				if !strings.Contains(body, "2[0-9][0-9])") {
+					t.Errorf("%s() does not use a glob 2xx check — an empty status would abort the loop", fn)
+				}
+				if strings.Contains(body, `"${status}" -ge 200`) {
+					t.Errorf("%s() still arithmetic-compares status; an empty value errors under set -e", fn)
+				}
+			}
+
+			// Every HA render carries the etcd reporter; only the init node pushes
+			// a join token. Guard against the extractor silently matching nothing.
+			if isHAGolden(tc.name) && seen == 0 {
+				t.Errorf("no push function found in HA render %s — extractor or template changed shape", tc.name)
+			}
+		})
+	}
+}
+
+// isHAGolden reports whether a golden case name is one of the HA (init/join)
+// renders, which are the only ones that carry the node-push block.
+func isHAGolden(name string) bool {
+	return strings.HasSuffix(name, "_init") || strings.HasSuffix(name, "_join")
+}

--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capk.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capk.yaml.tmpl
@@ -1025,23 +1025,41 @@ MANIFEST_EOF
         local patch
         patch="{\"data\":{\"${member_key}\":\"${status_b64}\"}}"
         local url="${api}/api/v1/namespaces/${ns}/secrets/${es_name}"
-        local status
-        status=$(curl -k -sS -o /tmp/kairos-etcdstatus-push.log -w "%{http_code}" \
-          -H "Authorization: Bearer ${token}" \
-          -H "Content-Type: application/strategic-merge-patch+json" \
-          -X PATCH \
-          --data "${patch}" \
-          "${url}" || true)
+        # A dropped report blocks HA formation exactly like a dropped join token:
+        # initMachineJoinable treats "member not reported" as not-joinable on k0s,
+        # so the KCP holds every joiner until some node reports. This reporter runs
+        # ONCE, from a oneshot unit, with no timer behind it — "retry on next boot"
+        # described behaviour that does not exist, since nothing reboots the node.
+        # Retry here on the same cadence as the join-token push. The 2xx test is a
+        # glob, not an arithmetic comparison, so an empty status from a failed curl
+        # cannot abort the loop.
+        local status="" reported=""
+        for i in {1..30}; do
+          status=$(curl -k -sS -o /tmp/kairos-etcdstatus-push.log -w "%{http_code}" \
+            -H "Authorization: Bearer ${token}" \
+            -H "Content-Type: application/strategic-merge-patch+json" \
+            -X PATCH \
+            --data "${patch}" \
+            "${url}" || true)
+          case "${status}" in
+            2[0-9][0-9]) reported=yes ;;
+          esac
+          if [ -n "${reported}" ]; then
+            break
+          fi
+          echo "Attempt $i/30: etcd-status report returned '${status}', retrying in 5 seconds..."
+          sleep 5
+        done
         unset token
-        if [ "${status}" -ge 200 ] && [ "${status}" -lt 300 ]; then
+        if [ -n "${reported}" ]; then
           echo "Reported etcd status to management secret ${ns}/${es_name} (member ${member_key})"
           return 0
         fi
-        echo "WARN: failed to report etcd status (status ${status})"
+        echo "WARN: failed to report etcd status after 30 attempts (last status '${status}')"
         return 1
       }
       if ! push_etcd_status; then
-        echo "WARN: etcd-status report failed; will retry on next boot"
+        echo "WARN: etcd-status report failed after retries; the joiner gate will hold until a member is reported"
       fi
       {{- end }}
 

--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capk.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capk.yaml.tmpl
@@ -906,10 +906,23 @@ MANIFEST_EOF
           echo "WARN: base64 not available; cannot push join token"
           return 1
         fi
-        local jt
-        jt=$(k0s token create --role=controller --expiry=24h 2>/dev/null || true)
+        local jt=""
+        # Same race as the CAPV template: `k0s token create` needs the bootstrap
+        # token machinery serving, not just the apiserver, and this script runs
+        # within seconds of k0s starting. The token is the ONLY gate on HA
+        # formation and the unit is a oneshot, so a single failed attempt strands
+        # every joiner permanently — there is no "next boot" to retry on. Bounded
+        # on the same 300s budget as the node-registration waits.
+        for i in {1..60}; do
+          jt=$(k0s token create --role=controller --expiry=24h 2>/dev/null || true)
+          if [ -n "${jt}" ]; then
+            break
+          fi
+          echo "Attempt $i/60: k0s token create not ready yet, retrying in 5 seconds..."
+          sleep 5
+        done
         if [ -z "${jt}" ]; then
-          echo "WARN: k0s token create returned empty; will retry on next boot"
+          echo "WARN: k0s token create still empty after 60 attempts (300s); joiners will block"
           return 1
         fi
         local jt_b64
@@ -922,19 +935,32 @@ MANIFEST_EOF
         local patch
         patch="{\"data\":{\"token\":\"${jt_b64}\"}}"
         local url="${api}/api/v1/namespaces/${ns}/secrets/${jt_name}"
-        local status
-        status=$(curl -k -sS -o /tmp/kairos-jointoken-push.log -w "%{http_code}" \
-          -H "Authorization: Bearer ${token}" \
-          -H "Content-Type: application/strategic-merge-patch+json" \
-          -X PATCH \
-          --data "${patch}" \
-          "${url}" || true)
+        # A transient failure here strands every joiner just as permanently, so
+        # retry. The 2xx test is a glob, not an arithmetic comparison, so an empty
+        # status from a failed curl cannot abort the loop.
+        local status="" pushed=""
+        for i in {1..30}; do
+          status=$(curl -k -sS -o /tmp/kairos-jointoken-push.log -w "%{http_code}" \
+            -H "Authorization: Bearer ${token}" \
+            -H "Content-Type: application/strategic-merge-patch+json" \
+            -X PATCH \
+            --data "${patch}" \
+            "${url}" || true)
+          case "${status}" in
+            2[0-9][0-9]) pushed=yes ;;
+          esac
+          if [ -n "${pushed}" ]; then
+            break
+          fi
+          echo "Attempt $i/30: join-token push returned '${status}', retrying in 5 seconds..."
+          sleep 5
+        done
         unset jt_b64 patch
-        if [ "${status}" -ge 200 ] && [ "${status}" -lt 300 ]; then
+        if [ -n "${pushed}" ]; then
           echo "Pushed controller-join token to management secret ${ns}/${jt_name}"
           return 0
         fi
-        echo "WARN: failed to push controller-join token (status ${status})"
+        echo "WARN: failed to push controller-join token after 30 attempts (last status '${status}')"
         return 1
       }
       if ! push_join_token; then

--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
@@ -930,9 +930,9 @@ MANIFEST_EOF
         #
         # This token is the ONLY gate on HA formation: initMachineJoinable holds
         # every joiner until the Secret is non-empty. The unit is a oneshot, so a
-        # single failed attempt used to strand the cluster permanently — the old
-        # "will retry on next boot" message described behaviour that does not
-        # exist, since nothing reboots the node. Observed on a bare-metal k0s HA
+        # single failed attempt used to strand the cluster permanently: the old
+        # code deferred to a next boot that never comes, since nothing reboots
+        # the node. Observed on a bare-metal k0s HA
         # lab: create returned empty at T+4s, the joiner gate then held for 45
         # minutes, and the identical command run by hand afterwards succeeded.
         #
@@ -1059,23 +1059,41 @@ MANIFEST_EOF
         local patch
         patch="{\"data\":{\"${member_key}\":\"${status_b64}\"}}"
         local url="${api}/api/v1/namespaces/${ns}/secrets/${es_name}"
-        local status
-        status=$(curl -k -sS -o /tmp/kairos-etcdstatus-push.log -w "%{http_code}" \
-          -H "Authorization: Bearer ${token}" \
-          -H "Content-Type: application/strategic-merge-patch+json" \
-          -X PATCH \
-          --data "${patch}" \
-          "${url}" || true)
+        # A dropped report blocks HA formation exactly like a dropped join token:
+        # initMachineJoinable treats "member not reported" as not-joinable on k0s,
+        # so the KCP holds every joiner until some node reports. This reporter runs
+        # ONCE, from a oneshot unit, with no timer behind it — "retry on next boot"
+        # described behaviour that does not exist, since nothing reboots the node.
+        # Retry here on the same cadence as the join-token push. The 2xx test is a
+        # glob, not an arithmetic comparison, so an empty status from a failed curl
+        # cannot abort the loop.
+        local status="" reported=""
+        for i in {1..30}; do
+          status=$(curl -k -sS -o /tmp/kairos-etcdstatus-push.log -w "%{http_code}" \
+            -H "Authorization: Bearer ${token}" \
+            -H "Content-Type: application/strategic-merge-patch+json" \
+            -X PATCH \
+            --data "${patch}" \
+            "${url}" || true)
+          case "${status}" in
+            2[0-9][0-9]) reported=yes ;;
+          esac
+          if [ -n "${reported}" ]; then
+            break
+          fi
+          echo "Attempt $i/30: etcd-status report returned '${status}', retrying in 5 seconds..."
+          sleep 5
+        done
         unset token
-        if [ "${status}" -ge 200 ] && [ "${status}" -lt 300 ]; then
+        if [ -n "${reported}" ]; then
           echo "Reported etcd status to management secret ${ns}/${es_name} (member ${member_key})"
           return 0
         fi
-        echo "WARN: failed to report etcd status (status ${status})"
+        echo "WARN: failed to report etcd status after 30 attempts (last status '${status}')"
         return 1
       }
       if ! push_etcd_status; then
-        echo "WARN: etcd-status report failed; will retry on next boot"
+        echo "WARN: etcd-status report failed after retries; the joiner gate will hold until a member is reported"
       fi
       {{- end }}
 

--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
@@ -921,11 +921,33 @@ MANIFEST_EOF
           echo "WARN: base64 not available; cannot push join token"
           return 1
         fi
-        local jt
+        local jt=""
+        # `k0s token create` needs more than "the apiserver is up" — the bootstrap
+        # token machinery has to be serving too, and that lags k0s start by a few
+        # seconds. This script runs immediately after the kubeconfig push, i.e.
+        # within seconds of k0s starting, so the first attempt loses that race
+        # often enough to matter.
+        #
+        # This token is the ONLY gate on HA formation: initMachineJoinable holds
+        # every joiner until the Secret is non-empty. The unit is a oneshot, so a
+        # single failed attempt used to strand the cluster permanently — the old
+        # "will retry on next boot" message described behaviour that does not
+        # exist, since nothing reboots the node. Observed on a bare-metal k0s HA
+        # lab: create returned empty at T+4s, the joiner gate then held for 45
+        # minutes, and the identical command run by hand afterwards succeeded.
+        #
+        # Bounded on the same 300s budget as the node-registration waits above.
         # Long expiry so the token stays valid across the whole HA join window.
-        jt=$(k0s token create --role=controller --expiry=24h 2>/dev/null || true)
+        for i in {1..60}; do
+          jt=$(k0s token create --role=controller --expiry=24h 2>/dev/null || true)
+          if [ -n "${jt}" ]; then
+            break
+          fi
+          echo "Attempt $i/60: k0s token create not ready yet, retrying in 5 seconds..."
+          sleep 5
+        done
         if [ -z "${jt}" ]; then
-          echo "WARN: k0s token create returned empty; will retry on next boot"
+          echo "WARN: k0s token create still empty after 60 attempts (300s); joiners will block"
           return 1
         fi
         local jt_b64
@@ -945,20 +967,34 @@ MANIFEST_EOF
         local patch
         patch="{\"data\":{\"token\":\"${jt_b64}\"}}"
         local url="${api}/api/v1/namespaces/${ns}/secrets/${jt_name}"
-        local status
-        status=$(curl -k -sS -o /tmp/kairos-jointoken-push.log -w "%{http_code}" \
-          -H "Authorization: Bearer ${token}" \
-          -H "Content-Type: application/strategic-merge-patch+json" \
-          -X PATCH \
-          --data "${patch}" \
-          "${url}" || true)
+        # Same reasoning as the create loop: a transient failure here strands every
+        # joiner just as permanently, so retry rather than give up after one shot.
+        # The 2xx test is a glob, not an arithmetic comparison, so an empty status
+        # from a failed curl cannot abort the loop.
+        local status="" pushed=""
+        for i in {1..30}; do
+          status=$(curl -k -sS -o /tmp/kairos-jointoken-push.log -w "%{http_code}" \
+            -H "Authorization: Bearer ${token}" \
+            -H "Content-Type: application/strategic-merge-patch+json" \
+            -X PATCH \
+            --data "${patch}" \
+            "${url}" || true)
+          case "${status}" in
+            2[0-9][0-9]) pushed=yes ;;
+          esac
+          if [ -n "${pushed}" ]; then
+            break
+          fi
+          echo "Attempt $i/30: join-token push returned '${status}', retrying in 5 seconds..."
+          sleep 5
+        done
         # Scrub the enveloped token too.
         unset jt_b64 patch
-        if [ "${status}" -ge 200 ] && [ "${status}" -lt 300 ]; then
+        if [ -n "${pushed}" ]; then
           echo "Pushed controller-join token to management secret ${ns}/${jt_name}"
           return 0
         fi
-        echo "WARN: failed to push controller-join token (status ${status})"
+        echo "WARN: failed to push controller-join token after 30 attempts (last status '${status}')"
         return 1
       }
       if ! push_join_token; then

--- a/internal/bootstrap/templates/k3s_kairos_cloud_config_capk.yaml.tmpl
+++ b/internal/bootstrap/templates/k3s_kairos_cloud_config_capk.yaml.tmpl
@@ -597,23 +597,41 @@ MANIFEST_EOF
         local patch
         patch="{\"data\":{\"${member_key}\":\"${status_b64}\"}}"
         local url="${api}/api/v1/namespaces/${ns}/secrets/${es_name}"
-        local status
-        status=$(curl -k -sS -o /tmp/kairos-etcdstatus-push.log -w "%{http_code}" \
-          -H "Authorization: Bearer ${token}" \
-          -H "Content-Type: application/strategic-merge-patch+json" \
-          -X PATCH \
-          --data "${patch}" \
-          "${url}" || true)
+        # A dropped report blocks HA formation exactly like a dropped join token:
+        # initMachineJoinable treats "member not reported" as not-joinable on k0s,
+        # so the KCP holds every joiner until some node reports. This reporter runs
+        # ONCE, from a oneshot unit, with no timer behind it — "retry on next boot"
+        # described behaviour that does not exist, since nothing reboots the node.
+        # Retry here on the same cadence as the join-token push. The 2xx test is a
+        # glob, not an arithmetic comparison, so an empty status from a failed curl
+        # cannot abort the loop.
+        local status="" reported=""
+        for i in {1..30}; do
+          status=$(curl -k -sS -o /tmp/kairos-etcdstatus-push.log -w "%{http_code}" \
+            -H "Authorization: Bearer ${token}" \
+            -H "Content-Type: application/strategic-merge-patch+json" \
+            -X PATCH \
+            --data "${patch}" \
+            "${url}" || true)
+          case "${status}" in
+            2[0-9][0-9]) reported=yes ;;
+          esac
+          if [ -n "${reported}" ]; then
+            break
+          fi
+          echo "Attempt $i/30: etcd-status report returned '${status}', retrying in 5 seconds..."
+          sleep 5
+        done
         unset token
-        if [ "${status}" -ge 200 ] && [ "${status}" -lt 300 ]; then
+        if [ -n "${reported}" ]; then
           echo "Reported etcd status to management secret ${ns}/${es_name} (member ${member_key})"
           return 0
         fi
-        echo "WARN: failed to report etcd status (status ${status})"
+        echo "WARN: failed to report etcd status after 30 attempts (last status '${status}')"
         return 1
       }
       if ! push_etcd_status; then
-        echo "WARN: etcd-status report failed; will retry on next boot"
+        echo "WARN: etcd-status report failed after retries; the joiner gate will hold until a member is reported"
       fi
       {{- end }}
 

--- a/internal/bootstrap/templates/k3s_kairos_cloud_config_capv.yaml.tmpl
+++ b/internal/bootstrap/templates/k3s_kairos_cloud_config_capv.yaml.tmpl
@@ -723,23 +723,41 @@ MANIFEST_EOF
         local patch
         patch="{\"data\":{\"${member_key}\":\"${status_b64}\"}}"
         local url="${api}/api/v1/namespaces/${ns}/secrets/${es_name}"
-        local status
-        status=$(curl -k -sS -o /tmp/kairos-etcdstatus-push.log -w "%{http_code}" \
-          -H "Authorization: Bearer ${token}" \
-          -H "Content-Type: application/strategic-merge-patch+json" \
-          -X PATCH \
-          --data "${patch}" \
-          "${url}" || true)
+        # A dropped report blocks HA formation exactly like a dropped join token:
+        # initMachineJoinable treats "member not reported" as not-joinable on k0s,
+        # so the KCP holds every joiner until some node reports. This reporter runs
+        # ONCE, from a oneshot unit, with no timer behind it — "retry on next boot"
+        # described behaviour that does not exist, since nothing reboots the node.
+        # Retry here on the same cadence as the join-token push. The 2xx test is a
+        # glob, not an arithmetic comparison, so an empty status from a failed curl
+        # cannot abort the loop.
+        local status="" reported=""
+        for i in {1..30}; do
+          status=$(curl -k -sS -o /tmp/kairos-etcdstatus-push.log -w "%{http_code}" \
+            -H "Authorization: Bearer ${token}" \
+            -H "Content-Type: application/strategic-merge-patch+json" \
+            -X PATCH \
+            --data "${patch}" \
+            "${url}" || true)
+          case "${status}" in
+            2[0-9][0-9]) reported=yes ;;
+          esac
+          if [ -n "${reported}" ]; then
+            break
+          fi
+          echo "Attempt $i/30: etcd-status report returned '${status}', retrying in 5 seconds..."
+          sleep 5
+        done
         unset token
-        if [ "${status}" -ge 200 ] && [ "${status}" -lt 300 ]; then
+        if [ -n "${reported}" ]; then
           echo "Reported etcd status to management secret ${ns}/${es_name} (member ${member_key})"
           return 0
         fi
-        echo "WARN: failed to report etcd status (status ${status})"
+        echo "WARN: failed to report etcd status after 30 attempts (last status '${status}')"
         return 1
       }
       if ! push_etcd_status; then
-        echo "WARN: etcd-status report failed; will retry on next boot"
+        echo "WARN: etcd-status report failed after retries; the joiner gate will hold until a member is reported"
       fi
       {{- end }}
 

--- a/internal/bootstrap/testdata/golden/k0s_capk_init.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capk_init.yaml
@@ -642,10 +642,23 @@ write_files:
           echo "WARN: base64 not available; cannot push join token"
           return 1
         fi
-        local jt
-        jt=$(k0s token create --role=controller --expiry=24h 2>/dev/null || true)
+        local jt=""
+        # Same race as the CAPV template: `k0s token create` needs the bootstrap
+        # token machinery serving, not just the apiserver, and this script runs
+        # within seconds of k0s starting. The token is the ONLY gate on HA
+        # formation and the unit is a oneshot, so a single failed attempt strands
+        # every joiner permanently — there is no "next boot" to retry on. Bounded
+        # on the same 300s budget as the node-registration waits.
+        for i in {1..60}; do
+          jt=$(k0s token create --role=controller --expiry=24h 2>/dev/null || true)
+          if [ -n "${jt}" ]; then
+            break
+          fi
+          echo "Attempt $i/60: k0s token create not ready yet, retrying in 5 seconds..."
+          sleep 5
+        done
         if [ -z "${jt}" ]; then
-          echo "WARN: k0s token create returned empty; will retry on next boot"
+          echo "WARN: k0s token create still empty after 60 attempts (300s); joiners will block"
           return 1
         fi
         local jt_b64
@@ -658,19 +671,32 @@ write_files:
         local patch
         patch="{\"data\":{\"token\":\"${jt_b64}\"}}"
         local url="${api}/api/v1/namespaces/${ns}/secrets/${jt_name}"
-        local status
-        status=$(curl -k -sS -o /tmp/kairos-jointoken-push.log -w "%{http_code}" \
-          -H "Authorization: Bearer ${token}" \
-          -H "Content-Type: application/strategic-merge-patch+json" \
-          -X PATCH \
-          --data "${patch}" \
-          "${url}" || true)
+        # A transient failure here strands every joiner just as permanently, so
+        # retry. The 2xx test is a glob, not an arithmetic comparison, so an empty
+        # status from a failed curl cannot abort the loop.
+        local status="" pushed=""
+        for i in {1..30}; do
+          status=$(curl -k -sS -o /tmp/kairos-jointoken-push.log -w "%{http_code}" \
+            -H "Authorization: Bearer ${token}" \
+            -H "Content-Type: application/strategic-merge-patch+json" \
+            -X PATCH \
+            --data "${patch}" \
+            "${url}" || true)
+          case "${status}" in
+            2[0-9][0-9]) pushed=yes ;;
+          esac
+          if [ -n "${pushed}" ]; then
+            break
+          fi
+          echo "Attempt $i/30: join-token push returned '${status}', retrying in 5 seconds..."
+          sleep 5
+        done
         unset jt_b64 patch
-        if [ "${status}" -ge 200 ] && [ "${status}" -lt 300 ]; then
+        if [ -n "${pushed}" ]; then
           echo "Pushed controller-join token to management secret ${ns}/${jt_name}"
           return 0
         fi
-        echo "WARN: failed to push controller-join token (status ${status})"
+        echo "WARN: failed to push controller-join token after 30 attempts (last status '${status}')"
         return 1
       }
       if ! push_join_token; then

--- a/internal/bootstrap/testdata/golden/k0s_capk_init.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capk_init.yaml
@@ -758,23 +758,41 @@ write_files:
         local patch
         patch="{\"data\":{\"${member_key}\":\"${status_b64}\"}}"
         local url="${api}/api/v1/namespaces/${ns}/secrets/${es_name}"
-        local status
-        status=$(curl -k -sS -o /tmp/kairos-etcdstatus-push.log -w "%{http_code}" \
-          -H "Authorization: Bearer ${token}" \
-          -H "Content-Type: application/strategic-merge-patch+json" \
-          -X PATCH \
-          --data "${patch}" \
-          "${url}" || true)
+        # A dropped report blocks HA formation exactly like a dropped join token:
+        # initMachineJoinable treats "member not reported" as not-joinable on k0s,
+        # so the KCP holds every joiner until some node reports. This reporter runs
+        # ONCE, from a oneshot unit, with no timer behind it — "retry on next boot"
+        # described behaviour that does not exist, since nothing reboots the node.
+        # Retry here on the same cadence as the join-token push. The 2xx test is a
+        # glob, not an arithmetic comparison, so an empty status from a failed curl
+        # cannot abort the loop.
+        local status="" reported=""
+        for i in {1..30}; do
+          status=$(curl -k -sS -o /tmp/kairos-etcdstatus-push.log -w "%{http_code}" \
+            -H "Authorization: Bearer ${token}" \
+            -H "Content-Type: application/strategic-merge-patch+json" \
+            -X PATCH \
+            --data "${patch}" \
+            "${url}" || true)
+          case "${status}" in
+            2[0-9][0-9]) reported=yes ;;
+          esac
+          if [ -n "${reported}" ]; then
+            break
+          fi
+          echo "Attempt $i/30: etcd-status report returned '${status}', retrying in 5 seconds..."
+          sleep 5
+        done
         unset token
-        if [ "${status}" -ge 200 ] && [ "${status}" -lt 300 ]; then
+        if [ -n "${reported}" ]; then
           echo "Reported etcd status to management secret ${ns}/${es_name} (member ${member_key})"
           return 0
         fi
-        echo "WARN: failed to report etcd status (status ${status})"
+        echo "WARN: failed to report etcd status after 30 attempts (last status '${status}')"
         return 1
       }
       if ! push_etcd_status; then
-        echo "WARN: etcd-status report failed; will retry on next boot"
+        echo "WARN: etcd-status report failed after retries; the joiner gate will hold until a member is reported"
       fi
 
       # Mark bootstrap success for CAPI/CAPK consumers

--- a/internal/bootstrap/testdata/golden/k0s_capk_join.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capk_join.yaml
@@ -688,23 +688,41 @@ write_files:
         local patch
         patch="{\"data\":{\"${member_key}\":\"${status_b64}\"}}"
         local url="${api}/api/v1/namespaces/${ns}/secrets/${es_name}"
-        local status
-        status=$(curl -k -sS -o /tmp/kairos-etcdstatus-push.log -w "%{http_code}" \
-          -H "Authorization: Bearer ${token}" \
-          -H "Content-Type: application/strategic-merge-patch+json" \
-          -X PATCH \
-          --data "${patch}" \
-          "${url}" || true)
+        # A dropped report blocks HA formation exactly like a dropped join token:
+        # initMachineJoinable treats "member not reported" as not-joinable on k0s,
+        # so the KCP holds every joiner until some node reports. This reporter runs
+        # ONCE, from a oneshot unit, with no timer behind it — "retry on next boot"
+        # described behaviour that does not exist, since nothing reboots the node.
+        # Retry here on the same cadence as the join-token push. The 2xx test is a
+        # glob, not an arithmetic comparison, so an empty status from a failed curl
+        # cannot abort the loop.
+        local status="" reported=""
+        for i in {1..30}; do
+          status=$(curl -k -sS -o /tmp/kairos-etcdstatus-push.log -w "%{http_code}" \
+            -H "Authorization: Bearer ${token}" \
+            -H "Content-Type: application/strategic-merge-patch+json" \
+            -X PATCH \
+            --data "${patch}" \
+            "${url}" || true)
+          case "${status}" in
+            2[0-9][0-9]) reported=yes ;;
+          esac
+          if [ -n "${reported}" ]; then
+            break
+          fi
+          echo "Attempt $i/30: etcd-status report returned '${status}', retrying in 5 seconds..."
+          sleep 5
+        done
         unset token
-        if [ "${status}" -ge 200 ] && [ "${status}" -lt 300 ]; then
+        if [ -n "${reported}" ]; then
           echo "Reported etcd status to management secret ${ns}/${es_name} (member ${member_key})"
           return 0
         fi
-        echo "WARN: failed to report etcd status (status ${status})"
+        echo "WARN: failed to report etcd status after 30 attempts (last status '${status}')"
         return 1
       }
       if ! push_etcd_status; then
-        echo "WARN: etcd-status report failed; will retry on next boot"
+        echo "WARN: etcd-status report failed after retries; the joiner gate will hold until a member is reported"
       fi
 
       # Mark bootstrap success for CAPI/CAPK consumers

--- a/internal/bootstrap/testdata/golden/k0s_capv_init.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capv_init.yaml
@@ -514,9 +514,9 @@ write_files:
         #
         # This token is the ONLY gate on HA formation: initMachineJoinable holds
         # every joiner until the Secret is non-empty. The unit is a oneshot, so a
-        # single failed attempt used to strand the cluster permanently — the old
-        # "will retry on next boot" message described behaviour that does not
-        # exist, since nothing reboots the node. Observed on a bare-metal k0s HA
+        # single failed attempt used to strand the cluster permanently: the old
+        # code deferred to a next boot that never comes, since nothing reboots
+        # the node. Observed on a bare-metal k0s HA
         # lab: create returned empty at T+4s, the joiner gate then held for 45
         # minutes, and the identical command run by hand afterwards succeeded.
         #
@@ -640,23 +640,41 @@ write_files:
         local patch
         patch="{\"data\":{\"${member_key}\":\"${status_b64}\"}}"
         local url="${api}/api/v1/namespaces/${ns}/secrets/${es_name}"
-        local status
-        status=$(curl -k -sS -o /tmp/kairos-etcdstatus-push.log -w "%{http_code}" \
-          -H "Authorization: Bearer ${token}" \
-          -H "Content-Type: application/strategic-merge-patch+json" \
-          -X PATCH \
-          --data "${patch}" \
-          "${url}" || true)
+        # A dropped report blocks HA formation exactly like a dropped join token:
+        # initMachineJoinable treats "member not reported" as not-joinable on k0s,
+        # so the KCP holds every joiner until some node reports. This reporter runs
+        # ONCE, from a oneshot unit, with no timer behind it — "retry on next boot"
+        # described behaviour that does not exist, since nothing reboots the node.
+        # Retry here on the same cadence as the join-token push. The 2xx test is a
+        # glob, not an arithmetic comparison, so an empty status from a failed curl
+        # cannot abort the loop.
+        local status="" reported=""
+        for i in {1..30}; do
+          status=$(curl -k -sS -o /tmp/kairos-etcdstatus-push.log -w "%{http_code}" \
+            -H "Authorization: Bearer ${token}" \
+            -H "Content-Type: application/strategic-merge-patch+json" \
+            -X PATCH \
+            --data "${patch}" \
+            "${url}" || true)
+          case "${status}" in
+            2[0-9][0-9]) reported=yes ;;
+          esac
+          if [ -n "${reported}" ]; then
+            break
+          fi
+          echo "Attempt $i/30: etcd-status report returned '${status}', retrying in 5 seconds..."
+          sleep 5
+        done
         unset token
-        if [ "${status}" -ge 200 ] && [ "${status}" -lt 300 ]; then
+        if [ -n "${reported}" ]; then
           echo "Reported etcd status to management secret ${ns}/${es_name} (member ${member_key})"
           return 0
         fi
-        echo "WARN: failed to report etcd status (status ${status})"
+        echo "WARN: failed to report etcd status after 30 attempts (last status '${status}')"
         return 1
       }
       if ! push_etcd_status; then
-        echo "WARN: etcd-status report failed; will retry on next boot"
+        echo "WARN: etcd-status report failed after retries; the joiner gate will hold until a member is reported"
       fi
 
       # Mark bootstrap success for CAPI/CAPK consumers

--- a/internal/bootstrap/testdata/golden/k0s_capv_init.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capv_init.yaml
@@ -505,11 +505,33 @@ write_files:
           echo "WARN: base64 not available; cannot push join token"
           return 1
         fi
-        local jt
+        local jt=""
+        # `k0s token create` needs more than "the apiserver is up" — the bootstrap
+        # token machinery has to be serving too, and that lags k0s start by a few
+        # seconds. This script runs immediately after the kubeconfig push, i.e.
+        # within seconds of k0s starting, so the first attempt loses that race
+        # often enough to matter.
+        #
+        # This token is the ONLY gate on HA formation: initMachineJoinable holds
+        # every joiner until the Secret is non-empty. The unit is a oneshot, so a
+        # single failed attempt used to strand the cluster permanently — the old
+        # "will retry on next boot" message described behaviour that does not
+        # exist, since nothing reboots the node. Observed on a bare-metal k0s HA
+        # lab: create returned empty at T+4s, the joiner gate then held for 45
+        # minutes, and the identical command run by hand afterwards succeeded.
+        #
+        # Bounded on the same 300s budget as the node-registration waits above.
         # Long expiry so the token stays valid across the whole HA join window.
-        jt=$(k0s token create --role=controller --expiry=24h 2>/dev/null || true)
+        for i in {1..60}; do
+          jt=$(k0s token create --role=controller --expiry=24h 2>/dev/null || true)
+          if [ -n "${jt}" ]; then
+            break
+          fi
+          echo "Attempt $i/60: k0s token create not ready yet, retrying in 5 seconds..."
+          sleep 5
+        done
         if [ -z "${jt}" ]; then
-          echo "WARN: k0s token create returned empty; will retry on next boot"
+          echo "WARN: k0s token create still empty after 60 attempts (300s); joiners will block"
           return 1
         fi
         local jt_b64
@@ -529,20 +551,34 @@ write_files:
         local patch
         patch="{\"data\":{\"token\":\"${jt_b64}\"}}"
         local url="${api}/api/v1/namespaces/${ns}/secrets/${jt_name}"
-        local status
-        status=$(curl -k -sS -o /tmp/kairos-jointoken-push.log -w "%{http_code}" \
-          -H "Authorization: Bearer ${token}" \
-          -H "Content-Type: application/strategic-merge-patch+json" \
-          -X PATCH \
-          --data "${patch}" \
-          "${url}" || true)
+        # Same reasoning as the create loop: a transient failure here strands every
+        # joiner just as permanently, so retry rather than give up after one shot.
+        # The 2xx test is a glob, not an arithmetic comparison, so an empty status
+        # from a failed curl cannot abort the loop.
+        local status="" pushed=""
+        for i in {1..30}; do
+          status=$(curl -k -sS -o /tmp/kairos-jointoken-push.log -w "%{http_code}" \
+            -H "Authorization: Bearer ${token}" \
+            -H "Content-Type: application/strategic-merge-patch+json" \
+            -X PATCH \
+            --data "${patch}" \
+            "${url}" || true)
+          case "${status}" in
+            2[0-9][0-9]) pushed=yes ;;
+          esac
+          if [ -n "${pushed}" ]; then
+            break
+          fi
+          echo "Attempt $i/30: join-token push returned '${status}', retrying in 5 seconds..."
+          sleep 5
+        done
         # Scrub the enveloped token too.
         unset jt_b64 patch
-        if [ "${status}" -ge 200 ] && [ "${status}" -lt 300 ]; then
+        if [ -n "${pushed}" ]; then
           echo "Pushed controller-join token to management secret ${ns}/${jt_name}"
           return 0
         fi
-        echo "WARN: failed to push controller-join token (status ${status})"
+        echo "WARN: failed to push controller-join token after 30 attempts (last status '${status}')"
         return 1
       }
       if ! push_join_token; then

--- a/internal/bootstrap/testdata/golden/k0s_capv_join.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capv_join.yaml
@@ -542,23 +542,41 @@ write_files:
         local patch
         patch="{\"data\":{\"${member_key}\":\"${status_b64}\"}}"
         local url="${api}/api/v1/namespaces/${ns}/secrets/${es_name}"
-        local status
-        status=$(curl -k -sS -o /tmp/kairos-etcdstatus-push.log -w "%{http_code}" \
-          -H "Authorization: Bearer ${token}" \
-          -H "Content-Type: application/strategic-merge-patch+json" \
-          -X PATCH \
-          --data "${patch}" \
-          "${url}" || true)
+        # A dropped report blocks HA formation exactly like a dropped join token:
+        # initMachineJoinable treats "member not reported" as not-joinable on k0s,
+        # so the KCP holds every joiner until some node reports. This reporter runs
+        # ONCE, from a oneshot unit, with no timer behind it — "retry on next boot"
+        # described behaviour that does not exist, since nothing reboots the node.
+        # Retry here on the same cadence as the join-token push. The 2xx test is a
+        # glob, not an arithmetic comparison, so an empty status from a failed curl
+        # cannot abort the loop.
+        local status="" reported=""
+        for i in {1..30}; do
+          status=$(curl -k -sS -o /tmp/kairos-etcdstatus-push.log -w "%{http_code}" \
+            -H "Authorization: Bearer ${token}" \
+            -H "Content-Type: application/strategic-merge-patch+json" \
+            -X PATCH \
+            --data "${patch}" \
+            "${url}" || true)
+          case "${status}" in
+            2[0-9][0-9]) reported=yes ;;
+          esac
+          if [ -n "${reported}" ]; then
+            break
+          fi
+          echo "Attempt $i/30: etcd-status report returned '${status}', retrying in 5 seconds..."
+          sleep 5
+        done
         unset token
-        if [ "${status}" -ge 200 ] && [ "${status}" -lt 300 ]; then
+        if [ -n "${reported}" ]; then
           echo "Reported etcd status to management secret ${ns}/${es_name} (member ${member_key})"
           return 0
         fi
-        echo "WARN: failed to report etcd status (status ${status})"
+        echo "WARN: failed to report etcd status after 30 attempts (last status '${status}')"
         return 1
       }
       if ! push_etcd_status; then
-        echo "WARN: etcd-status report failed; will retry on next boot"
+        echo "WARN: etcd-status report failed after retries; the joiner gate will hold until a member is reported"
       fi
 
       # Mark bootstrap success for CAPI/CAPK consumers

--- a/internal/bootstrap/testdata/golden/k3s_capk_init.yaml
+++ b/internal/bootstrap/testdata/golden/k3s_capk_init.yaml
@@ -403,23 +403,41 @@ write_files:
         local patch
         patch="{\"data\":{\"${member_key}\":\"${status_b64}\"}}"
         local url="${api}/api/v1/namespaces/${ns}/secrets/${es_name}"
-        local status
-        status=$(curl -k -sS -o /tmp/kairos-etcdstatus-push.log -w "%{http_code}" \
-          -H "Authorization: Bearer ${token}" \
-          -H "Content-Type: application/strategic-merge-patch+json" \
-          -X PATCH \
-          --data "${patch}" \
-          "${url}" || true)
+        # A dropped report blocks HA formation exactly like a dropped join token:
+        # initMachineJoinable treats "member not reported" as not-joinable on k0s,
+        # so the KCP holds every joiner until some node reports. This reporter runs
+        # ONCE, from a oneshot unit, with no timer behind it — "retry on next boot"
+        # described behaviour that does not exist, since nothing reboots the node.
+        # Retry here on the same cadence as the join-token push. The 2xx test is a
+        # glob, not an arithmetic comparison, so an empty status from a failed curl
+        # cannot abort the loop.
+        local status="" reported=""
+        for i in {1..30}; do
+          status=$(curl -k -sS -o /tmp/kairos-etcdstatus-push.log -w "%{http_code}" \
+            -H "Authorization: Bearer ${token}" \
+            -H "Content-Type: application/strategic-merge-patch+json" \
+            -X PATCH \
+            --data "${patch}" \
+            "${url}" || true)
+          case "${status}" in
+            2[0-9][0-9]) reported=yes ;;
+          esac
+          if [ -n "${reported}" ]; then
+            break
+          fi
+          echo "Attempt $i/30: etcd-status report returned '${status}', retrying in 5 seconds..."
+          sleep 5
+        done
         unset token
-        if [ "${status}" -ge 200 ] && [ "${status}" -lt 300 ]; then
+        if [ -n "${reported}" ]; then
           echo "Reported etcd status to management secret ${ns}/${es_name} (member ${member_key})"
           return 0
         fi
-        echo "WARN: failed to report etcd status (status ${status})"
+        echo "WARN: failed to report etcd status after 30 attempts (last status '${status}')"
         return 1
       }
       if ! push_etcd_status; then
-        echo "WARN: etcd-status report failed; will retry on next boot"
+        echo "WARN: etcd-status report failed after retries; the joiner gate will hold until a member is reported"
       fi
 
       # Mark bootstrap success for CAPI/CAPK consumers

--- a/internal/bootstrap/testdata/golden/k3s_capk_join.yaml
+++ b/internal/bootstrap/testdata/golden/k3s_capk_join.yaml
@@ -394,23 +394,41 @@ write_files:
         local patch
         patch="{\"data\":{\"${member_key}\":\"${status_b64}\"}}"
         local url="${api}/api/v1/namespaces/${ns}/secrets/${es_name}"
-        local status
-        status=$(curl -k -sS -o /tmp/kairos-etcdstatus-push.log -w "%{http_code}" \
-          -H "Authorization: Bearer ${token}" \
-          -H "Content-Type: application/strategic-merge-patch+json" \
-          -X PATCH \
-          --data "${patch}" \
-          "${url}" || true)
+        # A dropped report blocks HA formation exactly like a dropped join token:
+        # initMachineJoinable treats "member not reported" as not-joinable on k0s,
+        # so the KCP holds every joiner until some node reports. This reporter runs
+        # ONCE, from a oneshot unit, with no timer behind it — "retry on next boot"
+        # described behaviour that does not exist, since nothing reboots the node.
+        # Retry here on the same cadence as the join-token push. The 2xx test is a
+        # glob, not an arithmetic comparison, so an empty status from a failed curl
+        # cannot abort the loop.
+        local status="" reported=""
+        for i in {1..30}; do
+          status=$(curl -k -sS -o /tmp/kairos-etcdstatus-push.log -w "%{http_code}" \
+            -H "Authorization: Bearer ${token}" \
+            -H "Content-Type: application/strategic-merge-patch+json" \
+            -X PATCH \
+            --data "${patch}" \
+            "${url}" || true)
+          case "${status}" in
+            2[0-9][0-9]) reported=yes ;;
+          esac
+          if [ -n "${reported}" ]; then
+            break
+          fi
+          echo "Attempt $i/30: etcd-status report returned '${status}', retrying in 5 seconds..."
+          sleep 5
+        done
         unset token
-        if [ "${status}" -ge 200 ] && [ "${status}" -lt 300 ]; then
+        if [ -n "${reported}" ]; then
           echo "Reported etcd status to management secret ${ns}/${es_name} (member ${member_key})"
           return 0
         fi
-        echo "WARN: failed to report etcd status (status ${status})"
+        echo "WARN: failed to report etcd status after 30 attempts (last status '${status}')"
         return 1
       }
       if ! push_etcd_status; then
-        echo "WARN: etcd-status report failed; will retry on next boot"
+        echo "WARN: etcd-status report failed after retries; the joiner gate will hold until a member is reported"
       fi
 
       # Mark bootstrap success for CAPI/CAPK consumers

--- a/internal/bootstrap/testdata/golden/k3s_capv_init.yaml
+++ b/internal/bootstrap/testdata/golden/k3s_capv_init.yaml
@@ -460,23 +460,41 @@ write_files:
         local patch
         patch="{\"data\":{\"${member_key}\":\"${status_b64}\"}}"
         local url="${api}/api/v1/namespaces/${ns}/secrets/${es_name}"
-        local status
-        status=$(curl -k -sS -o /tmp/kairos-etcdstatus-push.log -w "%{http_code}" \
-          -H "Authorization: Bearer ${token}" \
-          -H "Content-Type: application/strategic-merge-patch+json" \
-          -X PATCH \
-          --data "${patch}" \
-          "${url}" || true)
+        # A dropped report blocks HA formation exactly like a dropped join token:
+        # initMachineJoinable treats "member not reported" as not-joinable on k0s,
+        # so the KCP holds every joiner until some node reports. This reporter runs
+        # ONCE, from a oneshot unit, with no timer behind it — "retry on next boot"
+        # described behaviour that does not exist, since nothing reboots the node.
+        # Retry here on the same cadence as the join-token push. The 2xx test is a
+        # glob, not an arithmetic comparison, so an empty status from a failed curl
+        # cannot abort the loop.
+        local status="" reported=""
+        for i in {1..30}; do
+          status=$(curl -k -sS -o /tmp/kairos-etcdstatus-push.log -w "%{http_code}" \
+            -H "Authorization: Bearer ${token}" \
+            -H "Content-Type: application/strategic-merge-patch+json" \
+            -X PATCH \
+            --data "${patch}" \
+            "${url}" || true)
+          case "${status}" in
+            2[0-9][0-9]) reported=yes ;;
+          esac
+          if [ -n "${reported}" ]; then
+            break
+          fi
+          echo "Attempt $i/30: etcd-status report returned '${status}', retrying in 5 seconds..."
+          sleep 5
+        done
         unset token
-        if [ "${status}" -ge 200 ] && [ "${status}" -lt 300 ]; then
+        if [ -n "${reported}" ]; then
           echo "Reported etcd status to management secret ${ns}/${es_name} (member ${member_key})"
           return 0
         fi
-        echo "WARN: failed to report etcd status (status ${status})"
+        echo "WARN: failed to report etcd status after 30 attempts (last status '${status}')"
         return 1
       }
       if ! push_etcd_status; then
-        echo "WARN: etcd-status report failed; will retry on next boot"
+        echo "WARN: etcd-status report failed after retries; the joiner gate will hold until a member is reported"
       fi
 
       # Mark bootstrap success for CAPI/CAPK consumers

--- a/internal/bootstrap/testdata/golden/k3s_capv_join.yaml
+++ b/internal/bootstrap/testdata/golden/k3s_capv_join.yaml
@@ -448,23 +448,41 @@ write_files:
         local patch
         patch="{\"data\":{\"${member_key}\":\"${status_b64}\"}}"
         local url="${api}/api/v1/namespaces/${ns}/secrets/${es_name}"
-        local status
-        status=$(curl -k -sS -o /tmp/kairos-etcdstatus-push.log -w "%{http_code}" \
-          -H "Authorization: Bearer ${token}" \
-          -H "Content-Type: application/strategic-merge-patch+json" \
-          -X PATCH \
-          --data "${patch}" \
-          "${url}" || true)
+        # A dropped report blocks HA formation exactly like a dropped join token:
+        # initMachineJoinable treats "member not reported" as not-joinable on k0s,
+        # so the KCP holds every joiner until some node reports. This reporter runs
+        # ONCE, from a oneshot unit, with no timer behind it — "retry on next boot"
+        # described behaviour that does not exist, since nothing reboots the node.
+        # Retry here on the same cadence as the join-token push. The 2xx test is a
+        # glob, not an arithmetic comparison, so an empty status from a failed curl
+        # cannot abort the loop.
+        local status="" reported=""
+        for i in {1..30}; do
+          status=$(curl -k -sS -o /tmp/kairos-etcdstatus-push.log -w "%{http_code}" \
+            -H "Authorization: Bearer ${token}" \
+            -H "Content-Type: application/strategic-merge-patch+json" \
+            -X PATCH \
+            --data "${patch}" \
+            "${url}" || true)
+          case "${status}" in
+            2[0-9][0-9]) reported=yes ;;
+          esac
+          if [ -n "${reported}" ]; then
+            break
+          fi
+          echo "Attempt $i/30: etcd-status report returned '${status}', retrying in 5 seconds..."
+          sleep 5
+        done
         unset token
-        if [ "${status}" -ge 200 ] && [ "${status}" -lt 300 ]; then
+        if [ -n "${reported}" ]; then
           echo "Reported etcd status to management secret ${ns}/${es_name} (member ${member_key})"
           return 0
         fi
-        echo "WARN: failed to report etcd status (status ${status})"
+        echo "WARN: failed to report etcd status after 30 attempts (last status '${status}')"
         return 1
       }
       if ! push_etcd_status; then
-        echo "WARN: etcd-status report failed; will retry on next boot"
+        echo "WARN: etcd-status report failed after retries; the joiner gate will hold until a member is reported"
       fi
 
       # Mark bootstrap success for CAPI/CAPK consumers


### PR DESCRIPTION
> Stacked on #97 (both append tests to `ha_test.go`; the template changes are independent). Merge after it — until then the Files tab shows that PR's diff as well.

## Summary

Both management-cluster push steps of the k0s post-bootstrap script made **one** attempt and, on failure, logged "will retry on next boot" — from a oneshot unit that then exits 0. Nothing reboots the node, so a single lost race stranded the cluster permanently. Both now retry.

## Why

`initMachineJoinable` holds every k0s joiner until the per-cluster controller-join Secret is non-empty, and only the init node can fill it. Reproduced on a bare-metal k0s HA lab (2026-09-08):

```
07:19:25  Started k0s - Zero Friction Kubernetes.
07:19:29  Pushed kubeconfig to management secret b7e2e/b7e2e-kubeconfig
07:19:29  WARN: k0s token create returned empty; will retry on next boot
07:19:29  WARN: controller-join token push failed; joiners will wait
07:19:29  k0s post-bootstrap tasks completed successfully
```

The KCP then logged "Holding back join machine until init machine is joinable" every 15 s for 45 minutes. The identical command run by hand on that node afterwards returned a 1738-byte token — the apiserver was simply not ready for token creation at T+4 s, a narrower window than "apiserver up" (the kubeconfig push in the same script had just succeeded).

The etcd-status report is the same shape in the sibling function, and a dropped report blocks HA formation identically: `initMachineJoinable` treats "member not reported" as not-joinable on k0s.

## What changes

- `k0s token create`: 60 attempts / 5 s, matching the 300 s budget the node-registration waits in the same script already use; the PATCH: 30 × 5 s, matching the sibling providerID patch. The token is still only base64-enveloped, never echoed.
- `push_etcd_status`: the PATCH retries 30 × 5 s. Applied to all four templates (k3s/k0s × CAPV/CAPK), which carry the identical block; only init/join goldens change.
- The 2xx check becomes a glob rather than an arithmetic comparison, so an empty status from a failed `curl` cannot abort the loop under `set -e`.

## Tests

`TestHA_K0sJoinTokenPushRetries`, and `TestHA_NodePushStepsRetry` — a structural invariant over every golden: each management-cluster push function must retry and use the glob 2xx check, and no render may claim it "will retry on next boot". Asserting the property rather than the wording means a third push added later is covered the day it is written.

Validated on the lab: the join token was pushed on the second attempt and the three-replica k0s control plane proceeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
