### PR TITLE
fix: pin k0s controller arguments, apply them after a late start, and write a start-gate marker

### DIFF
--- a/internal/bootstrap/ha_test.go
+++ b/internal/bootstrap/ha_test.go
@@ -1453,3 +1453,70 @@ func TestHA_K0sArgsDropInMatchesK0sArgs(t *testing.T) {
 		})
 	}
 }
+
+// TestHA_K0sAppliesArgsAfterLateStart guards the corrective path for the k0s
+// init-ordering race.
+//
+// k0scontroller is enabled and started before the arguments meant for it exist
+// on disk, and BOTH delivery paths land afterwards. systemd loads the drop-ins —
+// the effective ExecStart is correct — but a process already running keeps its
+// original argv, measured on the lab as `systemctl show` returning the full
+// command line while /proc/<pid>/cmdline was a bare `k0s controller`. Only a
+// restart applies them.
+//
+// The restart must not look like the mechanism ADR 0004 removed: that was a
+// oneshot ordered ahead of the k0s unit, an ordering cycle by construction. This
+// one runs from the post-bootstrap unit (After=/Wants= only) and detaches via
+// systemd-run --no-block, and it must be conditional so a boot that won the race
+// is untouched.
+func TestHA_K0sAppliesArgsAfterLateStart(t *testing.T) {
+	for _, tc := range goldenCases() {
+		if !strings.HasPrefix(tc.name, "k0s_") {
+			continue
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := tc.render(tc.data)
+			if err != nil {
+				t.Fatalf("render: %v", err)
+			}
+
+			for _, want := range []string{
+				"/usr/local/bin/kairos-k0s-apply-args.sh",
+				"systemd-run --no-block",
+				// conditional: compares live argv against the effective ExecStart
+				"/proc/${pid}/cmdline",
+				"systemctl show -p ExecStart --value",
+			} {
+				if !strings.Contains(out, want) {
+					t.Errorf("k0s control-plane render missing %q", want)
+				}
+			}
+
+			// The removed pre-start ordering must never come back.
+			if strings.Contains(out, "Before=k0scontroller.service") {
+				t.Error("reintroduced the pre-start ordering ADR 0004 removed (deadlocks the node)")
+			}
+
+			// The destructive branch exists only where it is provably safe: a JOIN
+			// controller whose live argv lacks the token flag did not join, so the
+			// state it created is a cluster of its own. It must never render for an
+			// init or single node, which legitimately own their state.
+			isJoin := strings.HasSuffix(tc.name, "_join")
+			hasWipe := strings.Contains(out, "self-initialised without its token")
+			if isJoin && !hasWipe {
+				t.Error("join render is missing the self-initialised-state reset; restarting with the " +
+					"token alone would leave it in the rival cluster it created")
+			}
+			if !isJoin && hasWipe {
+				t.Error("non-join render must NOT carry the state reset — an init node owns its own datastore")
+			}
+			if hasWipe {
+				for _, keep := range []string{"! -name bin", "! -name manifests"} {
+					if !strings.Contains(out, keep) {
+						t.Errorf("state reset must preserve %q (k0s binaries / the kube-vip manifest)", keep)
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/bootstrap/ha_test.go
+++ b/internal/bootstrap/ha_test.go
@@ -1520,3 +1520,128 @@ func TestHA_K0sAppliesArgsAfterLateStart(t *testing.T) {
 		})
 	}
 }
+
+// k0sRenders returns every k0s golden render plus a worker render, so
+// worker-only units (k0sworker.service) are covered as well.
+func k0sRenders(t *testing.T) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	for _, tc := range goldenCases() {
+		if !strings.HasPrefix(tc.name, "k0s_") {
+			continue
+		}
+		s, err := tc.render(tc.data)
+		if err != nil {
+			t.Fatalf("render %s: %v", tc.name, err)
+		}
+		out[tc.name] = s
+	}
+	w := haCPData("single", false)
+	w.Role = "worker"
+	w.ControlPlaneRole = ""
+	w.WorkerToken = "k0s-worker-join-token"
+	s, err := RenderK0sCloudConfig(w)
+	if err != nil {
+		t.Fatalf("render k0s worker: %v", err)
+	}
+	out["k0s_capv_worker"] = s
+	return out
+}
+
+// TestK0s_ArgsReadyMarkerIsLastFile guards the contract an image gate relies on:
+// /etc/k0s/.capi-args-ready is written LAST, after every file k0s needs at
+// start. yip writes files in order, so "the marker exists" means "the drop-ins,
+// k0s.yaml, the token and the resolver all exist". The beskar7 image gates its
+// k0s units on this path at the initramfs stage, which is what stops the
+// installer-boot join and the bare first start (2026-09-08 lab).
+func TestK0s_ArgsReadyMarkerIsLastFile(t *testing.T) {
+	for name, out := range k0sRenders(t) {
+		t.Run(name, func(t *testing.T) {
+			var last string
+			for _, line := range strings.Split(out, "\n") {
+				if strings.HasPrefix(line, "  - path: ") {
+					last = strings.TrimPrefix(line, "  - path: ")
+				}
+			}
+			if last != "/etc/k0s/.capi-args-ready" {
+				t.Errorf("last write_files entry is %q, want /etc/k0s/.capi-args-ready — a gate on the "+
+					"marker would then admit a k0s start before %q has landed", last, last)
+			}
+		})
+	}
+}
+
+// TestK0s_UnitsNameRealServices: the post-bootstrap units ordered on
+// `k0s.service` / `k0s-worker.service`, neither of which exists — the units are
+// k0scontroller.service and k0sworker.service. systemd keeps unknown names in
+// After= without effect, so the post-bootstrap script, and everything it
+// spawns, ran with no ordering against the controller at all.
+func TestK0s_UnitsNameRealServices(t *testing.T) {
+	for name, out := range k0sRenders(t) {
+		t.Run(name, func(t *testing.T) {
+			for _, phantom := range []string{"After=k0s.service", "Wants=k0s.service", "k0s-worker.service"} {
+				if strings.Contains(out, phantom) {
+					t.Errorf("render orders on %q, a unit that does not exist", phantom)
+				}
+			}
+			want := "After=k0scontroller.service"
+			if strings.HasSuffix(name, "_worker") {
+				want = "After=k0sworker.service"
+			}
+			if !strings.Contains(out, want) {
+				t.Errorf("render missing %q", want)
+			}
+			if strings.Contains(out, "Before=k0scontroller.service") {
+				t.Error("must not order ahead of the controller (ADR 0004 deadlock)")
+			}
+		})
+	}
+}
+
+// TestK0s_UnitsSkipRecoveryBoot: every unit the provider writes that already
+// skips the live installer (!cdroot) must also skip a recovery/install boot,
+// which does not carry cdroot, and the args drop-in must refuse to start k0s
+// with its arguments there. Observed: a join node registered as a voting etcd
+// member from its recovery boot and was rebooted 19s later by the installer.
+func TestK0s_UnitsSkipRecoveryBoot(t *testing.T) {
+	const cdroot = "ConditionKernelCommandLine=!cdroot"
+	const recovery = "ConditionPathExists=!/run/cos/recovery_mode"
+	for name, out := range k0sRenders(t) {
+		t.Run(name, func(t *testing.T) {
+			nc, nr := strings.Count(out, cdroot), strings.Count(out, recovery)
+			if nc == 0 {
+				t.Fatal("no live-installer condition rendered at all — template shape changed")
+			}
+			// one recovery condition per cdroot site, plus one on the args drop-in
+			// (control-plane renders only; workers have no controller drop-in)
+			wantExtra := 1
+			if strings.HasSuffix(name, "_worker") {
+				wantExtra = 0
+			}
+			if nr != nc+wantExtra {
+				t.Errorf("%d recovery-mode conditions for %d live-installer conditions (want %d)", nr, nc, nc+wantExtra)
+			}
+			if wantExtra == 1 {
+				body, ok := writeFileBody(out, "/etc/systemd/system/k0scontroller.service.d/zz-capi-args.conf")
+				if !ok || !strings.Contains(body, recovery) {
+					t.Error("args drop-in lacks the recovery-mode condition; the plugin's restart would join from an installer boot")
+				}
+			}
+		})
+	}
+}
+
+// writeFileBody returns the `content:` body of a write_files entry for path.
+func writeFileBody(out, path string) (string, bool) {
+	marker := "- path: " + path + "\n"
+	i := strings.Index(out, marker)
+	if i < 0 {
+		return "", false
+	}
+	rest := out[i+len(marker):]
+	// The entry ends at the next list item at the same indentation.
+	if j := strings.Index(rest, "\n  - path: "); j >= 0 {
+		rest = rest[:j]
+	}
+	return rest, true
+}

--- a/internal/bootstrap/ha_test.go
+++ b/internal/bootstrap/ha_test.go
@@ -1366,3 +1366,90 @@ func TestHA_NodePushStepsRetry(t *testing.T) {
 func isHAGolden(name string) bool {
 	return strings.HasSuffix(name, "_init") || strings.HasSuffix(name, "_join")
 }
+
+// k0sArgsFromBlock returns the `k0s:` -> `args:` list from a rendered
+// cloud-config, joined the way they appear on a command line.
+func k0sArgsFromBlock(out string) (string, bool) {
+	i := strings.Index(out, "\nk0s:\n")
+	if i < 0 {
+		return "", false
+	}
+	var args []string
+	inArgs := false
+	for _, line := range strings.Split(out[i+1:], "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !inArgs {
+			if trimmed == "args:" {
+				inArgs = true
+			} else if trimmed != "" && !strings.HasPrefix(trimmed, "#") &&
+				!strings.HasPrefix(trimmed, "k0s:") && !strings.HasPrefix(trimmed, "enabled:") {
+				return "", false // left the k0s block before finding args
+			}
+			continue
+		}
+		switch {
+		case strings.HasPrefix(trimmed, "- --"):
+			args = append(args, strings.TrimPrefix(trimmed, "- "))
+		case trimmed == "" || strings.HasPrefix(trimmed, "#"):
+			// comments and blanks are interleaved through the args list
+		default:
+			return strings.Join(args, " "), true // end of the args list
+		}
+	}
+	return strings.Join(args, " "), true
+}
+
+// TestHA_K0sArgsDropInMatchesK0sArgs guards the fix for the k0s init-ordering
+// race by guarding the thing that makes it fragile: two copies of the same
+// argument list.
+//
+// provider-kairos translates `k0s.args:` into k0scontroller.service.d/
+// override.conf, but writes it AFTER enabling the unit. Measured across four
+// boots on identical images, three won the race by a fraction of a second and
+// one lost by 3.3s — that boot ran a bare `k0s controller`, so no kubelet, no
+// Node, and a stalled control plane. On a join node the casualty would be
+// --token-file, which is the k3s split-brain failure wearing k0s clothes.
+//
+// The zz-capi-args.conf drop-in is written by write_files (boot stage, always
+// before the unit is enabled) and sorts after override.conf, so it wins whenever
+// both exist. That only helps while the two lists agree, hence this test: it
+// re-derives the command line from `k0s.args:` and requires the drop-in's
+// ExecStart to match it exactly, for every rendered case.
+func TestHA_K0sArgsDropInMatchesK0sArgs(t *testing.T) {
+	const prefix = "ExecStart=/usr/bin/k0s controller"
+
+	for _, tc := range goldenCases() {
+		if !strings.HasPrefix(tc.name, "k0s_") {
+			continue
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := tc.render(tc.data)
+			if err != nil {
+				t.Fatalf("render: %v", err)
+			}
+
+			args, ok := k0sArgsFromBlock(out)
+			if !ok {
+				t.Fatalf("could not locate the k0s args block in %s", tc.name)
+			}
+
+			var execStart string
+			for _, line := range strings.Split(out, "\n") {
+				if trimmed := strings.TrimSpace(line); strings.HasPrefix(trimmed, prefix) {
+					execStart = strings.TrimSpace(strings.TrimPrefix(trimmed, prefix))
+					break
+				}
+			}
+			if execStart == "" && args == "" {
+				return // nothing to deliver, nothing to pin
+			}
+			if execStart == "" {
+				t.Fatalf("k0s.args carries %q but no zz-capi-args.conf drop-in was written — "+
+					"those args reach the node only through the plugin's late override", args)
+			}
+			if execStart != args {
+				t.Errorf("drop-in ExecStart has drifted from k0s.args\n  k0s.args:  %q\n  ExecStart: %q", args, execStart)
+			}
+		})
+	}
+}

--- a/internal/bootstrap/template_test.go
+++ b/internal/bootstrap/template_test.go
@@ -1183,9 +1183,22 @@ func TestRenderMetal3_K0sControlPlane(t *testing.T) {
 			t.Errorf("Metal3 k0s: removed pre-start mechanism must NOT appear: %q", gone)
 		}
 	}
-	if strings.Contains(result, "systemctl restart k0scontroller") {
-		t.Error("Metal3 k0s: must NOT restart k0scontroller (the pre-start restart deadlocked); providerID is set via post-bootstrap patch")
-	}
+	// The mechanism ADR 0004 removed was a PRE-START restart: a
+	// Before=k0scontroller oneshot, which is an ordering cycle by construction
+	// and deadlocked the node with the apiserver down. That ordering is already
+	// forbidden by the loop above, which is the part that actually matters.
+	//
+	// A restart from the post-bootstrap unit is a different thing and is now
+	// required: k0s is started before its arguments exist on disk, and systemd
+	// loading the drop-in afterwards does not change the argv of a process that
+	// is already running (measured 2026-09-08 — effective ExecStart correct,
+	// /proc/<pid>/cmdline bare). kairos-k0s-apply-args.sh restarts only when the
+	// live argv differs, from a unit that is After=/Wants= only, detached via
+	// systemd-run --no-block so it is never part of the caller's transaction.
+	//
+	// The invariant that survived is the ordering one, and the `gone` loop above
+	// already asserts it: Before=k0scontroller.service must not appear. The
+	// providerID is still set by the post-bootstrap patch, asserted below.
 
 	// (b) The post-bootstrap patch mechanism must be present: the function, the
 	// config-drive read (mounted ro,nodev,nosuid,noexec), the fail-closed UUID

--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capk.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capk.yaml.tmpl
@@ -614,6 +614,80 @@ write_files:
       [Install]
       WantedBy=timers.target
   {{- end }}
+  {{- if eq .Role "control-plane" }}
+  # INIT-ORDERING (bare-metal lab, 2026-09-08). k0scontroller is enabled and
+  # started before the arguments meant for it exist on disk. BOTH delivery paths
+  # land afterwards: provider-kairos writes override.conf 3-4s late, and the
+  # write_files drop-in lands within the same second as the start, i.e. after
+  # systemd has loaded the unit. systemd picks the files up — the EFFECTIVE
+  # ExecStart is correct — but the running process keeps its original argv:
+  #
+  #   systemctl show -p ExecStart  ->  the full, correct command line
+  #   /proc/<pid>/cmdline          ->  k0s controller          (bare)
+  #
+  # Consequence: no worker role, so no kubelet, so the Node never registers, so
+  # the providerID patch times out and the control plane stalls at 0/3 joined.
+  # On a join node the missing flag is the token, and the controller initialises
+  # a cluster of its own instead of joining.
+  #
+  # NOT the mechanism ADR 0004 removed. That one was a oneshot ordered ahead of
+  # the k0s unit, which is an ordering cycle by construction and deadlocked the
+  # node with the apiserver down. This runs from the post-bootstrap unit, which is
+  # After=/Wants= only, and detaches the restart through systemd-run --no-block
+  # so the restart job is never part of the caller's transaction. It is also a
+  # no-op whenever the argv already matches, so a boot that won the race and
+  # every subsequent boot are untouched.
+  - path: /usr/local/bin/kairos-k0s-apply-args.sh
+    permissions: "0755"
+    owner: root
+    group: root
+    content: |
+      #!/bin/bash
+      set -u
+      UNIT=k0scontroller.service
+
+      pid="$(systemctl show -p MainPID --value "${UNIT}" 2>/dev/null || echo 0)"
+      if [ -z "${pid}" ] || [ "${pid}" = "0" ] || [ ! -r "/proc/${pid}/cmdline" ]; then
+        exit 0
+      fi
+      running="$(tr '\0' ' ' < "/proc/${pid}/cmdline" 2>/dev/null || true)"
+      wanted="$(systemctl show -p ExecStart --value "${UNIT}" 2>/dev/null |
+                sed -n 's/.*argv\[\]=\([^;]*\).*/\1/p' || true)"
+      [ -n "${running}" ] && [ -n "${wanted}" ] || exit 0
+
+      # Collapse whitespace so a formatting difference is not read as a drift.
+      r="$(echo ${running})"
+      w="$(echo ${wanted})"
+      if [ "${r}" = "${w}" ]; then
+        exit 0
+      fi
+
+      echo "k0s started before its arguments existed; applying them"
+      echo "  running: ${r}"
+      echo "  wanted:  ${w}"
+      {{- if .IsJoinControlPlane }}
+      # A join controller that came up without its token did not join anything:
+      # it initialised a cluster of its own, with its own CA and etcd. Restarting
+      # with the token does not merge that away, so the state it created has to
+      # go. Guarded twice over — this branch is rendered only for a JOIN node,
+      # and only fires when the LIVE process is missing the token flag, i.e. one
+      # that is provably not a member of the real cluster.
+      #
+      # bin/ holds the extracted k0s binaries and manifests/ holds the kube-vip
+      # manifest that write_files put there; neither identifies a cluster, and
+      # removing them would be destructive for no reason.
+      case "${r}" in
+        *--token-file*) ;;
+        *)
+          echo "  join controller self-initialised without its token; discarding that state"
+          systemctl stop "${UNIT}" || true
+          find /var/lib/k0s -mindepth 1 -maxdepth 1 \
+            ! -name bin ! -name manifests -exec rm -rf {} + 2>/dev/null || true
+          ;;
+      esac
+      {{- end }}
+      systemctl restart "${UNIT}" || true
+  {{- end }}
   - path: /usr/local/bin/kairos-k0s-post-bootstrap.sh
     permissions: "0755"
     owner: root
@@ -621,6 +695,30 @@ write_files:
     content: |
       #!/bin/bash
       set -e
+
+      {{- if eq .Role "control-plane" }}
+      # Apply the k0s arguments if systemd started the controller before they
+      # existed (see /usr/local/bin/kairos-k0s-apply-args.sh). This has to happen
+      # before anything below: without the worker role there is no kubelet, so
+      # the Node never registers and every step that waits for it times out.
+      #
+      # Detached through systemd-run so the restart is its own transaction and
+      # can never block this unit; then wait for k0s to answer again.
+      if [ -x /usr/local/bin/kairos-k0s-apply-args.sh ]; then
+        if command -v systemd-run >/dev/null 2>&1; then
+          systemd-run --no-block --unit=kairos-k0s-apply-args --collect \
+            /usr/local/bin/kairos-k0s-apply-args.sh || true
+        else
+          setsid /usr/local/bin/kairos-k0s-apply-args.sh >/dev/null 2>&1 &
+        fi
+        for i in {1..60}; do
+          if k0s status >/dev/null 2>&1; then
+            break
+          fi
+          sleep 5
+        done
+      fi
+      {{- end }}
 
       {{- if .IsKubeVirt }}
       # CAPK: always mark bootstrap success on script exit

--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capk.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capk.yaml.tmpl
@@ -130,6 +130,38 @@ write_files:
     group: root
     content: |
 {{ persistencyOEM | indent 6 }}
+  {{- if and (eq .Role "control-plane") (or .SingleNode .PodCIDR .ServiceCIDR .IsKubeVirt .ProviderID .IsHAControlPlane) }}
+  # INIT-ORDERING (bare-metal lab, 2026-09-08). provider-kairos turns `k0s.args:`
+  # into /etc/systemd/system/k0scontroller.service.d/override.conf, and it writes
+  # that file AFTER enabling the unit. It usually wins by a fraction of a second,
+  # but not always — measured across four k0s boots on identical images:
+  #
+  #   07:12:16.064 override / 07:12:16 start   args applied
+  #   07:19:25.756 override / 07:19:25 start   args applied
+  #   08:08:12.016 override / 08:08:12 start   args applied
+  #   08:35:04.287 override / 08:35:01 start   args LOST  (3.3s late)
+  #
+  # On the boot that lost, /proc/<pid>/cmdline was a bare `k0s controller` with
+  # every flag missing: no worker role, so no kubelet, so the Node never
+  # registered and the whole control plane stalled. On a JOIN node the casualty
+  # is the join-token flag, which is the k3s split-brain failure in k0s clothing.
+  #
+  # write_files lands in the boot stage, before the unit is enabled, so a drop-in
+  # written here is always present at the first start. It sorts after
+  # override.conf, so it wins whenever both exist and is harmless when the plugin
+  # never gets there. Same belt-and-braces as the k3s 93-ha-datastore.yaml pin —
+  # k0s has no config.yaml.d equivalent for CLI-only flags, so the drop-in is the
+  # available mechanism. Keep this list identical to `k0s.args:` above;
+  # TestHA_K0sArgsDropInMatchesK0sArgs fails the build if they drift.
+  - path: /etc/systemd/system/k0scontroller.service.d/zz-capi-args.conf
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      [Service]
+      ExecStart=
+      ExecStart=/usr/bin/k0s controller{{ if .SingleNode }} --single{{ end }}{{ if or .PodCIDR .ServiceCIDR .IsKubeVirt }} --config /etc/k0s/k0s.yaml{{ end }}{{ if .IsJoinControlPlane }} --token-file=/etc/k0s/controller-token{{ end }}{{ if .IsHAControlPlane }} --enable-worker{{ end }}{{ if .ProviderID }} --kubelet-extra-args=--provider-id={{ .ProviderID }}{{ end }}
+  {{- end }}
   {{- /*
     /etc/k0s/k0s.yaml on CAPK control-plane nodes. IsKubeVirt is always true here,
     so every CAPK control-plane node writes this file (the runtime lb-sans updater

--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capk.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capk.yaml.tmpl
@@ -158,6 +158,14 @@ write_files:
     owner: root
     group: root
     content: |
+      [Unit]
+      # Never start with these arguments inside a recovery/install boot: on
+      # a join node that is a real controller-join, registered as a voter,
+      # that the installer then reboots out from under the cluster (measured
+      # on the beskar7 lab, 2026-09-08). The bare first start cannot join —
+      # it has no token and this drop-in is not loaded yet — and every start
+      # that carries the token follows a reload that also loads this file.
+      ConditionPathExists=!/run/cos/recovery_mode
       [Service]
       ExecStart=
       ExecStart=/usr/bin/k0s controller{{ if .SingleNode }} --single{{ end }}{{ if or .PodCIDR .ServiceCIDR .IsKubeVirt }} --config /etc/k0s/k0s.yaml{{ end }}{{ if .IsJoinControlPlane }} --token-file=/etc/k0s/controller-token{{ end }}{{ if .IsHAControlPlane }} --enable-worker{{ end }}{{ if .ProviderID }} --kubelet-extra-args=--provider-id={{ .ProviderID }}{{ end }}
@@ -355,8 +363,8 @@ write_files:
     content: |
       [Unit]
       Description=Ensure k0s apiserver SANs include LoadBalancer endpoint
-      After=k0s.service
-      Wants=k0s.service
+      After=k0scontroller.service
+      Wants=k0scontroller.service
 
       [Service]
       Type=oneshot
@@ -481,12 +489,13 @@ write_files:
       # up cloud-init's runcmd and preventing kairos-agent from rebooting
       # into the installed system. (KD-3b lab finding on Hadron.)
       ConditionKernelCommandLine=!cdroot
+      ConditionPathExists=!/run/cos/recovery_mode
       {{- if eq .Role "control-plane" }}
-      After=k0s.service
-      Wants=k0s.service
+      After=k0scontroller.service
+      Wants=k0scontroller.service
       {{- else }}
-      After=k0s-worker.service
-      Wants=k0s-worker.service
+      After=k0sworker.service
+      Wants=k0sworker.service
       {{- end }}
 
       [Service]
@@ -506,6 +515,7 @@ write_files:
       # Skip on live installer; pairs with the same gate on the main
       # post-bootstrap service. (KD-3b.)
       ConditionKernelCommandLine=!cdroot
+      ConditionPathExists=!/run/cos/recovery_mode
       After=systemd-udev-settle.service
       Before=multi-user.target
 
@@ -592,8 +602,9 @@ write_files:
       [Unit]
       Description=Kairos k0s etcd-leave responder (ADR 0005 §E.3)
       ConditionKernelCommandLine=!cdroot
-      After=k0s.service
-      Wants=k0s.service
+      ConditionPathExists=!/run/cos/recovery_mode
+      After=k0scontroller.service
+      Wants=k0scontroller.service
 
       [Service]
       Type=oneshot
@@ -606,6 +617,7 @@ write_files:
       [Unit]
       Description=Poll for Kairos k0s etcd-leave requests (ADR 0005 §E.3)
       ConditionKernelCommandLine=!cdroot
+      ConditionPathExists=!/run/cos/recovery_mode
 
       [Timer]
       OnBootSec=60
@@ -948,7 +960,7 @@ MANIFEST_EOF
       # Push kubeconfig to management cluster without SSH (KubeVirt)
       push_kubeconfig() {
         local kubeconfig_file="/var/lib/k0s/pki/admin.conf"
-        # Wait up to 5min for k0s to write admin.conf. After=k0s.service only
+        # Wait up to 5min for k0s to write admin.conf. After=k0scontroller.service only
         # orders against service activation, not bootstrap completion, so on
         # slower hosts (Hadron+CAPV lab finding) the file is not yet present
         # when this unit fires. Without this wait the unit silently abandons
@@ -1205,6 +1217,20 @@ MANIFEST_EOF
   {{- end }}
 
 {{- /* DNS overrides */}}
+  # Written LAST, deliberately. Everything k0s needs at start — the argument
+  # drop-ins, k0s.yaml, the join/worker token, the address resolver — is above
+  # this point, and yip writes files in order. An image can gate its k0s units on
+  # this path (ConditionPathExists=/etc/k0s/.capi-args-ready) so the unit can
+  # never start before this config has fully landed; the beskar7 image does
+  # exactly that at its initramfs stage. Without such a gate this file is inert.
+  # Rendered for every role: a worker needs it for k0sworker.service.
+  - path: /etc/k0s/.capi-args-ready
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      written by cluster-api-provider-kairos as the last of its write_files;
+      k0s may start once this exists
 stages:
   boot:
     - name: "Ensure SSH service is enabled"

--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
@@ -152,6 +152,38 @@ write_files:
     group: root
     content: |
 {{ persistencyOEM | indent 6 }}
+  {{- if and (eq .Role "control-plane") (or .SingleNode .PodCIDR .ServiceCIDR .ProviderID .IsHAControlPlane) }}
+  # INIT-ORDERING (bare-metal lab, 2026-09-08). provider-kairos turns `k0s.args:`
+  # into /etc/systemd/system/k0scontroller.service.d/override.conf, and it writes
+  # that file AFTER enabling the unit. It usually wins by a fraction of a second,
+  # but not always — measured across four k0s boots on identical images:
+  #
+  #   07:12:16.064 override / 07:12:16 start   args applied
+  #   07:19:25.756 override / 07:19:25 start   args applied
+  #   08:08:12.016 override / 08:08:12 start   args applied
+  #   08:35:04.287 override / 08:35:01 start   args LOST  (3.3s late)
+  #
+  # On the boot that lost, /proc/<pid>/cmdline was a bare `k0s controller` with
+  # every flag missing: no worker role, so no kubelet, so the Node never
+  # registered and the whole control plane stalled. On a JOIN node the casualty
+  # is the join-token flag, which is the k3s split-brain failure in k0s clothing.
+  #
+  # write_files lands in the boot stage, before the unit is enabled, so a drop-in
+  # written here is always present at the first start. It sorts after
+  # override.conf, so it wins whenever both exist and is harmless when the plugin
+  # never gets there. Same belt-and-braces as the k3s 93-ha-datastore.yaml pin —
+  # k0s has no config.yaml.d equivalent for CLI-only flags, so the drop-in is the
+  # available mechanism. Keep this list identical to `k0s.args:` above;
+  # TestHA_K0sArgsDropInMatchesK0sArgs fails the build if they drift.
+  - path: /etc/systemd/system/k0scontroller.service.d/zz-capi-args.conf
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      [Service]
+      ExecStart=
+      ExecStart=/usr/bin/k0s controller{{ if .SingleNode }}{{ if .K0sSingleNode }} --single{{ else }} --enable-worker{{ end }}{{ end }}{{ if or .PodCIDR .ServiceCIDR .IsInitControlPlane }} --config /etc/k0s/k0s.yaml{{ end }}{{ if .IsJoinControlPlane }} --token-file=/etc/k0s/controller-token{{ end }}{{ if .RenderKubeVIP }} --enable-worker{{ end }}{{ if and .ProviderID (not .Metal3) }} --kubelet-extra-args=--provider-id={{ .ProviderID }}{{ end }}
+  {{- end }}
   {{- /*
     HA-init nodes always emit /etc/k0s/k0s.yaml so the apiserver cert covers the
     stable control-plane endpoint (api.sans). The pre-existing CIDR-only path is

--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
@@ -180,6 +180,14 @@ write_files:
     owner: root
     group: root
     content: |
+      [Unit]
+      # Never start with these arguments inside a recovery/install boot: on
+      # a join node that is a real controller-join, registered as a voter,
+      # that the installer then reboots out from under the cluster (measured
+      # on the beskar7 lab, 2026-09-08). The bare first start cannot join —
+      # it has no token and this drop-in is not loaded yet — and every start
+      # that carries the token follows a reload that also loads this file.
+      ConditionPathExists=!/run/cos/recovery_mode
       [Service]
       ExecStart=
       ExecStart=/usr/bin/k0s controller{{ if .SingleNode }}{{ if .K0sSingleNode }} --single{{ else }} --enable-worker{{ end }}{{ end }}{{ if or .PodCIDR .ServiceCIDR .IsInitControlPlane }} --config /etc/k0s/k0s.yaml{{ end }}{{ if .IsJoinControlPlane }} --token-file=/etc/k0s/controller-token{{ end }}{{ if .RenderKubeVIP }} --enable-worker{{ end }}{{ if and .ProviderID (not .Metal3) }} --kubelet-extra-args=--provider-id={{ .ProviderID }}{{ end }}
@@ -358,12 +366,13 @@ write_files:
       # up cloud-init's runcmd and preventing kairos-agent from rebooting
       # into the installed system. (KD-3b lab finding on Hadron.)
       ConditionKernelCommandLine=!cdroot
+      ConditionPathExists=!/run/cos/recovery_mode
       {{- if eq .Role "control-plane" }}
-      After=k0s.service
-      Wants=k0s.service
+      After=k0scontroller.service
+      Wants=k0scontroller.service
       {{- else }}
-      After=k0s-worker.service
-      Wants=k0s-worker.service
+      After=k0sworker.service
+      Wants=k0sworker.service
       {{- end }}
 
       [Service]
@@ -383,6 +392,7 @@ write_files:
       # Skip on live installer; pairs with the same gate on the main
       # post-bootstrap service. (KD-3b.)
       ConditionKernelCommandLine=!cdroot
+      ConditionPathExists=!/run/cos/recovery_mode
       After=systemd-udev-settle.service
       Before=multi-user.target
 
@@ -469,8 +479,9 @@ write_files:
       [Unit]
       Description=Kairos k0s etcd-leave responder (ADR 0005 §E.3)
       ConditionKernelCommandLine=!cdroot
-      After=k0s.service
-      Wants=k0s.service
+      ConditionPathExists=!/run/cos/recovery_mode
+      After=k0scontroller.service
+      Wants=k0scontroller.service
 
       [Service]
       Type=oneshot
@@ -483,6 +494,7 @@ write_files:
       [Unit]
       Description=Poll for Kairos k0s etcd-leave requests (ADR 0005 §E.3)
       ConditionKernelCommandLine=!cdroot
+      ConditionPathExists=!/run/cos/recovery_mode
 
       [Timer]
       OnBootSec=60
@@ -959,7 +971,7 @@ MANIFEST_EOF
       # host (set by the infrastructure provider) instead of an LB IP.
       push_kubeconfig() {
         local kubeconfig_file="/var/lib/k0s/pki/admin.conf"
-        # Wait up to 5min for k0s to write admin.conf. After=k0s.service only
+        # Wait up to 5min for k0s to write admin.conf. After=k0scontroller.service only
         # orders against service activation, not bootstrap completion, so on
         # slower hosts (Hadron+CAPV lab finding) the file is not yet present
         # when this unit fires. Without this wait the unit silently abandons
@@ -1239,6 +1251,20 @@ MANIFEST_EOF
   {{- end }}
 
 {{- /* DNS overrides */}}
+  # Written LAST, deliberately. Everything k0s needs at start — the argument
+  # drop-ins, k0s.yaml, the join/worker token, the address resolver — is above
+  # this point, and yip writes files in order. An image can gate its k0s units on
+  # this path (ConditionPathExists=/etc/k0s/.capi-args-ready) so the unit can
+  # never start before this config has fully landed; the beskar7 image does
+  # exactly that at its initramfs stage. Without such a gate this file is inert.
+  # Rendered for every role: a worker needs it for k0sworker.service.
+  - path: /etc/k0s/.capi-args-ready
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      written by cluster-api-provider-kairos as the last of its write_files;
+      k0s may start once this exists
 stages:
   boot:
     {{- if and .IsFleet (not .ProviderID) (ne .Role "control-plane") }}

--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
@@ -491,6 +491,80 @@ write_files:
       [Install]
       WantedBy=timers.target
   {{- end }}
+  {{- if eq .Role "control-plane" }}
+  # INIT-ORDERING (bare-metal lab, 2026-09-08). k0scontroller is enabled and
+  # started before the arguments meant for it exist on disk. BOTH delivery paths
+  # land afterwards: provider-kairos writes override.conf 3-4s late, and the
+  # write_files drop-in lands within the same second as the start, i.e. after
+  # systemd has loaded the unit. systemd picks the files up — the EFFECTIVE
+  # ExecStart is correct — but the running process keeps its original argv:
+  #
+  #   systemctl show -p ExecStart  ->  the full, correct command line
+  #   /proc/<pid>/cmdline          ->  k0s controller          (bare)
+  #
+  # Consequence: no worker role, so no kubelet, so the Node never registers, so
+  # the providerID patch times out and the control plane stalls at 0/3 joined.
+  # On a join node the missing flag is the token, and the controller initialises
+  # a cluster of its own instead of joining.
+  #
+  # NOT the mechanism ADR 0004 removed. That one was a oneshot ordered ahead of
+  # the k0s unit, which is an ordering cycle by construction and deadlocked the
+  # node with the apiserver down. This runs from the post-bootstrap unit, which is
+  # After=/Wants= only, and detaches the restart through systemd-run --no-block
+  # so the restart job is never part of the caller's transaction. It is also a
+  # no-op whenever the argv already matches, so a boot that won the race and
+  # every subsequent boot are untouched.
+  - path: /usr/local/bin/kairos-k0s-apply-args.sh
+    permissions: "0755"
+    owner: root
+    group: root
+    content: |
+      #!/bin/bash
+      set -u
+      UNIT=k0scontroller.service
+
+      pid="$(systemctl show -p MainPID --value "${UNIT}" 2>/dev/null || echo 0)"
+      if [ -z "${pid}" ] || [ "${pid}" = "0" ] || [ ! -r "/proc/${pid}/cmdline" ]; then
+        exit 0
+      fi
+      running="$(tr '\0' ' ' < "/proc/${pid}/cmdline" 2>/dev/null || true)"
+      wanted="$(systemctl show -p ExecStart --value "${UNIT}" 2>/dev/null |
+                sed -n 's/.*argv\[\]=\([^;]*\).*/\1/p' || true)"
+      [ -n "${running}" ] && [ -n "${wanted}" ] || exit 0
+
+      # Collapse whitespace so a formatting difference is not read as a drift.
+      r="$(echo ${running})"
+      w="$(echo ${wanted})"
+      if [ "${r}" = "${w}" ]; then
+        exit 0
+      fi
+
+      echo "k0s started before its arguments existed; applying them"
+      echo "  running: ${r}"
+      echo "  wanted:  ${w}"
+      {{- if .IsJoinControlPlane }}
+      # A join controller that came up without its token did not join anything:
+      # it initialised a cluster of its own, with its own CA and etcd. Restarting
+      # with the token does not merge that away, so the state it created has to
+      # go. Guarded twice over — this branch is rendered only for a JOIN node,
+      # and only fires when the LIVE process is missing the token flag, i.e. one
+      # that is provably not a member of the real cluster.
+      #
+      # bin/ holds the extracted k0s binaries and manifests/ holds the kube-vip
+      # manifest that write_files put there; neither identifies a cluster, and
+      # removing them would be destructive for no reason.
+      case "${r}" in
+        *--token-file*) ;;
+        *)
+          echo "  join controller self-initialised without its token; discarding that state"
+          systemctl stop "${UNIT}" || true
+          find /var/lib/k0s -mindepth 1 -maxdepth 1 \
+            ! -name bin ! -name manifests -exec rm -rf {} + 2>/dev/null || true
+          ;;
+      esac
+      {{- end }}
+      systemctl restart "${UNIT}" || true
+  {{- end }}
   - path: /usr/local/bin/kairos-k0s-post-bootstrap.sh
     permissions: "0755"
     owner: root
@@ -498,6 +572,30 @@ write_files:
     content: |
       #!/bin/bash
       set -e
+
+      {{- if eq .Role "control-plane" }}
+      # Apply the k0s arguments if systemd started the controller before they
+      # existed (see /usr/local/bin/kairos-k0s-apply-args.sh). This has to happen
+      # before anything below: without the worker role there is no kubelet, so
+      # the Node never registers and every step that waits for it times out.
+      #
+      # Detached through systemd-run so the restart is its own transaction and
+      # can never block this unit; then wait for k0s to answer again.
+      if [ -x /usr/local/bin/kairos-k0s-apply-args.sh ]; then
+        if command -v systemd-run >/dev/null 2>&1; then
+          systemd-run --no-block --unit=kairos-k0s-apply-args --collect \
+            /usr/local/bin/kairos-k0s-apply-args.sh || true
+        else
+          setsid /usr/local/bin/kairos-k0s-apply-args.sh >/dev/null 2>&1 &
+        fi
+        for i in {1..60}; do
+          if k0s status >/dev/null 2>&1; then
+            break
+          fi
+          sleep 5
+        done
+      fi
+      {{- end }}
 
       {{- if .HostnamePrefix }}
       # Enforce hostname from cloud-config on immutable rootfs

--- a/internal/bootstrap/testdata/golden/k0s_capk_init.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capk_init.yaml
@@ -73,6 +73,14 @@ write_files:
     owner: root
     group: root
     content: |
+      [Unit]
+      # Never start with these arguments inside a recovery/install boot: on
+      # a join node that is a real controller-join, registered as a voter,
+      # that the installer then reboots out from under the cluster (measured
+      # on the beskar7 lab, 2026-09-08). The bare first start cannot join —
+      # it has no token and this drop-in is not loaded yet — and every start
+      # that carries the token follows a reload that also loads this file.
+      ConditionPathExists=!/run/cos/recovery_mode
       [Service]
       ExecStart=
       ExecStart=/usr/bin/k0s controller --config /etc/k0s/k0s.yaml --enable-worker
@@ -211,8 +219,8 @@ write_files:
     content: |
       [Unit]
       Description=Ensure k0s apiserver SANs include LoadBalancer endpoint
-      After=k0s.service
-      Wants=k0s.service
+      After=k0scontroller.service
+      Wants=k0scontroller.service
 
       [Service]
       Type=oneshot
@@ -318,8 +326,9 @@ write_files:
       # up cloud-init's runcmd and preventing kairos-agent from rebooting
       # into the installed system. (KD-3b lab finding on Hadron.)
       ConditionKernelCommandLine=!cdroot
-      After=k0s.service
-      Wants=k0s.service
+      ConditionPathExists=!/run/cos/recovery_mode
+      After=k0scontroller.service
+      Wants=k0scontroller.service
 
       [Service]
       Type=oneshot
@@ -338,6 +347,7 @@ write_files:
       # Skip on live installer; pairs with the same gate on the main
       # post-bootstrap service. (KD-3b.)
       ConditionKernelCommandLine=!cdroot
+      ConditionPathExists=!/run/cos/recovery_mode
       After=systemd-udev-settle.service
       Before=multi-user.target
 
@@ -417,8 +427,9 @@ write_files:
       [Unit]
       Description=Kairos k0s etcd-leave responder (ADR 0005 §E.3)
       ConditionKernelCommandLine=!cdroot
-      After=k0s.service
-      Wants=k0s.service
+      ConditionPathExists=!/run/cos/recovery_mode
+      After=k0scontroller.service
+      Wants=k0scontroller.service
 
       [Service]
       Type=oneshot
@@ -431,6 +442,7 @@ write_files:
       [Unit]
       Description=Poll for Kairos k0s etcd-leave requests (ADR 0005 §E.3)
       ConditionKernelCommandLine=!cdroot
+      ConditionPathExists=!/run/cos/recovery_mode
 
       [Timer]
       OnBootSec=60
@@ -659,7 +671,7 @@ write_files:
       # Push kubeconfig to management cluster without SSH (KubeVirt)
       push_kubeconfig() {
         local kubeconfig_file="/var/lib/k0s/pki/admin.conf"
-        # Wait up to 5min for k0s to write admin.conf. After=k0s.service only
+        # Wait up to 5min for k0s to write admin.conf. After=k0scontroller.service only
         # orders against service activation, not bootstrap completion, so on
         # slower hosts (Hadron+CAPV lab finding) the file is not yet present
         # when this unit fires. Without this wait the unit silently abandons
@@ -904,6 +916,20 @@ write_files:
       chmod 0644 /run/cluster-api/bootstrap-success.complete
 
       echo "k0s post-bootstrap tasks completed successfully"
+  # Written LAST, deliberately. Everything k0s needs at start — the argument
+  # drop-ins, k0s.yaml, the join/worker token, the address resolver — is above
+  # this point, and yip writes files in order. An image can gate its k0s units on
+  # this path (ConditionPathExists=/etc/k0s/.capi-args-ready) so the unit can
+  # never start before this config has fully landed; the beskar7 image does
+  # exactly that at its initramfs stage. Without such a gate this file is inert.
+  # Rendered for every role: a worker needs it for k0sworker.service.
+  - path: /etc/k0s/.capi-args-ready
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      written by cluster-api-provider-kairos as the last of its write_files;
+      k0s may start once this exists
 stages:
   boot:
     - name: "Ensure SSH service is enabled"

--- a/internal/bootstrap/testdata/golden/k0s_capk_init.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capk_init.yaml
@@ -46,6 +46,36 @@ write_files:
           - environment_file: /run/cos/extra-layout.env
             environment:
               PERSISTENT_STATE_PATHS: "/etc/cni /etc/k0s /etc/kubernetes /etc/rancher /etc/ssh /etc/systemd /var/lib/cni /var/lib/containerd /var/lib/k0s /var/lib/kubelet /var/lib/rancher /var/log"
+  # INIT-ORDERING (bare-metal lab, 2026-09-08). provider-kairos turns `k0s.args:`
+  # into /etc/systemd/system/k0scontroller.service.d/override.conf, and it writes
+  # that file AFTER enabling the unit. It usually wins by a fraction of a second,
+  # but not always — measured across four k0s boots on identical images:
+  #
+  #   07:12:16.064 override / 07:12:16 start   args applied
+  #   07:19:25.756 override / 07:19:25 start   args applied
+  #   08:08:12.016 override / 08:08:12 start   args applied
+  #   08:35:04.287 override / 08:35:01 start   args LOST  (3.3s late)
+  #
+  # On the boot that lost, /proc/<pid>/cmdline was a bare `k0s controller` with
+  # every flag missing: no worker role, so no kubelet, so the Node never
+  # registered and the whole control plane stalled. On a JOIN node the casualty
+  # is the join-token flag, which is the k3s split-brain failure in k0s clothing.
+  #
+  # write_files lands in the boot stage, before the unit is enabled, so a drop-in
+  # written here is always present at the first start. It sorts after
+  # override.conf, so it wins whenever both exist and is harmless when the plugin
+  # never gets there. Same belt-and-braces as the k3s 93-ha-datastore.yaml pin —
+  # k0s has no config.yaml.d equivalent for CLI-only flags, so the drop-in is the
+  # available mechanism. Keep this list identical to `k0s.args:` above;
+  # TestHA_K0sArgsDropInMatchesK0sArgs fails the build if they drift.
+  - path: /etc/systemd/system/k0scontroller.service.d/zz-capi-args.conf
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      [Service]
+      ExecStart=
+      ExecStart=/usr/bin/k0s controller --config /etc/k0s/k0s.yaml --enable-worker
   - path: /etc/k0s/k0s.yaml
     permissions: "0644"
     content: |

--- a/internal/bootstrap/testdata/golden/k0s_capk_init.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capk_init.yaml
@@ -438,6 +438,57 @@ write_files:
 
       [Install]
       WantedBy=timers.target
+  # INIT-ORDERING (bare-metal lab, 2026-09-08). k0scontroller is enabled and
+  # started before the arguments meant for it exist on disk. BOTH delivery paths
+  # land afterwards: provider-kairos writes override.conf 3-4s late, and the
+  # write_files drop-in lands within the same second as the start, i.e. after
+  # systemd has loaded the unit. systemd picks the files up — the EFFECTIVE
+  # ExecStart is correct — but the running process keeps its original argv:
+  #
+  #   systemctl show -p ExecStart  ->  the full, correct command line
+  #   /proc/<pid>/cmdline          ->  k0s controller          (bare)
+  #
+  # Consequence: no worker role, so no kubelet, so the Node never registers, so
+  # the providerID patch times out and the control plane stalls at 0/3 joined.
+  # On a join node the missing flag is the token, and the controller initialises
+  # a cluster of its own instead of joining.
+  #
+  # NOT the mechanism ADR 0004 removed. That one was a oneshot ordered ahead of
+  # the k0s unit, which is an ordering cycle by construction and deadlocked the
+  # node with the apiserver down. This runs from the post-bootstrap unit, which is
+  # After=/Wants= only, and detaches the restart through systemd-run --no-block
+  # so the restart job is never part of the caller's transaction. It is also a
+  # no-op whenever the argv already matches, so a boot that won the race and
+  # every subsequent boot are untouched.
+  - path: /usr/local/bin/kairos-k0s-apply-args.sh
+    permissions: "0755"
+    owner: root
+    group: root
+    content: |
+      #!/bin/bash
+      set -u
+      UNIT=k0scontroller.service
+
+      pid="$(systemctl show -p MainPID --value "${UNIT}" 2>/dev/null || echo 0)"
+      if [ -z "${pid}" ] || [ "${pid}" = "0" ] || [ ! -r "/proc/${pid}/cmdline" ]; then
+        exit 0
+      fi
+      running="$(tr '\0' ' ' < "/proc/${pid}/cmdline" 2>/dev/null || true)"
+      wanted="$(systemctl show -p ExecStart --value "${UNIT}" 2>/dev/null |
+                sed -n 's/.*argv\[\]=\([^;]*\).*/\1/p' || true)"
+      [ -n "${running}" ] && [ -n "${wanted}" ] || exit 0
+
+      # Collapse whitespace so a formatting difference is not read as a drift.
+      r="$(echo ${running})"
+      w="$(echo ${wanted})"
+      if [ "${r}" = "${w}" ]; then
+        exit 0
+      fi
+
+      echo "k0s started before its arguments existed; applying them"
+      echo "  running: ${r}"
+      echo "  wanted:  ${w}"
+      systemctl restart "${UNIT}" || true
   - path: /usr/local/bin/kairos-k0s-post-bootstrap.sh
     permissions: "0755"
     owner: root
@@ -445,6 +496,27 @@ write_files:
     content: |
       #!/bin/bash
       set -e
+      # Apply the k0s arguments if systemd started the controller before they
+      # existed (see /usr/local/bin/kairos-k0s-apply-args.sh). This has to happen
+      # before anything below: without the worker role there is no kubelet, so
+      # the Node never registers and every step that waits for it times out.
+      #
+      # Detached through systemd-run so the restart is its own transaction and
+      # can never block this unit; then wait for k0s to answer again.
+      if [ -x /usr/local/bin/kairos-k0s-apply-args.sh ]; then
+        if command -v systemd-run >/dev/null 2>&1; then
+          systemd-run --no-block --unit=kairos-k0s-apply-args --collect \
+            /usr/local/bin/kairos-k0s-apply-args.sh || true
+        else
+          setsid /usr/local/bin/kairos-k0s-apply-args.sh >/dev/null 2>&1 &
+        fi
+        for i in {1..60}; do
+          if k0s status >/dev/null 2>&1; then
+            break
+          fi
+          sleep 5
+        done
+      fi
       # CAPK: always mark bootstrap success on script exit
       mark_bootstrap_success() {
         mkdir -p /run/cluster-api

--- a/internal/bootstrap/testdata/golden/k0s_capk_join.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capk_join.yaml
@@ -74,6 +74,14 @@ write_files:
     owner: root
     group: root
     content: |
+      [Unit]
+      # Never start with these arguments inside a recovery/install boot: on
+      # a join node that is a real controller-join, registered as a voter,
+      # that the installer then reboots out from under the cluster (measured
+      # on the beskar7 lab, 2026-09-08). The bare first start cannot join —
+      # it has no token and this drop-in is not loaded yet — and every start
+      # that carries the token follows a reload that also loads this file.
+      ConditionPathExists=!/run/cos/recovery_mode
       [Service]
       ExecStart=
       ExecStart=/usr/bin/k0s controller --config /etc/k0s/k0s.yaml --token-file=/etc/k0s/controller-token --enable-worker
@@ -216,8 +224,8 @@ write_files:
     content: |
       [Unit]
       Description=Ensure k0s apiserver SANs include LoadBalancer endpoint
-      After=k0s.service
-      Wants=k0s.service
+      After=k0scontroller.service
+      Wants=k0scontroller.service
 
       [Service]
       Type=oneshot
@@ -323,8 +331,9 @@ write_files:
       # up cloud-init's runcmd and preventing kairos-agent from rebooting
       # into the installed system. (KD-3b lab finding on Hadron.)
       ConditionKernelCommandLine=!cdroot
-      After=k0s.service
-      Wants=k0s.service
+      ConditionPathExists=!/run/cos/recovery_mode
+      After=k0scontroller.service
+      Wants=k0scontroller.service
 
       [Service]
       Type=oneshot
@@ -343,6 +352,7 @@ write_files:
       # Skip on live installer; pairs with the same gate on the main
       # post-bootstrap service. (KD-3b.)
       ConditionKernelCommandLine=!cdroot
+      ConditionPathExists=!/run/cos/recovery_mode
       After=systemd-udev-settle.service
       Before=multi-user.target
 
@@ -422,8 +432,9 @@ write_files:
       [Unit]
       Description=Kairos k0s etcd-leave responder (ADR 0005 §E.3)
       ConditionKernelCommandLine=!cdroot
-      After=k0s.service
-      Wants=k0s.service
+      ConditionPathExists=!/run/cos/recovery_mode
+      After=k0scontroller.service
+      Wants=k0scontroller.service
 
       [Service]
       Type=oneshot
@@ -436,6 +447,7 @@ write_files:
       [Unit]
       Description=Poll for Kairos k0s etcd-leave requests (ADR 0005 §E.3)
       ConditionKernelCommandLine=!cdroot
+      ConditionPathExists=!/run/cos/recovery_mode
 
       [Timer]
       OnBootSec=60
@@ -683,7 +695,7 @@ write_files:
       # Push kubeconfig to management cluster without SSH (KubeVirt)
       push_kubeconfig() {
         local kubeconfig_file="/var/lib/k0s/pki/admin.conf"
-        # Wait up to 5min for k0s to write admin.conf. After=k0s.service only
+        # Wait up to 5min for k0s to write admin.conf. After=k0scontroller.service only
         # orders against service activation, not bootstrap completion, so on
         # slower hosts (Hadron+CAPV lab finding) the file is not yet present
         # when this unit fires. Without this wait the unit silently abandons
@@ -853,6 +865,20 @@ write_files:
       chmod 0644 /run/cluster-api/bootstrap-success.complete
 
       echo "k0s post-bootstrap tasks completed successfully"
+  # Written LAST, deliberately. Everything k0s needs at start — the argument
+  # drop-ins, k0s.yaml, the join/worker token, the address resolver — is above
+  # this point, and yip writes files in order. An image can gate its k0s units on
+  # this path (ConditionPathExists=/etc/k0s/.capi-args-ready) so the unit can
+  # never start before this config has fully landed; the beskar7 image does
+  # exactly that at its initramfs stage. Without such a gate this file is inert.
+  # Rendered for every role: a worker needs it for k0sworker.service.
+  - path: /etc/k0s/.capi-args-ready
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      written by cluster-api-provider-kairos as the last of its write_files;
+      k0s may start once this exists
 stages:
   boot:
     - name: "Ensure SSH service is enabled"

--- a/internal/bootstrap/testdata/golden/k0s_capk_join.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capk_join.yaml
@@ -443,6 +443,76 @@ write_files:
 
       [Install]
       WantedBy=timers.target
+  # INIT-ORDERING (bare-metal lab, 2026-09-08). k0scontroller is enabled and
+  # started before the arguments meant for it exist on disk. BOTH delivery paths
+  # land afterwards: provider-kairos writes override.conf 3-4s late, and the
+  # write_files drop-in lands within the same second as the start, i.e. after
+  # systemd has loaded the unit. systemd picks the files up — the EFFECTIVE
+  # ExecStart is correct — but the running process keeps its original argv:
+  #
+  #   systemctl show -p ExecStart  ->  the full, correct command line
+  #   /proc/<pid>/cmdline          ->  k0s controller          (bare)
+  #
+  # Consequence: no worker role, so no kubelet, so the Node never registers, so
+  # the providerID patch times out and the control plane stalls at 0/3 joined.
+  # On a join node the missing flag is the token, and the controller initialises
+  # a cluster of its own instead of joining.
+  #
+  # NOT the mechanism ADR 0004 removed. That one was a oneshot ordered ahead of
+  # the k0s unit, which is an ordering cycle by construction and deadlocked the
+  # node with the apiserver down. This runs from the post-bootstrap unit, which is
+  # After=/Wants= only, and detaches the restart through systemd-run --no-block
+  # so the restart job is never part of the caller's transaction. It is also a
+  # no-op whenever the argv already matches, so a boot that won the race and
+  # every subsequent boot are untouched.
+  - path: /usr/local/bin/kairos-k0s-apply-args.sh
+    permissions: "0755"
+    owner: root
+    group: root
+    content: |
+      #!/bin/bash
+      set -u
+      UNIT=k0scontroller.service
+
+      pid="$(systemctl show -p MainPID --value "${UNIT}" 2>/dev/null || echo 0)"
+      if [ -z "${pid}" ] || [ "${pid}" = "0" ] || [ ! -r "/proc/${pid}/cmdline" ]; then
+        exit 0
+      fi
+      running="$(tr '\0' ' ' < "/proc/${pid}/cmdline" 2>/dev/null || true)"
+      wanted="$(systemctl show -p ExecStart --value "${UNIT}" 2>/dev/null |
+                sed -n 's/.*argv\[\]=\([^;]*\).*/\1/p' || true)"
+      [ -n "${running}" ] && [ -n "${wanted}" ] || exit 0
+
+      # Collapse whitespace so a formatting difference is not read as a drift.
+      r="$(echo ${running})"
+      w="$(echo ${wanted})"
+      if [ "${r}" = "${w}" ]; then
+        exit 0
+      fi
+
+      echo "k0s started before its arguments existed; applying them"
+      echo "  running: ${r}"
+      echo "  wanted:  ${w}"
+      # A join controller that came up without its token did not join anything:
+      # it initialised a cluster of its own, with its own CA and etcd. Restarting
+      # with the token does not merge that away, so the state it created has to
+      # go. Guarded twice over — this branch is rendered only for a JOIN node,
+      # and only fires when the LIVE process is missing the token flag, i.e. one
+      # that is provably not a member of the real cluster.
+      #
+      # bin/ holds the extracted k0s binaries and manifests/ holds the kube-vip
+      # manifest that write_files put there; neither identifies a cluster, and
+      # removing them would be destructive for no reason.
+      case "${r}" in
+        *--token-file*) ;;
+        *)
+          echo "  join controller self-initialised without its token; discarding that state"
+          systemctl stop "${UNIT}" || true
+          find /var/lib/k0s -mindepth 1 -maxdepth 1 \
+            ! -name bin ! -name manifests -exec rm -rf {} + 2>/dev/null || true
+          ;;
+      esac
+      systemctl restart "${UNIT}" || true
   - path: /usr/local/bin/kairos-k0s-post-bootstrap.sh
     permissions: "0755"
     owner: root
@@ -450,6 +520,27 @@ write_files:
     content: |
       #!/bin/bash
       set -e
+      # Apply the k0s arguments if systemd started the controller before they
+      # existed (see /usr/local/bin/kairos-k0s-apply-args.sh). This has to happen
+      # before anything below: without the worker role there is no kubelet, so
+      # the Node never registers and every step that waits for it times out.
+      #
+      # Detached through systemd-run so the restart is its own transaction and
+      # can never block this unit; then wait for k0s to answer again.
+      if [ -x /usr/local/bin/kairos-k0s-apply-args.sh ]; then
+        if command -v systemd-run >/dev/null 2>&1; then
+          systemd-run --no-block --unit=kairos-k0s-apply-args --collect \
+            /usr/local/bin/kairos-k0s-apply-args.sh || true
+        else
+          setsid /usr/local/bin/kairos-k0s-apply-args.sh >/dev/null 2>&1 &
+        fi
+        for i in {1..60}; do
+          if k0s status >/dev/null 2>&1; then
+            break
+          fi
+          sleep 5
+        done
+      fi
       # CAPK: always mark bootstrap success on script exit
       mark_bootstrap_success() {
         mkdir -p /run/cluster-api

--- a/internal/bootstrap/testdata/golden/k0s_capk_join.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capk_join.yaml
@@ -47,6 +47,36 @@ write_files:
           - environment_file: /run/cos/extra-layout.env
             environment:
               PERSISTENT_STATE_PATHS: "/etc/cni /etc/k0s /etc/kubernetes /etc/rancher /etc/ssh /etc/systemd /var/lib/cni /var/lib/containerd /var/lib/k0s /var/lib/kubelet /var/lib/rancher /var/log"
+  # INIT-ORDERING (bare-metal lab, 2026-09-08). provider-kairos turns `k0s.args:`
+  # into /etc/systemd/system/k0scontroller.service.d/override.conf, and it writes
+  # that file AFTER enabling the unit. It usually wins by a fraction of a second,
+  # but not always — measured across four k0s boots on identical images:
+  #
+  #   07:12:16.064 override / 07:12:16 start   args applied
+  #   07:19:25.756 override / 07:19:25 start   args applied
+  #   08:08:12.016 override / 08:08:12 start   args applied
+  #   08:35:04.287 override / 08:35:01 start   args LOST  (3.3s late)
+  #
+  # On the boot that lost, /proc/<pid>/cmdline was a bare `k0s controller` with
+  # every flag missing: no worker role, so no kubelet, so the Node never
+  # registered and the whole control plane stalled. On a JOIN node the casualty
+  # is the join-token flag, which is the k3s split-brain failure in k0s clothing.
+  #
+  # write_files lands in the boot stage, before the unit is enabled, so a drop-in
+  # written here is always present at the first start. It sorts after
+  # override.conf, so it wins whenever both exist and is harmless when the plugin
+  # never gets there. Same belt-and-braces as the k3s 93-ha-datastore.yaml pin —
+  # k0s has no config.yaml.d equivalent for CLI-only flags, so the drop-in is the
+  # available mechanism. Keep this list identical to `k0s.args:` above;
+  # TestHA_K0sArgsDropInMatchesK0sArgs fails the build if they drift.
+  - path: /etc/systemd/system/k0scontroller.service.d/zz-capi-args.conf
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      [Service]
+      ExecStart=
+      ExecStart=/usr/bin/k0s controller --config /etc/k0s/k0s.yaml --token-file=/etc/k0s/controller-token --enable-worker
   - path: /etc/k0s/k0s.yaml
     permissions: "0644"
     content: |

--- a/internal/bootstrap/testdata/golden/k0s_capk_single.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capk_single.yaml
@@ -30,6 +30,36 @@ write_files:
           - environment_file: /run/cos/extra-layout.env
             environment:
               PERSISTENT_STATE_PATHS: "/etc/cni /etc/k0s /etc/kubernetes /etc/rancher /etc/ssh /etc/systemd /var/lib/cni /var/lib/containerd /var/lib/k0s /var/lib/kubelet /var/lib/rancher /var/log"
+  # INIT-ORDERING (bare-metal lab, 2026-09-08). provider-kairos turns `k0s.args:`
+  # into /etc/systemd/system/k0scontroller.service.d/override.conf, and it writes
+  # that file AFTER enabling the unit. It usually wins by a fraction of a second,
+  # but not always — measured across four k0s boots on identical images:
+  #
+  #   07:12:16.064 override / 07:12:16 start   args applied
+  #   07:19:25.756 override / 07:19:25 start   args applied
+  #   08:08:12.016 override / 08:08:12 start   args applied
+  #   08:35:04.287 override / 08:35:01 start   args LOST  (3.3s late)
+  #
+  # On the boot that lost, /proc/<pid>/cmdline was a bare `k0s controller` with
+  # every flag missing: no worker role, so no kubelet, so the Node never
+  # registered and the whole control plane stalled. On a JOIN node the casualty
+  # is the join-token flag, which is the k3s split-brain failure in k0s clothing.
+  #
+  # write_files lands in the boot stage, before the unit is enabled, so a drop-in
+  # written here is always present at the first start. It sorts after
+  # override.conf, so it wins whenever both exist and is harmless when the plugin
+  # never gets there. Same belt-and-braces as the k3s 93-ha-datastore.yaml pin —
+  # k0s has no config.yaml.d equivalent for CLI-only flags, so the drop-in is the
+  # available mechanism. Keep this list identical to `k0s.args:` above;
+  # TestHA_K0sArgsDropInMatchesK0sArgs fails the build if they drift.
+  - path: /etc/systemd/system/k0scontroller.service.d/zz-capi-args.conf
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      [Service]
+      ExecStart=
+      ExecStart=/usr/bin/k0s controller --single --config /etc/k0s/k0s.yaml
   - path: /etc/k0s/k0s.yaml
     permissions: "0644"
     content: |

--- a/internal/bootstrap/testdata/golden/k0s_capk_single.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capk_single.yaml
@@ -57,6 +57,14 @@ write_files:
     owner: root
     group: root
     content: |
+      [Unit]
+      # Never start with these arguments inside a recovery/install boot: on
+      # a join node that is a real controller-join, registered as a voter,
+      # that the installer then reboots out from under the cluster (measured
+      # on the beskar7 lab, 2026-09-08). The bare first start cannot join —
+      # it has no token and this drop-in is not loaded yet — and every start
+      # that carries the token follows a reload that also loads this file.
+      ConditionPathExists=!/run/cos/recovery_mode
       [Service]
       ExecStart=
       ExecStart=/usr/bin/k0s controller --single --config /etc/k0s/k0s.yaml
@@ -75,8 +83,8 @@ write_files:
     content: |
       [Unit]
       Description=Ensure k0s apiserver SANs include LoadBalancer endpoint
-      After=k0s.service
-      Wants=k0s.service
+      After=k0scontroller.service
+      Wants=k0scontroller.service
 
       [Service]
       Type=oneshot
@@ -181,8 +189,9 @@ write_files:
       # up cloud-init's runcmd and preventing kairos-agent from rebooting
       # into the installed system. (KD-3b lab finding on Hadron.)
       ConditionKernelCommandLine=!cdroot
-      After=k0s.service
-      Wants=k0s.service
+      ConditionPathExists=!/run/cos/recovery_mode
+      After=k0scontroller.service
+      Wants=k0scontroller.service
 
       [Service]
       Type=oneshot
@@ -201,6 +210,7 @@ write_files:
       # Skip on live installer; pairs with the same gate on the main
       # post-bootstrap service. (KD-3b.)
       ConditionKernelCommandLine=!cdroot
+      ConditionPathExists=!/run/cos/recovery_mode
       After=systemd-udev-settle.service
       Before=multi-user.target
 
@@ -441,6 +451,20 @@ write_files:
       chmod 0644 /run/cluster-api/bootstrap-success.complete
 
       echo "k0s post-bootstrap tasks completed successfully"
+  # Written LAST, deliberately. Everything k0s needs at start — the argument
+  # drop-ins, k0s.yaml, the join/worker token, the address resolver — is above
+  # this point, and yip writes files in order. An image can gate its k0s units on
+  # this path (ConditionPathExists=/etc/k0s/.capi-args-ready) so the unit can
+  # never start before this config has fully landed; the beskar7 image does
+  # exactly that at its initramfs stage. Without such a gate this file is inert.
+  # Rendered for every role: a worker needs it for k0sworker.service.
+  - path: /etc/k0s/.capi-args-ready
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      written by cluster-api-provider-kairos as the last of its write_files;
+      k0s may start once this exists
 stages:
   boot:
     - name: "Ensure SSH service is enabled"

--- a/internal/bootstrap/testdata/golden/k0s_capk_single.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capk_single.yaml
@@ -217,6 +217,57 @@ write_files:
 
       [Install]
       WantedBy=multi-user.target
+  # INIT-ORDERING (bare-metal lab, 2026-09-08). k0scontroller is enabled and
+  # started before the arguments meant for it exist on disk. BOTH delivery paths
+  # land afterwards: provider-kairos writes override.conf 3-4s late, and the
+  # write_files drop-in lands within the same second as the start, i.e. after
+  # systemd has loaded the unit. systemd picks the files up — the EFFECTIVE
+  # ExecStart is correct — but the running process keeps its original argv:
+  #
+  #   systemctl show -p ExecStart  ->  the full, correct command line
+  #   /proc/<pid>/cmdline          ->  k0s controller          (bare)
+  #
+  # Consequence: no worker role, so no kubelet, so the Node never registers, so
+  # the providerID patch times out and the control plane stalls at 0/3 joined.
+  # On a join node the missing flag is the token, and the controller initialises
+  # a cluster of its own instead of joining.
+  #
+  # NOT the mechanism ADR 0004 removed. That one was a oneshot ordered ahead of
+  # the k0s unit, which is an ordering cycle by construction and deadlocked the
+  # node with the apiserver down. This runs from the post-bootstrap unit, which is
+  # After=/Wants= only, and detaches the restart through systemd-run --no-block
+  # so the restart job is never part of the caller's transaction. It is also a
+  # no-op whenever the argv already matches, so a boot that won the race and
+  # every subsequent boot are untouched.
+  - path: /usr/local/bin/kairos-k0s-apply-args.sh
+    permissions: "0755"
+    owner: root
+    group: root
+    content: |
+      #!/bin/bash
+      set -u
+      UNIT=k0scontroller.service
+
+      pid="$(systemctl show -p MainPID --value "${UNIT}" 2>/dev/null || echo 0)"
+      if [ -z "${pid}" ] || [ "${pid}" = "0" ] || [ ! -r "/proc/${pid}/cmdline" ]; then
+        exit 0
+      fi
+      running="$(tr '\0' ' ' < "/proc/${pid}/cmdline" 2>/dev/null || true)"
+      wanted="$(systemctl show -p ExecStart --value "${UNIT}" 2>/dev/null |
+                sed -n 's/.*argv\[\]=\([^;]*\).*/\1/p' || true)"
+      [ -n "${running}" ] && [ -n "${wanted}" ] || exit 0
+
+      # Collapse whitespace so a formatting difference is not read as a drift.
+      r="$(echo ${running})"
+      w="$(echo ${wanted})"
+      if [ "${r}" = "${w}" ]; then
+        exit 0
+      fi
+
+      echo "k0s started before its arguments existed; applying them"
+      echo "  running: ${r}"
+      echo "  wanted:  ${w}"
+      systemctl restart "${UNIT}" || true
   - path: /usr/local/bin/kairos-k0s-post-bootstrap.sh
     permissions: "0755"
     owner: root
@@ -224,6 +275,27 @@ write_files:
     content: |
       #!/bin/bash
       set -e
+      # Apply the k0s arguments if systemd started the controller before they
+      # existed (see /usr/local/bin/kairos-k0s-apply-args.sh). This has to happen
+      # before anything below: without the worker role there is no kubelet, so
+      # the Node never registers and every step that waits for it times out.
+      #
+      # Detached through systemd-run so the restart is its own transaction and
+      # can never block this unit; then wait for k0s to answer again.
+      if [ -x /usr/local/bin/kairos-k0s-apply-args.sh ]; then
+        if command -v systemd-run >/dev/null 2>&1; then
+          systemd-run --no-block --unit=kairos-k0s-apply-args --collect \
+            /usr/local/bin/kairos-k0s-apply-args.sh || true
+        else
+          setsid /usr/local/bin/kairos-k0s-apply-args.sh >/dev/null 2>&1 &
+        fi
+        for i in {1..60}; do
+          if k0s status >/dev/null 2>&1; then
+            break
+          fi
+          sleep 5
+        done
+      fi
       # CAPK: always mark bootstrap success on script exit
       mark_bootstrap_success() {
         mkdir -p /run/cluster-api

--- a/internal/bootstrap/testdata/golden/k0s_capv_init.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capv_init.yaml
@@ -68,6 +68,14 @@ write_files:
     owner: root
     group: root
     content: |
+      [Unit]
+      # Never start with these arguments inside a recovery/install boot: on
+      # a join node that is a real controller-join, registered as a voter,
+      # that the installer then reboots out from under the cluster (measured
+      # on the beskar7 lab, 2026-09-08). The bare first start cannot join —
+      # it has no token and this drop-in is not loaded yet — and every start
+      # that carries the token follows a reload that also loads this file.
+      ConditionPathExists=!/run/cos/recovery_mode
       [Service]
       ExecStart=
       ExecStart=/usr/bin/k0s controller --config /etc/k0s/k0s.yaml --enable-worker
@@ -233,8 +241,9 @@ write_files:
       # up cloud-init's runcmd and preventing kairos-agent from rebooting
       # into the installed system. (KD-3b lab finding on Hadron.)
       ConditionKernelCommandLine=!cdroot
-      After=k0s.service
-      Wants=k0s.service
+      ConditionPathExists=!/run/cos/recovery_mode
+      After=k0scontroller.service
+      Wants=k0scontroller.service
 
       [Service]
       Type=oneshot
@@ -253,6 +262,7 @@ write_files:
       # Skip on live installer; pairs with the same gate on the main
       # post-bootstrap service. (KD-3b.)
       ConditionKernelCommandLine=!cdroot
+      ConditionPathExists=!/run/cos/recovery_mode
       After=systemd-udev-settle.service
       Before=multi-user.target
 
@@ -332,8 +342,9 @@ write_files:
       [Unit]
       Description=Kairos k0s etcd-leave responder (ADR 0005 §E.3)
       ConditionKernelCommandLine=!cdroot
-      After=k0s.service
-      Wants=k0s.service
+      ConditionPathExists=!/run/cos/recovery_mode
+      After=k0scontroller.service
+      Wants=k0scontroller.service
 
       [Service]
       Type=oneshot
@@ -346,6 +357,7 @@ write_files:
       [Unit]
       Description=Poll for Kairos k0s etcd-leave requests (ADR 0005 §E.3)
       ConditionKernelCommandLine=!cdroot
+      ConditionPathExists=!/run/cos/recovery_mode
 
       [Timer]
       OnBootSec=60
@@ -522,7 +534,7 @@ write_files:
       # host (set by the infrastructure provider) instead of an LB IP.
       push_kubeconfig() {
         local kubeconfig_file="/var/lib/k0s/pki/admin.conf"
-        # Wait up to 5min for k0s to write admin.conf. After=k0s.service only
+        # Wait up to 5min for k0s to write admin.conf. After=k0scontroller.service only
         # orders against service activation, not bootstrap completion, so on
         # slower hosts (Hadron+CAPV lab finding) the file is not yet present
         # when this unit fires. Without this wait the unit silently abandons
@@ -786,6 +798,20 @@ write_files:
       chmod 0644 /run/cluster-api/bootstrap-success.complete
 
       echo "k0s post-bootstrap tasks completed successfully"
+  # Written LAST, deliberately. Everything k0s needs at start — the argument
+  # drop-ins, k0s.yaml, the join/worker token, the address resolver — is above
+  # this point, and yip writes files in order. An image can gate its k0s units on
+  # this path (ConditionPathExists=/etc/k0s/.capi-args-ready) so the unit can
+  # never start before this config has fully landed; the beskar7 image does
+  # exactly that at its initramfs stage. Without such a gate this file is inert.
+  # Rendered for every role: a worker needs it for k0sworker.service.
+  - path: /etc/k0s/.capi-args-ready
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      written by cluster-api-provider-kairos as the last of its write_files;
+      k0s may start once this exists
 stages:
   boot:
     - name: "Ensure SSH service is enabled"

--- a/internal/bootstrap/testdata/golden/k0s_capv_init.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capv_init.yaml
@@ -353,6 +353,57 @@ write_files:
 
       [Install]
       WantedBy=timers.target
+  # INIT-ORDERING (bare-metal lab, 2026-09-08). k0scontroller is enabled and
+  # started before the arguments meant for it exist on disk. BOTH delivery paths
+  # land afterwards: provider-kairos writes override.conf 3-4s late, and the
+  # write_files drop-in lands within the same second as the start, i.e. after
+  # systemd has loaded the unit. systemd picks the files up — the EFFECTIVE
+  # ExecStart is correct — but the running process keeps its original argv:
+  #
+  #   systemctl show -p ExecStart  ->  the full, correct command line
+  #   /proc/<pid>/cmdline          ->  k0s controller          (bare)
+  #
+  # Consequence: no worker role, so no kubelet, so the Node never registers, so
+  # the providerID patch times out and the control plane stalls at 0/3 joined.
+  # On a join node the missing flag is the token, and the controller initialises
+  # a cluster of its own instead of joining.
+  #
+  # NOT the mechanism ADR 0004 removed. That one was a oneshot ordered ahead of
+  # the k0s unit, which is an ordering cycle by construction and deadlocked the
+  # node with the apiserver down. This runs from the post-bootstrap unit, which is
+  # After=/Wants= only, and detaches the restart through systemd-run --no-block
+  # so the restart job is never part of the caller's transaction. It is also a
+  # no-op whenever the argv already matches, so a boot that won the race and
+  # every subsequent boot are untouched.
+  - path: /usr/local/bin/kairos-k0s-apply-args.sh
+    permissions: "0755"
+    owner: root
+    group: root
+    content: |
+      #!/bin/bash
+      set -u
+      UNIT=k0scontroller.service
+
+      pid="$(systemctl show -p MainPID --value "${UNIT}" 2>/dev/null || echo 0)"
+      if [ -z "${pid}" ] || [ "${pid}" = "0" ] || [ ! -r "/proc/${pid}/cmdline" ]; then
+        exit 0
+      fi
+      running="$(tr '\0' ' ' < "/proc/${pid}/cmdline" 2>/dev/null || true)"
+      wanted="$(systemctl show -p ExecStart --value "${UNIT}" 2>/dev/null |
+                sed -n 's/.*argv\[\]=\([^;]*\).*/\1/p' || true)"
+      [ -n "${running}" ] && [ -n "${wanted}" ] || exit 0
+
+      # Collapse whitespace so a formatting difference is not read as a drift.
+      r="$(echo ${running})"
+      w="$(echo ${wanted})"
+      if [ "${r}" = "${w}" ]; then
+        exit 0
+      fi
+
+      echo "k0s started before its arguments existed; applying them"
+      echo "  running: ${r}"
+      echo "  wanted:  ${w}"
+      systemctl restart "${UNIT}" || true
   - path: /usr/local/bin/kairos-k0s-post-bootstrap.sh
     permissions: "0755"
     owner: root
@@ -360,6 +411,27 @@ write_files:
     content: |
       #!/bin/bash
       set -e
+      # Apply the k0s arguments if systemd started the controller before they
+      # existed (see /usr/local/bin/kairos-k0s-apply-args.sh). This has to happen
+      # before anything below: without the worker role there is no kubelet, so
+      # the Node never registers and every step that waits for it times out.
+      #
+      # Detached through systemd-run so the restart is its own transaction and
+      # can never block this unit; then wait for k0s to answer again.
+      if [ -x /usr/local/bin/kairos-k0s-apply-args.sh ]; then
+        if command -v systemd-run >/dev/null 2>&1; then
+          systemd-run --no-block --unit=kairos-k0s-apply-args --collect \
+            /usr/local/bin/kairos-k0s-apply-args.sh || true
+        else
+          setsid /usr/local/bin/kairos-k0s-apply-args.sh >/dev/null 2>&1 &
+        fi
+        for i in {1..60}; do
+          if k0s status >/dev/null 2>&1; then
+            break
+          fi
+          sleep 5
+        done
+      fi
       # CAPV self-discovery: ProviderID was not available at render time (assigned
       # after VM clone), so compute vsphere://<uuid> from DMI at boot.
       # KD-55: fail-OPEN. If the UUID is absent or malformed, warn and continue so

--- a/internal/bootstrap/testdata/golden/k0s_capv_init.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capv_init.yaml
@@ -41,6 +41,36 @@ write_files:
           - environment_file: /run/cos/extra-layout.env
             environment:
               PERSISTENT_STATE_PATHS: "/etc/cni /etc/k0s /etc/kubernetes /etc/rancher /etc/ssh /etc/systemd /var/lib/cni /var/lib/containerd /var/lib/k0s /var/lib/kubelet /var/lib/rancher /var/log"
+  # INIT-ORDERING (bare-metal lab, 2026-09-08). provider-kairos turns `k0s.args:`
+  # into /etc/systemd/system/k0scontroller.service.d/override.conf, and it writes
+  # that file AFTER enabling the unit. It usually wins by a fraction of a second,
+  # but not always — measured across four k0s boots on identical images:
+  #
+  #   07:12:16.064 override / 07:12:16 start   args applied
+  #   07:19:25.756 override / 07:19:25 start   args applied
+  #   08:08:12.016 override / 08:08:12 start   args applied
+  #   08:35:04.287 override / 08:35:01 start   args LOST  (3.3s late)
+  #
+  # On the boot that lost, /proc/<pid>/cmdline was a bare `k0s controller` with
+  # every flag missing: no worker role, so no kubelet, so the Node never
+  # registered and the whole control plane stalled. On a JOIN node the casualty
+  # is the join-token flag, which is the k3s split-brain failure in k0s clothing.
+  #
+  # write_files lands in the boot stage, before the unit is enabled, so a drop-in
+  # written here is always present at the first start. It sorts after
+  # override.conf, so it wins whenever both exist and is harmless when the plugin
+  # never gets there. Same belt-and-braces as the k3s 93-ha-datastore.yaml pin —
+  # k0s has no config.yaml.d equivalent for CLI-only flags, so the drop-in is the
+  # available mechanism. Keep this list identical to `k0s.args:` above;
+  # TestHA_K0sArgsDropInMatchesK0sArgs fails the build if they drift.
+  - path: /etc/systemd/system/k0scontroller.service.d/zz-capi-args.conf
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      [Service]
+      ExecStart=
+      ExecStart=/usr/bin/k0s controller --config /etc/k0s/k0s.yaml --enable-worker
   - path: /etc/k0s/k0s.yaml
     permissions: "0644"
     content: |

--- a/internal/bootstrap/testdata/golden/k0s_capv_join.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capv_join.yaml
@@ -71,6 +71,14 @@ write_files:
     owner: root
     group: root
     content: |
+      [Unit]
+      # Never start with these arguments inside a recovery/install boot: on
+      # a join node that is a real controller-join, registered as a voter,
+      # that the installer then reboots out from under the cluster (measured
+      # on the beskar7 lab, 2026-09-08). The bare first start cannot join —
+      # it has no token and this drop-in is not loaded yet — and every start
+      # that carries the token follows a reload that also loads this file.
+      ConditionPathExists=!/run/cos/recovery_mode
       [Service]
       ExecStart=
       ExecStart=/usr/bin/k0s controller --token-file=/etc/k0s/controller-token --enable-worker
@@ -236,8 +244,9 @@ write_files:
       # up cloud-init's runcmd and preventing kairos-agent from rebooting
       # into the installed system. (KD-3b lab finding on Hadron.)
       ConditionKernelCommandLine=!cdroot
-      After=k0s.service
-      Wants=k0s.service
+      ConditionPathExists=!/run/cos/recovery_mode
+      After=k0scontroller.service
+      Wants=k0scontroller.service
 
       [Service]
       Type=oneshot
@@ -256,6 +265,7 @@ write_files:
       # Skip on live installer; pairs with the same gate on the main
       # post-bootstrap service. (KD-3b.)
       ConditionKernelCommandLine=!cdroot
+      ConditionPathExists=!/run/cos/recovery_mode
       After=systemd-udev-settle.service
       Before=multi-user.target
 
@@ -335,8 +345,9 @@ write_files:
       [Unit]
       Description=Kairos k0s etcd-leave responder (ADR 0005 §E.3)
       ConditionKernelCommandLine=!cdroot
-      After=k0s.service
-      Wants=k0s.service
+      ConditionPathExists=!/run/cos/recovery_mode
+      After=k0scontroller.service
+      Wants=k0scontroller.service
 
       [Service]
       Type=oneshot
@@ -349,6 +360,7 @@ write_files:
       [Unit]
       Description=Poll for Kairos k0s etcd-leave requests (ADR 0005 §E.3)
       ConditionKernelCommandLine=!cdroot
+      ConditionPathExists=!/run/cos/recovery_mode
 
       [Timer]
       OnBootSec=60
@@ -544,7 +556,7 @@ write_files:
       # host (set by the infrastructure provider) instead of an LB IP.
       push_kubeconfig() {
         local kubeconfig_file="/var/lib/k0s/pki/admin.conf"
-        # Wait up to 5min for k0s to write admin.conf. After=k0s.service only
+        # Wait up to 5min for k0s to write admin.conf. After=k0scontroller.service only
         # orders against service activation, not bootstrap completion, so on
         # slower hosts (Hadron+CAPV lab finding) the file is not yet present
         # when this unit fires. Without this wait the unit silently abandons
@@ -707,6 +719,20 @@ write_files:
       chmod 0644 /run/cluster-api/bootstrap-success.complete
 
       echo "k0s post-bootstrap tasks completed successfully"
+  # Written LAST, deliberately. Everything k0s needs at start — the argument
+  # drop-ins, k0s.yaml, the join/worker token, the address resolver — is above
+  # this point, and yip writes files in order. An image can gate its k0s units on
+  # this path (ConditionPathExists=/etc/k0s/.capi-args-ready) so the unit can
+  # never start before this config has fully landed; the beskar7 image does
+  # exactly that at its initramfs stage. Without such a gate this file is inert.
+  # Rendered for every role: a worker needs it for k0sworker.service.
+  - path: /etc/k0s/.capi-args-ready
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      written by cluster-api-provider-kairos as the last of its write_files;
+      k0s may start once this exists
 stages:
   boot:
     - name: "Ensure SSH service is enabled"

--- a/internal/bootstrap/testdata/golden/k0s_capv_join.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capv_join.yaml
@@ -356,6 +356,76 @@ write_files:
 
       [Install]
       WantedBy=timers.target
+  # INIT-ORDERING (bare-metal lab, 2026-09-08). k0scontroller is enabled and
+  # started before the arguments meant for it exist on disk. BOTH delivery paths
+  # land afterwards: provider-kairos writes override.conf 3-4s late, and the
+  # write_files drop-in lands within the same second as the start, i.e. after
+  # systemd has loaded the unit. systemd picks the files up — the EFFECTIVE
+  # ExecStart is correct — but the running process keeps its original argv:
+  #
+  #   systemctl show -p ExecStart  ->  the full, correct command line
+  #   /proc/<pid>/cmdline          ->  k0s controller          (bare)
+  #
+  # Consequence: no worker role, so no kubelet, so the Node never registers, so
+  # the providerID patch times out and the control plane stalls at 0/3 joined.
+  # On a join node the missing flag is the token, and the controller initialises
+  # a cluster of its own instead of joining.
+  #
+  # NOT the mechanism ADR 0004 removed. That one was a oneshot ordered ahead of
+  # the k0s unit, which is an ordering cycle by construction and deadlocked the
+  # node with the apiserver down. This runs from the post-bootstrap unit, which is
+  # After=/Wants= only, and detaches the restart through systemd-run --no-block
+  # so the restart job is never part of the caller's transaction. It is also a
+  # no-op whenever the argv already matches, so a boot that won the race and
+  # every subsequent boot are untouched.
+  - path: /usr/local/bin/kairos-k0s-apply-args.sh
+    permissions: "0755"
+    owner: root
+    group: root
+    content: |
+      #!/bin/bash
+      set -u
+      UNIT=k0scontroller.service
+
+      pid="$(systemctl show -p MainPID --value "${UNIT}" 2>/dev/null || echo 0)"
+      if [ -z "${pid}" ] || [ "${pid}" = "0" ] || [ ! -r "/proc/${pid}/cmdline" ]; then
+        exit 0
+      fi
+      running="$(tr '\0' ' ' < "/proc/${pid}/cmdline" 2>/dev/null || true)"
+      wanted="$(systemctl show -p ExecStart --value "${UNIT}" 2>/dev/null |
+                sed -n 's/.*argv\[\]=\([^;]*\).*/\1/p' || true)"
+      [ -n "${running}" ] && [ -n "${wanted}" ] || exit 0
+
+      # Collapse whitespace so a formatting difference is not read as a drift.
+      r="$(echo ${running})"
+      w="$(echo ${wanted})"
+      if [ "${r}" = "${w}" ]; then
+        exit 0
+      fi
+
+      echo "k0s started before its arguments existed; applying them"
+      echo "  running: ${r}"
+      echo "  wanted:  ${w}"
+      # A join controller that came up without its token did not join anything:
+      # it initialised a cluster of its own, with its own CA and etcd. Restarting
+      # with the token does not merge that away, so the state it created has to
+      # go. Guarded twice over — this branch is rendered only for a JOIN node,
+      # and only fires when the LIVE process is missing the token flag, i.e. one
+      # that is provably not a member of the real cluster.
+      #
+      # bin/ holds the extracted k0s binaries and manifests/ holds the kube-vip
+      # manifest that write_files put there; neither identifies a cluster, and
+      # removing them would be destructive for no reason.
+      case "${r}" in
+        *--token-file*) ;;
+        *)
+          echo "  join controller self-initialised without its token; discarding that state"
+          systemctl stop "${UNIT}" || true
+          find /var/lib/k0s -mindepth 1 -maxdepth 1 \
+            ! -name bin ! -name manifests -exec rm -rf {} + 2>/dev/null || true
+          ;;
+      esac
+      systemctl restart "${UNIT}" || true
   - path: /usr/local/bin/kairos-k0s-post-bootstrap.sh
     permissions: "0755"
     owner: root
@@ -363,6 +433,27 @@ write_files:
     content: |
       #!/bin/bash
       set -e
+      # Apply the k0s arguments if systemd started the controller before they
+      # existed (see /usr/local/bin/kairos-k0s-apply-args.sh). This has to happen
+      # before anything below: without the worker role there is no kubelet, so
+      # the Node never registers and every step that waits for it times out.
+      #
+      # Detached through systemd-run so the restart is its own transaction and
+      # can never block this unit; then wait for k0s to answer again.
+      if [ -x /usr/local/bin/kairos-k0s-apply-args.sh ]; then
+        if command -v systemd-run >/dev/null 2>&1; then
+          systemd-run --no-block --unit=kairos-k0s-apply-args --collect \
+            /usr/local/bin/kairos-k0s-apply-args.sh || true
+        else
+          setsid /usr/local/bin/kairos-k0s-apply-args.sh >/dev/null 2>&1 &
+        fi
+        for i in {1..60}; do
+          if k0s status >/dev/null 2>&1; then
+            break
+          fi
+          sleep 5
+        done
+      fi
       # CAPV self-discovery: ProviderID was not available at render time (assigned
       # after VM clone), so compute vsphere://<uuid> from DMI at boot.
       # KD-55: fail-OPEN. If the UUID is absent or malformed, warn and continue so

--- a/internal/bootstrap/testdata/golden/k0s_capv_join.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capv_join.yaml
@@ -44,6 +44,36 @@ write_files:
           - environment_file: /run/cos/extra-layout.env
             environment:
               PERSISTENT_STATE_PATHS: "/etc/cni /etc/k0s /etc/kubernetes /etc/rancher /etc/ssh /etc/systemd /var/lib/cni /var/lib/containerd /var/lib/k0s /var/lib/kubelet /var/lib/rancher /var/log"
+  # INIT-ORDERING (bare-metal lab, 2026-09-08). provider-kairos turns `k0s.args:`
+  # into /etc/systemd/system/k0scontroller.service.d/override.conf, and it writes
+  # that file AFTER enabling the unit. It usually wins by a fraction of a second,
+  # but not always — measured across four k0s boots on identical images:
+  #
+  #   07:12:16.064 override / 07:12:16 start   args applied
+  #   07:19:25.756 override / 07:19:25 start   args applied
+  #   08:08:12.016 override / 08:08:12 start   args applied
+  #   08:35:04.287 override / 08:35:01 start   args LOST  (3.3s late)
+  #
+  # On the boot that lost, /proc/<pid>/cmdline was a bare `k0s controller` with
+  # every flag missing: no worker role, so no kubelet, so the Node never
+  # registered and the whole control plane stalled. On a JOIN node the casualty
+  # is the join-token flag, which is the k3s split-brain failure in k0s clothing.
+  #
+  # write_files lands in the boot stage, before the unit is enabled, so a drop-in
+  # written here is always present at the first start. It sorts after
+  # override.conf, so it wins whenever both exist and is harmless when the plugin
+  # never gets there. Same belt-and-braces as the k3s 93-ha-datastore.yaml pin —
+  # k0s has no config.yaml.d equivalent for CLI-only flags, so the drop-in is the
+  # available mechanism. Keep this list identical to `k0s.args:` above;
+  # TestHA_K0sArgsDropInMatchesK0sArgs fails the build if they drift.
+  - path: /etc/systemd/system/k0scontroller.service.d/zz-capi-args.conf
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      [Service]
+      ExecStart=
+      ExecStart=/usr/bin/k0s controller --token-file=/etc/k0s/controller-token --enable-worker
   # ADR 0005 (HA) join node: k0s controller-role join token. Sourced from
   # .JoinToken, which the Phase-3 controller produces on the init controller
   # (k0s token create --role=controller) and delivers over the node-push channel

--- a/internal/bootstrap/testdata/golden/k0s_capv_single.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capv_single.yaml
@@ -34,6 +34,36 @@ write_files:
           - environment_file: /run/cos/extra-layout.env
             environment:
               PERSISTENT_STATE_PATHS: "/etc/cni /etc/k0s /etc/kubernetes /etc/rancher /etc/ssh /etc/systemd /var/lib/cni /var/lib/containerd /var/lib/k0s /var/lib/kubelet /var/lib/rancher /var/log"
+  # INIT-ORDERING (bare-metal lab, 2026-09-08). provider-kairos turns `k0s.args:`
+  # into /etc/systemd/system/k0scontroller.service.d/override.conf, and it writes
+  # that file AFTER enabling the unit. It usually wins by a fraction of a second,
+  # but not always — measured across four k0s boots on identical images:
+  #
+  #   07:12:16.064 override / 07:12:16 start   args applied
+  #   07:19:25.756 override / 07:19:25 start   args applied
+  #   08:08:12.016 override / 08:08:12 start   args applied
+  #   08:35:04.287 override / 08:35:01 start   args LOST  (3.3s late)
+  #
+  # On the boot that lost, /proc/<pid>/cmdline was a bare `k0s controller` with
+  # every flag missing: no worker role, so no kubelet, so the Node never
+  # registered and the whole control plane stalled. On a JOIN node the casualty
+  # is the join-token flag, which is the k3s split-brain failure in k0s clothing.
+  #
+  # write_files lands in the boot stage, before the unit is enabled, so a drop-in
+  # written here is always present at the first start. It sorts after
+  # override.conf, so it wins whenever both exist and is harmless when the plugin
+  # never gets there. Same belt-and-braces as the k3s 93-ha-datastore.yaml pin —
+  # k0s has no config.yaml.d equivalent for CLI-only flags, so the drop-in is the
+  # available mechanism. Keep this list identical to `k0s.args:` above;
+  # TestHA_K0sArgsDropInMatchesK0sArgs fails the build if they drift.
+  - path: /etc/systemd/system/k0scontroller.service.d/zz-capi-args.conf
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      [Service]
+      ExecStart=
+      ExecStart=/usr/bin/k0s controller --enable-worker
   - path: /usr/local/etc/hostname
     permissions: "0644"
     owner: root

--- a/internal/bootstrap/testdata/golden/k0s_capv_single.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capv_single.yaml
@@ -61,6 +61,14 @@ write_files:
     owner: root
     group: root
     content: |
+      [Unit]
+      # Never start with these arguments inside a recovery/install boot: on
+      # a join node that is a real controller-join, registered as a voter,
+      # that the installer then reboots out from under the cluster (measured
+      # on the beskar7 lab, 2026-09-08). The bare first start cannot join —
+      # it has no token and this drop-in is not loaded yet — and every start
+      # that carries the token follows a reload that also loads this file.
+      ConditionPathExists=!/run/cos/recovery_mode
       [Service]
       ExecStart=
       ExecStart=/usr/bin/k0s controller --enable-worker
@@ -83,8 +91,9 @@ write_files:
       # up cloud-init's runcmd and preventing kairos-agent from rebooting
       # into the installed system. (KD-3b lab finding on Hadron.)
       ConditionKernelCommandLine=!cdroot
-      After=k0s.service
-      Wants=k0s.service
+      ConditionPathExists=!/run/cos/recovery_mode
+      After=k0scontroller.service
+      Wants=k0scontroller.service
 
       [Service]
       Type=oneshot
@@ -103,6 +112,7 @@ write_files:
       # Skip on live installer; pairs with the same gate on the main
       # post-bootstrap service. (KD-3b.)
       ConditionKernelCommandLine=!cdroot
+      ConditionPathExists=!/run/cos/recovery_mode
       After=systemd-udev-settle.service
       Before=multi-user.target
 
@@ -290,6 +300,20 @@ write_files:
       chmod 0644 /run/cluster-api/bootstrap-success.complete
 
       echo "k0s post-bootstrap tasks completed successfully"
+  # Written LAST, deliberately. Everything k0s needs at start — the argument
+  # drop-ins, k0s.yaml, the join/worker token, the address resolver — is above
+  # this point, and yip writes files in order. An image can gate its k0s units on
+  # this path (ConditionPathExists=/etc/k0s/.capi-args-ready) so the unit can
+  # never start before this config has fully landed; the beskar7 image does
+  # exactly that at its initramfs stage. Without such a gate this file is inert.
+  # Rendered for every role: a worker needs it for k0sworker.service.
+  - path: /etc/k0s/.capi-args-ready
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      written by cluster-api-provider-kairos as the last of its write_files;
+      k0s may start once this exists
 stages:
   boot:
     - name: "Ensure SSH service is enabled"

--- a/internal/bootstrap/testdata/golden/k0s_capv_single.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capv_single.yaml
@@ -119,6 +119,57 @@ write_files:
 
       [Install]
       WantedBy=multi-user.target
+  # INIT-ORDERING (bare-metal lab, 2026-09-08). k0scontroller is enabled and
+  # started before the arguments meant for it exist on disk. BOTH delivery paths
+  # land afterwards: provider-kairos writes override.conf 3-4s late, and the
+  # write_files drop-in lands within the same second as the start, i.e. after
+  # systemd has loaded the unit. systemd picks the files up — the EFFECTIVE
+  # ExecStart is correct — but the running process keeps its original argv:
+  #
+  #   systemctl show -p ExecStart  ->  the full, correct command line
+  #   /proc/<pid>/cmdline          ->  k0s controller          (bare)
+  #
+  # Consequence: no worker role, so no kubelet, so the Node never registers, so
+  # the providerID patch times out and the control plane stalls at 0/3 joined.
+  # On a join node the missing flag is the token, and the controller initialises
+  # a cluster of its own instead of joining.
+  #
+  # NOT the mechanism ADR 0004 removed. That one was a oneshot ordered ahead of
+  # the k0s unit, which is an ordering cycle by construction and deadlocked the
+  # node with the apiserver down. This runs from the post-bootstrap unit, which is
+  # After=/Wants= only, and detaches the restart through systemd-run --no-block
+  # so the restart job is never part of the caller's transaction. It is also a
+  # no-op whenever the argv already matches, so a boot that won the race and
+  # every subsequent boot are untouched.
+  - path: /usr/local/bin/kairos-k0s-apply-args.sh
+    permissions: "0755"
+    owner: root
+    group: root
+    content: |
+      #!/bin/bash
+      set -u
+      UNIT=k0scontroller.service
+
+      pid="$(systemctl show -p MainPID --value "${UNIT}" 2>/dev/null || echo 0)"
+      if [ -z "${pid}" ] || [ "${pid}" = "0" ] || [ ! -r "/proc/${pid}/cmdline" ]; then
+        exit 0
+      fi
+      running="$(tr '\0' ' ' < "/proc/${pid}/cmdline" 2>/dev/null || true)"
+      wanted="$(systemctl show -p ExecStart --value "${UNIT}" 2>/dev/null |
+                sed -n 's/.*argv\[\]=\([^;]*\).*/\1/p' || true)"
+      [ -n "${running}" ] && [ -n "${wanted}" ] || exit 0
+
+      # Collapse whitespace so a formatting difference is not read as a drift.
+      r="$(echo ${running})"
+      w="$(echo ${wanted})"
+      if [ "${r}" = "${w}" ]; then
+        exit 0
+      fi
+
+      echo "k0s started before its arguments existed; applying them"
+      echo "  running: ${r}"
+      echo "  wanted:  ${w}"
+      systemctl restart "${UNIT}" || true
   - path: /usr/local/bin/kairos-k0s-post-bootstrap.sh
     permissions: "0755"
     owner: root
@@ -126,6 +177,27 @@ write_files:
     content: |
       #!/bin/bash
       set -e
+      # Apply the k0s arguments if systemd started the controller before they
+      # existed (see /usr/local/bin/kairos-k0s-apply-args.sh). This has to happen
+      # before anything below: without the worker role there is no kubelet, so
+      # the Node never registers and every step that waits for it times out.
+      #
+      # Detached through systemd-run so the restart is its own transaction and
+      # can never block this unit; then wait for k0s to answer again.
+      if [ -x /usr/local/bin/kairos-k0s-apply-args.sh ]; then
+        if command -v systemd-run >/dev/null 2>&1; then
+          systemd-run --no-block --unit=kairos-k0s-apply-args --collect \
+            /usr/local/bin/kairos-k0s-apply-args.sh || true
+        else
+          setsid /usr/local/bin/kairos-k0s-apply-args.sh >/dev/null 2>&1 &
+        fi
+        for i in {1..60}; do
+          if k0s status >/dev/null 2>&1; then
+            break
+          fi
+          sleep 5
+        done
+      fi
       # CAPV self-discovery: ProviderID was not available at render time (assigned
       # after VM clone), so compute vsphere://<uuid> from DMI at boot.
       # KD-55: fail-OPEN. If the UUID is absent or malformed, warn and continue so


### PR DESCRIPTION
> Stacked on #98 (same k0s templates and test file). Merge after it — until then the Files tab shows that PR's diff as well.

## Summary

The Kairos k0s provider turns `k0s.args` into `k0scontroller.service.d/override.conf` and writes it **after** the unit has been started. Measured across five k0s boots on identical images, the override landed 3–4 s after the first start on two of them:

```
07:12:16.064 override / 07:12:16 start   applied
07:19:25.756 override / 07:19:25 start   applied
08:08:12.016 override / 08:08:12 start   applied
08:35:04.287 override / 08:35:01 start   LOST
08:59:29.186 override / 08:59:25 start   LOST
```

On a boot that loses, `/proc/<pid>/cmdline` is a bare `k0s controller` with every flag missing: no worker role means no kubelet, the Node never registers, and a **join** controller initialises a cluster of its own instead of joining — k0s never attempts a join once a CA exists, so a lost race is not recoverable in place. Three commits close it, and the third adds a small contract an image can build on.

## What changes

1. **`zz-capi-args.conf` drop-in** written by `write_files`, carrying the full controller command line. It sorts after `override.conf`, so it wins whenever both are loaded, and it sidesteps the provider silently discarding `--kubelet-extra-args` during its translation. `TestHA_K0sArgsDropInMatchesK0sArgs` guards it against drifting from `k0s.args`. On its own this is only half a fix: systemd loads the drop-in (`systemctl show -p ExecStart` is correct) but a process launched before the file existed keeps its argv — verified on-node.
2. **`kairos-k0s-apply-args.sh`** compares the live argv against the effective `ExecStart` and restarts the controller only when they differ, so a boot that won the race and every later boot are untouched. Invoked from the post-bootstrap unit — which is `After=`/`Wants=` only — via `systemd-run --no-block --collect`, so the restart is its own transaction and can never block the caller. This is **not** the pre-start ordering ADR 0004 removed (a oneshot ordered ahead of the k0s unit, an ordering cycle by construction); `TestRenderMetal3_K0sControlPlane` still forbids that, and its blanket "no restart" assertion is replaced with a comment explaining the distinction. A join controller that came up without its token has initialised its own etcd and CA; that state is discarded before the restart, only for join renders and only when the live argv lacks the token flag (`bin/` and `manifests/` are kept). `TestHA_K0sAppliesArgsAfterLateStart` covers all of it, negative-verified by leaking the destructive branch into init/single.
3. **A start-gate marker, real unit names, recovery-boot conditions.**
   - `/etc/k0s/.capi-args-ready` is written as the **last** `write_files` entry for every role. yip writes files in order, so its existence means the drop-ins, `k0s.yaml`, the token and everything else exist. An image can gate its k0s units on it, together with `!/run/cos/recovery_mode`; without such a gate the file is inert. The consumer is the beskar7 image (projectbeskar/beskar7#156), whose whole-disk image goes through a recovery-partition install boot on which Kairos applies the cloud-config too — observed there: a joiner registered as a *voting* etcd member from the installer 19 s before its own kernel existed, then got rebooted by it, and the single-member init lost quorum for good. The provider's existing guard keys on `cdroot`, which that boot does not carry.
   - The post-bootstrap units ordered on `k0s.service` / `k0s-worker.service`, which do not exist (they are `k0scontroller.service` / `k0sworker.service`); systemd keeps unknown names in `After=` without effect, so the script had no ordering against the controller at all.
   - `ConditionPathExists=!/run/cos/recovery_mode` beside every existing `ConditionKernelCommandLine=!cdroot`, and on the args drop-in.
   `TestK0s_ArgsReadyMarkerIsLastFile`, `TestK0s_UnitsNameRealServices`, `TestK0s_UnitsSkipRecoveryBoot` — over every k0s golden plus a worker render, each negative-verified.

The third commit also carries the `writeFileBody` test helper (a `write_files` body extractor) that its tests use; it was introduced in the api.address series, which follows this PR.

## Verification

Three-replica k0s `KairosControlPlane` on the bare-metal lab with the gated image: per node one k0s start, `NRestarts=0`, effective `ExecStart` equal to the live argv, no k0s output in the install boot's journal, one join attempt; KCP 3/3 with `EtcdHealthy=True`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
