### PR TITLE
fix: advertise a routable k0s api.address and etcd peerAddress on CAPV, as CAPK already does

### DIFF
--- a/internal/bootstrap/ha_test.go
+++ b/internal/bootstrap/ha_test.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -1739,7 +1740,9 @@ func TestHA_K0sApiAddressResolved(t *testing.T) {
 			// Fail open rather than leave a sentinel in place — either of them.
 			for _, del := range []string{
 				`sed -i "/^[[:space:]]*address: ${SENTINEL}\$/d"`,
-				`sed -i "/^[[:space:]]*peerAddress: ${PEER_SENTINEL}\$/d"`,
+				// The etcd side drops the whole storage section, not just its
+				// value line — see TestHA_K0sApiAddressResolverRuns for why.
+				`sed -i "/^[[:space:]]*storage:\$/,/^[[:space:]]*peerAddress: ${PEER_SENTINEL}\$/d"`,
 			} {
 				if !strings.Contains(out, del) {
 					t.Errorf("resolver must DELETE the line when no address is found (%s); an "+
@@ -1766,4 +1769,188 @@ func TestHA_K0sApiAddressResolved(t *testing.T) {
 func cfgBody(out string) string {
 	body, _ := writeFileBody(out, "/etc/k0s/k0s.yaml")
 	return body
+}
+
+// writeFileContent returns the de-indented file content of a write_files entry,
+// i.e. the bytes yip would put on disk.
+func writeFileContent(out, path string) (string, bool) {
+	body, ok := writeFileBody(out, path)
+	if !ok {
+		return "", false
+	}
+	i := strings.Index(body, "content: |\n")
+	if i < 0 {
+		return "", false
+	}
+	lines := strings.Split(body[i+len("content: |\n"):], "\n")
+	indent := -1
+	for _, l := range lines {
+		if strings.TrimSpace(l) == "" {
+			continue
+		}
+		if n := len(l) - len(strings.TrimLeft(l, " ")); indent < 0 || n < indent {
+			indent = n
+		}
+	}
+	var b strings.Builder
+	for _, l := range lines {
+		if len(l) >= indent {
+			b.WriteString(l[indent:])
+		} else {
+			b.WriteString(strings.TrimLeft(l, " "))
+		}
+		b.WriteString("\n")
+	}
+	return b.String(), true
+}
+
+// TestHA_K0sApiAddressResolverRuns executes the rendered resolver against the
+// rendered k0s.yaml, because the string-level assertions in
+// TestHA_K0sApiAddressResolved cannot see what the script does to the file.
+//
+//   - resolves: `ip route get` answers with a source address, and both
+//     spec.api.address and spec.storage.etcd.peerAddress end up equal to it.
+//   - fails open: there is no `ip` at all. The address line goes, and the
+//     WHOLE storage section goes with it. Deleting only the peerAddress line
+//     leaves `etcd:` as an explicit null, and k0s does not repair that:
+//     StorageSpec.UnmarshalJSON re-defaults etcd only for kine, so
+//     spec.storage.etcd stays nil, `k0s config validate` passes, and the etcd
+//     component dereferences it at start (k0s v1.34.8:
+//     cmd/controller/controller.go:264 hands the nil through and
+//     pkg/component/controller/etcd.go:167 calls GetPeerURL on it). A nil
+//     spec.api, by contrast, is restored by ClusterConfig.UnmarshalJSON, so
+//     the address line alone is fine to drop. Caught in review of the first
+//     version of this resolver.
+//
+// Each run gets a PATH holding only what that path needs, so the fail-open run
+// never sleeps: without `seq` the wait loop has nothing to iterate and without
+// `ip` there is nothing to detect. Every run is repeated once to prove the
+// script is a no-op on a resolved file.
+func TestHA_K0sApiAddressResolverRuns(t *testing.T) {
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not available")
+	}
+	const resolverPath = "/usr/local/bin/kairos-k0s-api-addr.sh"
+
+	for _, tc := range goldenCases() {
+		if !strings.HasPrefix(tc.name, "k0s_capv_") {
+			continue
+		}
+		if !strings.HasSuffix(tc.name, "_init") && !strings.HasSuffix(tc.name, "_join") {
+			continue
+		}
+		out, err := tc.render(tc.data)
+		if err != nil {
+			t.Fatalf("render %s: %v", tc.name, err)
+		}
+		resolver, ok := writeFileContent(out, resolverPath)
+		if !ok {
+			t.Fatalf("%s: no resolver script in render", tc.name)
+		}
+		cfg, ok := writeFileContent(out, "/etc/k0s/k0s.yaml")
+		if !ok {
+			t.Fatalf("%s: no k0s.yaml in render", tc.name)
+		}
+
+		run := func(t *testing.T, tools []string, fakeIP string) map[string]any {
+			t.Helper()
+			dir := t.TempDir()
+			bin := filepath.Join(dir, "bin")
+			if err := os.Mkdir(bin, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			for _, tool := range tools {
+				p, err := exec.LookPath(tool)
+				if err != nil {
+					t.Skipf("%s not available", tool)
+				}
+				if err := os.Symlink(p, filepath.Join(bin, tool)); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if fakeIP != "" {
+				if err := os.WriteFile(filepath.Join(bin, "ip"), []byte(fakeIP), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			cfgPath := filepath.Join(dir, "k0s.yaml")
+			if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			script := strings.Replace(resolver, "CFG=/etc/k0s/k0s.yaml\n", "CFG="+cfgPath+"\n", 1)
+			if script == resolver {
+				t.Fatal("resolver does not declare CFG=/etc/k0s/k0s.yaml; cannot redirect it")
+			}
+			scriptPath := filepath.Join(dir, "resolver.sh")
+			if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			var first []byte
+			for i := 0; i < 2; i++ {
+				cmd := exec.Command(bash, scriptPath)
+				cmd.Env = []string{"PATH=" + bin}
+				if b, err := cmd.CombinedOutput(); err != nil {
+					t.Fatalf("run %d: %v\n%s", i+1, err, b)
+				}
+				got, err := os.ReadFile(cfgPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if i == 0 {
+					first = got
+				} else if string(got) != string(first) {
+					t.Errorf("second run changed the file; the resolver must be a no-op once resolved")
+				}
+			}
+			if strings.Contains(string(first), "__") {
+				t.Errorf("a placeholder survived:\n%s", first)
+			}
+			var doc map[string]any
+			if err := yaml.Unmarshal(first, &doc); err != nil {
+				t.Fatalf("result is not YAML: %v\n%s", err, first)
+			}
+			spec, _ := doc["spec"].(map[string]any)
+			if spec == nil {
+				t.Fatalf("result has no spec mapping:\n%s", first)
+			}
+			return spec
+		}
+
+		t.Run(tc.name+"/resolves", func(t *testing.T) {
+			spec := run(t, []string{"sed", "grep", "seq", "head", "cut", "awk"},
+				"#!/bin/sh\necho '192.168.1.240 via 10.9.8.1 dev eth0 src 10.9.8.7 uid 0'\n")
+			api, _ := spec["api"].(map[string]any)
+			if api == nil || api["address"] != "10.9.8.7" {
+				t.Errorf("spec.api = %v; want address 10.9.8.7 from the route source", spec["api"])
+			}
+			storage, _ := spec["storage"].(map[string]any)
+			etcd, _ := storage["etcd"].(map[string]any)
+			if etcd == nil || etcd["peerAddress"] != "10.9.8.7" {
+				t.Errorf("spec.storage = %v; want etcd.peerAddress 10.9.8.7 from the same source", spec["storage"])
+			}
+		})
+
+		t.Run(tc.name+"/fails open", func(t *testing.T) {
+			spec := run(t, []string{"sed", "grep"}, "")
+			if api, present := spec["api"]; present && api != nil {
+				if _, isMap := api.(map[string]any); !isMap {
+					t.Errorf("spec.api is %T after fail-open; must be a mapping or absent", api)
+				}
+			}
+			storage, present := spec["storage"]
+			if !present {
+				return
+			}
+			m, isMap := storage.(map[string]any)
+			if !isMap {
+				t.Fatalf("spec.storage is an explicit null after fail-open; k0s keeps a StorageSpec "+
+					"with a nil etcd and the etcd component dereferences it at start (got %T)", storage)
+			}
+			if etcd, ok := m["etcd"]; ok && etcd == nil {
+				t.Errorf("spec.storage.etcd is an explicit null after fail-open; k0s's StorageSpec " +
+					"defaulting only repairs kine, so this passes `k0s config validate` and then panics at etcd start")
+			}
+		})
+	}
 }

--- a/internal/bootstrap/ha_test.go
+++ b/internal/bootstrap/ha_test.go
@@ -1645,3 +1645,125 @@ func writeFileBody(out, path string) (string, bool) {
 	}
 	return rest, true
 }
+
+// TestHA_K0sApiAddressResolved guards the CAPV port of CAPK's api.address
+// mechanism, and the invariant that makes it safe: a sentinel is only ever
+// written together with something that resolves it.
+//
+// A bare-metal HA node is dual-homed — an isolated provisioning NIC plus a
+// routable one — exactly like a KubeVirt node behind masquerade. With no
+// spec.api.address, k0s picks an advertise address itself. On the beskar7 lab
+// (2026-09-08) it chose the provisioning address, `k0s token create` baked that
+// into the controller-join token, and every joiner failed with
+//
+//	failed to join existing cluster via https://192.168.190.61:9443:
+//	  Get ".../v1beta1/ca": context deadline exceeded
+//
+// while the join API answered 401 (i.e. healthy) when probed on the node itself.
+// The CAPK template had carried api.address since its own masquerade lab; the
+// CAPV template never got it.
+//
+// The failure mode to guard hardest is an unsubstituted sentinel: k0s rejects
+// the config and crash-loops. So the sentinel must never be rendered without
+// both the resolver script and the ExecStartPre that runs it, and the resolver
+// must delete the line rather than leave it if no address can be found.
+func TestHA_K0sApiAddressResolved(t *testing.T) {
+	const sentinel = "__API_ADDR__"
+
+	for _, tc := range goldenCases() {
+		if !strings.HasPrefix(tc.name, "k0s_capv_") {
+			continue
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := tc.render(tc.data)
+			if err != nil {
+				t.Fatalf("render: %v", err)
+			}
+
+			hasSentinel := strings.Contains(out, "address: "+sentinel)
+			isHA := strings.HasSuffix(tc.name, "_init") || strings.HasSuffix(tc.name, "_join")
+
+			if isHA && !hasSentinel {
+				t.Error("HA control-plane render has no api.address; k0s will advertise an " +
+					"address of its own choosing and bake it into join tokens")
+			}
+			if !isHA && hasSentinel {
+				t.Error("non-HA render must not carry api.address — there are no joiners to reach it")
+			}
+			if !hasSentinel {
+				return
+			}
+
+			// A sentinel without its resolver is a crash-looping node.
+			for _, required := range []string{
+				// The write_files entry itself, not just a mention of the path —
+				// matching the path alone also matches the ExecStartPre line, which
+				// would let a missing script slip through.
+				"- path: /usr/local/bin/kairos-k0s-api-addr.sh",
+				"- path: /etc/systemd/system/k0scontroller.service.d/zz-capi-api-addr.conf",
+				"ExecStartPre=/bin/sh -c '/usr/local/bin/kairos-k0s-api-addr.sh || true'",
+			} {
+				if !strings.Contains(out, required) {
+					t.Errorf("api.address sentinel rendered without %q — k0s would reject the config", required)
+				}
+			}
+
+			// Selected by routing to the control-plane endpoint, never by interface
+			// name, and never advertising the VIP itself as a per-node address.
+			for _, want := range []string{
+				`ip -4 route get "${ENDPOINT}"`,
+				`[ "${src}" != "${ENDPOINT}" ]`,
+				"ip -4 route show default",
+			} {
+				if !strings.Contains(out, want) {
+					t.Errorf("api.address resolver missing %q", want)
+				}
+			}
+
+			// Exactly one occurrence INSIDE the config file. The resolver anchors on
+			// the address line, so a stray copy elsewhere in k0s.yaml would be
+			// rewritten by the substitution and would keep the "already done" check
+			// alive forever. Observed on-node before this was anchored: the
+			// explanatory comment came out reading "172.16.56.47 is a sentinel
+			// replaced with...". The resolver's own SENTINEL= assignment is a
+			// separate file and does not count.
+			if cfg, ok := writeFileBody(out, "/etc/k0s/k0s.yaml"); ok {
+				if n := strings.Count(cfg, sentinel); n != 1 {
+					t.Errorf("sentinel %s appears %d times inside k0s.yaml; it must appear exactly "+
+						"once, on the address line", sentinel, n)
+				}
+			} else {
+				t.Error("api.address rendered but /etc/k0s/k0s.yaml was not written")
+			}
+
+			// Fail open rather than leave a sentinel in place — either of them.
+			for _, del := range []string{
+				`sed -i "/^[[:space:]]*address: ${SENTINEL}\$/d"`,
+				`sed -i "/^[[:space:]]*peerAddress: ${PEER_SENTINEL}\$/d"`,
+			} {
+				if !strings.Contains(out, del) {
+					t.Errorf("resolver must DELETE the line when no address is found (%s); an "+
+						"unsubstituted sentinel makes k0s reject the config and crash-loop", del)
+				}
+			}
+
+			// etcd peerAddress must be set too, not just api.address. The API
+			// advertise address gets a joiner as far as talking to the init; the peer
+			// address is how members reach each OTHER. CAPK sets both, and a port that
+			// takes only half leaves etcd peering on whichever interface k0s picks.
+			if !strings.Contains(cfgBody(out), "peerAddress: __ETCD_PEER_ADDR__") {
+				t.Error("HA render sets api.address but not storage.etcd.peerAddress — " +
+					"etcd members would peer over an arbitrary interface")
+			}
+			if !strings.Contains(out, `sed -i "s|^\([[:space:]]*peerAddress: \)${PEER_SENTINEL}\$|\1${ADDR}|"`) {
+				t.Error("resolver does not substitute the etcd peerAddress sentinel")
+			}
+		})
+	}
+}
+
+// cfgBody returns the /etc/k0s/k0s.yaml write_files body, or "" if absent.
+func cfgBody(out string) string {
+	body, _ := writeFileBody(out, "/etc/k0s/k0s.yaml")
+	return body
+}

--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
@@ -199,7 +199,8 @@ write_files:
     as before (.IsInitControlPlane is false for single/join/worker/empty role).
   */ -}}
   {{- $haSans := and .IsInitControlPlane .ManagementEndpoint .ManagementEndpoint.ControlPlaneEndpointHost }}
-  {{- if and (eq .Role "control-plane") (or .PodCIDR .ServiceCIDR $haSans) }}
+  {{- $apiAddr := and .IsHAControlPlane .ManagementEndpoint .ManagementEndpoint.ControlPlaneEndpointHost }}
+  {{- if and (eq .Role "control-plane") (or .PodCIDR .ServiceCIDR $haSans $apiAddr) }}
   - path: /etc/k0s/k0s.yaml
     permissions: "0644"
     content: |
@@ -207,12 +208,34 @@ write_files:
       kind: ClusterConfig
       metadata:
         name: k0s
-      {{- if or .PodCIDR .ServiceCIDR $haSans }}
+      {{- if or .PodCIDR .ServiceCIDR $haSans $apiAddr }}
       spec:
-      {{- if $haSans }}
+      {{- if or $haSans $apiAddr }}
         api:
+      {{- if $apiAddr }}
+          # Per-node API advertise address, same requirement the CAPK template
+          # already meets for KubeVirt masquerade. A bare-metal node is dual-homed
+          # too — an isolated provisioning NIC plus a routable LAN NIC — and with
+          # no api.address k0s picks one itself. Observed on the beskar7 lab
+          # (2026-09-08): it chose the provisioning address, `k0s token create`
+          # baked that into the controller-join token, and every joiner then failed
+          # with "failed to join existing cluster via https://192.168.190.61:9443:
+          # context deadline exceeded" while the join API answered perfectly well
+          # on the node itself.
+          #
+          # The placeholder below is replaced with this node's routable address by
+          # the k0scontroller ExecStartPre. It is deliberately the ONLY occurrence
+          # in this file: the resolver anchors on the address line, and its
+          # "already done" check keys on the same thing, so a stray copy in prose
+          # would make it re-run on every boot. Leaving a placeholder in place
+          # would make k0s reject the config, so when no address can be found the
+          # resolver deletes this line instead (KD-55 fail-open).
+          address: __API_ADDR__
+      {{- end }}
+      {{- if $haSans }}
           sans:
             - {{ .ManagementEndpoint.ControlPlaneEndpointHost | quote }}
+      {{- end }}
       {{- end }}
       {{- if or .PodCIDR .ServiceCIDR }}
         network:
@@ -223,9 +246,102 @@ write_files:
           serviceCIDR: {{ .ServiceCIDR | quote }}
       {{ end }}
       {{- end }}
+      {{- if $apiAddr }}
+        storage:
+          etcd:
+            # Per-node etcd peer address. The API advertise address alone is not
+            # enough: members also have to reach each OTHER, and on a dual-homed
+            # node k0s will otherwise peer over whichever interface it picks. Set
+            # from the same routable address, resolved by the same ExecStartPre
+            # before k0s starts, because etcd reads peerAddress at init/join and
+            # cannot be corrected afterwards. CAPK sets both for the same reason.
+            peerAddress: __ETCD_PEER_ADDR__
+      {{- end }}
       {{- else }}
       spec: {}
       {{- end }}
+  {{- end }}
+  {{- if $apiAddr }}
+  - path: /usr/local/bin/kairos-k0s-api-addr.sh
+    permissions: "0755"
+    owner: root
+    group: root
+    content: |
+      #!/bin/bash
+      set -u
+
+      CFG=/etc/k0s/k0s.yaml
+      SENTINEL=__API_ADDR__
+      PEER_SENTINEL=__ETCD_PEER_ADDR__
+      ENDPOINT={{ .ManagementEndpoint.ControlPlaneEndpointHost | shquote }}
+
+      [ -f "${CFG}" ] || exit 0
+      # Idempotent: both addresses are fixed once the API and etcd have
+      # initialised, and this runs on every k0s start. Anchored to the value
+      # lines so nothing else in the file can keep this alive.
+      if ! grep -qE "^[[:space:]]*(address|peerAddress): (${SENTINEL}|${PEER_SENTINEL})\$" "${CFG}"; then
+        exit 0
+      fi
+
+      detect_addr() {
+        local src dev
+        # The address the kernel would use to reach the control-plane endpoint.
+        # That is by definition the one joiners can reach, which is what has to
+        # end up in the join token. Selected by routing, never by interface name.
+        src="$(ip -4 route get "${ENDPOINT}" 2>/dev/null |
+               sed -n 's/.*[[:space:]]src[[:space:]]\{1,\}\([0-9.]\{1,\}\).*/\1/p' | head -1)"
+        # If the endpoint is already local — kube-vip claimed the VIP on an earlier
+        # boot — the kernel answers with the VIP itself, which is not a per-node
+        # address and must not be advertised as one.
+        if [ -n "${src}" ] && [ "${src}" != "${ENDPOINT}" ]; then
+          echo "${src}"
+          return 0
+        fi
+        # Fall back to whichever interface carries the default route. An isolated
+        # provisioning network advertises no gateway, so this lands on the routable
+        # one.
+        dev="$(ip -4 route show default 2>/dev/null | awk '{print $5; exit}')"
+        if [ -n "${dev}" ]; then
+          src="$(ip -4 -o addr show dev "${dev}" scope global 2>/dev/null |
+                 awk '{print $4}' | cut -d/ -f1 | head -1)"
+          if [ -n "${src}" ]; then
+            echo "${src}"
+            return 0
+          fi
+        fi
+        return 1
+      }
+
+      # Bounded wait: the DHCP lease can lag the ExecStartPre by a few seconds, and
+      # k0s reads this address at first init/join so it must be right by then.
+      ADDR=""
+      for i in $(seq 1 30); do
+        ADDR="$(detect_addr || true)"
+        if [ -n "${ADDR}" ]; then
+          break
+        fi
+        echo "k0s-api-addr: waiting for a routable address (${i}/30)..."
+        sleep 2
+      done
+
+      if [ -n "${ADDR}" ]; then
+        sed -i "s|^\([[:space:]]*address: \)${SENTINEL}\$|\1${ADDR}|" "${CFG}"
+        sed -i "s|^\([[:space:]]*peerAddress: \)${PEER_SENTINEL}\$|\1${ADDR}|" "${CFG}"
+        echo "k0s-api-addr: api.address and etcd peerAddress set to ${ADDR}"
+      else
+        # Fail open. An unsubstituted sentinel makes k0s reject the config and
+        # crash-loop; dropping the line just returns k0s to auto-detection.
+        sed -i "/^[[:space:]]*address: ${SENTINEL}\$/d" "${CFG}"
+        sed -i "/^[[:space:]]*peerAddress: ${PEER_SENTINEL}\$/d" "${CFG}"
+        echo "k0s-api-addr: no routable address found; removed api.address and peerAddress, k0s will auto-detect"
+      fi
+  - path: /etc/systemd/system/k0scontroller.service.d/zz-capi-api-addr.conf
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      [Service]
+      ExecStartPre=/bin/sh -c '/usr/local/bin/kairos-k0s-api-addr.sh || true'
   {{- end }}
   {{- if .IsJoinControlPlane }}
   # ADR 0005 (HA) join node: k0s controller-role join token. Sourced from

--- a/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
+++ b/internal/bootstrap/templates/k0s_kairos_cloud_config_capv.yaml.tmpl
@@ -330,10 +330,19 @@ write_files:
         echo "k0s-api-addr: api.address and etcd peerAddress set to ${ADDR}"
       else
         # Fail open. An unsubstituted sentinel makes k0s reject the config and
-        # crash-loop; dropping the line just returns k0s to auto-detection.
+        # crash-loop, so the settings are removed instead. The two halves need
+        # different surgery: an empty `api:` is re-defaulted by k0s, but an
+        # empty `etcd:` is not — its storage defaulting only repairs kine, so
+        # spec.storage.etcd stays nil and the etcd component dereferences it
+        # at start, after `k0s config validate` has passed. The storage section
+        # exists only to carry peerAddress, so drop the whole section and let
+        # k0s fall back to its default etcd config. The range delete runs only
+        # when its closing line is present, so it can never run to end of file.
         sed -i "/^[[:space:]]*address: ${SENTINEL}\$/d" "${CFG}"
-        sed -i "/^[[:space:]]*peerAddress: ${PEER_SENTINEL}\$/d" "${CFG}"
-        echo "k0s-api-addr: no routable address found; removed api.address and peerAddress, k0s will auto-detect"
+        if grep -qE "^[[:space:]]*peerAddress: ${PEER_SENTINEL}\$" "${CFG}"; then
+          sed -i "/^[[:space:]]*storage:\$/,/^[[:space:]]*peerAddress: ${PEER_SENTINEL}\$/d" "${CFG}"
+        fi
+        echo "k0s-api-addr: no routable address found; removed api.address and the etcd storage section, k0s will auto-detect"
       fi
   - path: /etc/systemd/system/k0scontroller.service.d/zz-capi-api-addr.conf
     permissions: "0644"

--- a/internal/bootstrap/testdata/golden/k0s_capv_init.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capv_init.yaml
@@ -88,8 +88,115 @@ write_files:
         name: k0s
       spec:
         api:
+          # Per-node API advertise address, same requirement the CAPK template
+          # already meets for KubeVirt masquerade. A bare-metal node is dual-homed
+          # too — an isolated provisioning NIC plus a routable LAN NIC — and with
+          # no api.address k0s picks one itself. Observed on the beskar7 lab
+          # (2026-09-08): it chose the provisioning address, `k0s token create`
+          # baked that into the controller-join token, and every joiner then failed
+          # with "failed to join existing cluster via https://192.168.190.61:9443:
+          # context deadline exceeded" while the join API answered perfectly well
+          # on the node itself.
+          #
+          # The placeholder below is replaced with this node's routable address by
+          # the k0scontroller ExecStartPre. It is deliberately the ONLY occurrence
+          # in this file: the resolver anchors on the address line, and its
+          # "already done" check keys on the same thing, so a stray copy in prose
+          # would make it re-run on every boot. Leaving a placeholder in place
+          # would make k0s reject the config, so when no address can be found the
+          # resolver deletes this line instead (KD-55 fail-open).
+          address: __API_ADDR__
           sans:
             - 192.168.1.240
+        storage:
+          etcd:
+            # Per-node etcd peer address. The API advertise address alone is not
+            # enough: members also have to reach each OTHER, and on a dual-homed
+            # node k0s will otherwise peer over whichever interface it picks. Set
+            # from the same routable address, resolved by the same ExecStartPre
+            # before k0s starts, because etcd reads peerAddress at init/join and
+            # cannot be corrected afterwards. CAPK sets both for the same reason.
+            peerAddress: __ETCD_PEER_ADDR__
+  - path: /usr/local/bin/kairos-k0s-api-addr.sh
+    permissions: "0755"
+    owner: root
+    group: root
+    content: |
+      #!/bin/bash
+      set -u
+
+      CFG=/etc/k0s/k0s.yaml
+      SENTINEL=__API_ADDR__
+      PEER_SENTINEL=__ETCD_PEER_ADDR__
+      ENDPOINT='192.168.1.240'
+
+      [ -f "${CFG}" ] || exit 0
+      # Idempotent: both addresses are fixed once the API and etcd have
+      # initialised, and this runs on every k0s start. Anchored to the value
+      # lines so nothing else in the file can keep this alive.
+      if ! grep -qE "^[[:space:]]*(address|peerAddress): (${SENTINEL}|${PEER_SENTINEL})\$" "${CFG}"; then
+        exit 0
+      fi
+
+      detect_addr() {
+        local src dev
+        # The address the kernel would use to reach the control-plane endpoint.
+        # That is by definition the one joiners can reach, which is what has to
+        # end up in the join token. Selected by routing, never by interface name.
+        src="$(ip -4 route get "${ENDPOINT}" 2>/dev/null |
+               sed -n 's/.*[[:space:]]src[[:space:]]\{1,\}\([0-9.]\{1,\}\).*/\1/p' | head -1)"
+        # If the endpoint is already local — kube-vip claimed the VIP on an earlier
+        # boot — the kernel answers with the VIP itself, which is not a per-node
+        # address and must not be advertised as one.
+        if [ -n "${src}" ] && [ "${src}" != "${ENDPOINT}" ]; then
+          echo "${src}"
+          return 0
+        fi
+        # Fall back to whichever interface carries the default route. An isolated
+        # provisioning network advertises no gateway, so this lands on the routable
+        # one.
+        dev="$(ip -4 route show default 2>/dev/null | awk '{print $5; exit}')"
+        if [ -n "${dev}" ]; then
+          src="$(ip -4 -o addr show dev "${dev}" scope global 2>/dev/null |
+                 awk '{print $4}' | cut -d/ -f1 | head -1)"
+          if [ -n "${src}" ]; then
+            echo "${src}"
+            return 0
+          fi
+        fi
+        return 1
+      }
+
+      # Bounded wait: the DHCP lease can lag the ExecStartPre by a few seconds, and
+      # k0s reads this address at first init/join so it must be right by then.
+      ADDR=""
+      for i in $(seq 1 30); do
+        ADDR="$(detect_addr || true)"
+        if [ -n "${ADDR}" ]; then
+          break
+        fi
+        echo "k0s-api-addr: waiting for a routable address (${i}/30)..."
+        sleep 2
+      done
+
+      if [ -n "${ADDR}" ]; then
+        sed -i "s|^\([[:space:]]*address: \)${SENTINEL}\$|\1${ADDR}|" "${CFG}"
+        sed -i "s|^\([[:space:]]*peerAddress: \)${PEER_SENTINEL}\$|\1${ADDR}|" "${CFG}"
+        echo "k0s-api-addr: api.address and etcd peerAddress set to ${ADDR}"
+      else
+        # Fail open. An unsubstituted sentinel makes k0s reject the config and
+        # crash-loop; dropping the line just returns k0s to auto-detection.
+        sed -i "/^[[:space:]]*address: ${SENTINEL}\$/d" "${CFG}"
+        sed -i "/^[[:space:]]*peerAddress: ${PEER_SENTINEL}\$/d" "${CFG}"
+        echo "k0s-api-addr: no routable address found; removed api.address and peerAddress, k0s will auto-detect"
+      fi
+  - path: /etc/systemd/system/k0scontroller.service.d/zz-capi-api-addr.conf
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      [Service]
+      ExecStartPre=/bin/sh -c '/usr/local/bin/kairos-k0s-api-addr.sh || true'
   # ADR 0005 § D.1 (HA) kube-vip DaemonSet + RBAC (CAPV/CAPM3 only; CAPK uses its
   # built-in LoadBalancer Service per OQ-5 and never reaches this block).
   # k0s applies manifests under /var/lib/k0s/manifests/<dir>/ via its

--- a/internal/bootstrap/testdata/golden/k0s_capv_init.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capv_init.yaml
@@ -185,10 +185,19 @@ write_files:
         echo "k0s-api-addr: api.address and etcd peerAddress set to ${ADDR}"
       else
         # Fail open. An unsubstituted sentinel makes k0s reject the config and
-        # crash-loop; dropping the line just returns k0s to auto-detection.
+        # crash-loop, so the settings are removed instead. The two halves need
+        # different surgery: an empty `api:` is re-defaulted by k0s, but an
+        # empty `etcd:` is not — its storage defaulting only repairs kine, so
+        # spec.storage.etcd stays nil and the etcd component dereferences it
+        # at start, after `k0s config validate` has passed. The storage section
+        # exists only to carry peerAddress, so drop the whole section and let
+        # k0s fall back to its default etcd config. The range delete runs only
+        # when its closing line is present, so it can never run to end of file.
         sed -i "/^[[:space:]]*address: ${SENTINEL}\$/d" "${CFG}"
-        sed -i "/^[[:space:]]*peerAddress: ${PEER_SENTINEL}\$/d" "${CFG}"
-        echo "k0s-api-addr: no routable address found; removed api.address and peerAddress, k0s will auto-detect"
+        if grep -qE "^[[:space:]]*peerAddress: ${PEER_SENTINEL}\$" "${CFG}"; then
+          sed -i "/^[[:space:]]*storage:\$/,/^[[:space:]]*peerAddress: ${PEER_SENTINEL}\$/d" "${CFG}"
+        fi
+        echo "k0s-api-addr: no routable address found; removed api.address and the etcd storage section, k0s will auto-detect"
       fi
   - path: /etc/systemd/system/k0scontroller.service.d/zz-capi-api-addr.conf
     permissions: "0644"

--- a/internal/bootstrap/testdata/golden/k0s_capv_join.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capv_join.yaml
@@ -186,10 +186,19 @@ write_files:
         echo "k0s-api-addr: api.address and etcd peerAddress set to ${ADDR}"
       else
         # Fail open. An unsubstituted sentinel makes k0s reject the config and
-        # crash-loop; dropping the line just returns k0s to auto-detection.
+        # crash-loop, so the settings are removed instead. The two halves need
+        # different surgery: an empty `api:` is re-defaulted by k0s, but an
+        # empty `etcd:` is not — its storage defaulting only repairs kine, so
+        # spec.storage.etcd stays nil and the etcd component dereferences it
+        # at start, after `k0s config validate` has passed. The storage section
+        # exists only to carry peerAddress, so drop the whole section and let
+        # k0s fall back to its default etcd config. The range delete runs only
+        # when its closing line is present, so it can never run to end of file.
         sed -i "/^[[:space:]]*address: ${SENTINEL}\$/d" "${CFG}"
-        sed -i "/^[[:space:]]*peerAddress: ${PEER_SENTINEL}\$/d" "${CFG}"
-        echo "k0s-api-addr: no routable address found; removed api.address and peerAddress, k0s will auto-detect"
+        if grep -qE "^[[:space:]]*peerAddress: ${PEER_SENTINEL}\$" "${CFG}"; then
+          sed -i "/^[[:space:]]*storage:\$/,/^[[:space:]]*peerAddress: ${PEER_SENTINEL}\$/d" "${CFG}"
+        fi
+        echo "k0s-api-addr: no routable address found; removed api.address and the etcd storage section, k0s will auto-detect"
       fi
   - path: /etc/systemd/system/k0scontroller.service.d/zz-capi-api-addr.conf
     permissions: "0644"

--- a/internal/bootstrap/testdata/golden/k0s_capv_join.yaml
+++ b/internal/bootstrap/testdata/golden/k0s_capv_join.yaml
@@ -82,6 +82,122 @@ write_files:
       [Service]
       ExecStart=
       ExecStart=/usr/bin/k0s controller --token-file=/etc/k0s/controller-token --enable-worker
+  - path: /etc/k0s/k0s.yaml
+    permissions: "0644"
+    content: |
+      apiVersion: k0s.k0sproject.io/v1beta1
+      kind: ClusterConfig
+      metadata:
+        name: k0s
+      spec:
+        api:
+          # Per-node API advertise address, same requirement the CAPK template
+          # already meets for KubeVirt masquerade. A bare-metal node is dual-homed
+          # too — an isolated provisioning NIC plus a routable LAN NIC — and with
+          # no api.address k0s picks one itself. Observed on the beskar7 lab
+          # (2026-09-08): it chose the provisioning address, `k0s token create`
+          # baked that into the controller-join token, and every joiner then failed
+          # with "failed to join existing cluster via https://192.168.190.61:9443:
+          # context deadline exceeded" while the join API answered perfectly well
+          # on the node itself.
+          #
+          # The placeholder below is replaced with this node's routable address by
+          # the k0scontroller ExecStartPre. It is deliberately the ONLY occurrence
+          # in this file: the resolver anchors on the address line, and its
+          # "already done" check keys on the same thing, so a stray copy in prose
+          # would make it re-run on every boot. Leaving a placeholder in place
+          # would make k0s reject the config, so when no address can be found the
+          # resolver deletes this line instead (KD-55 fail-open).
+          address: __API_ADDR__
+        storage:
+          etcd:
+            # Per-node etcd peer address. The API advertise address alone is not
+            # enough: members also have to reach each OTHER, and on a dual-homed
+            # node k0s will otherwise peer over whichever interface it picks. Set
+            # from the same routable address, resolved by the same ExecStartPre
+            # before k0s starts, because etcd reads peerAddress at init/join and
+            # cannot be corrected afterwards. CAPK sets both for the same reason.
+            peerAddress: __ETCD_PEER_ADDR__
+  - path: /usr/local/bin/kairos-k0s-api-addr.sh
+    permissions: "0755"
+    owner: root
+    group: root
+    content: |
+      #!/bin/bash
+      set -u
+
+      CFG=/etc/k0s/k0s.yaml
+      SENTINEL=__API_ADDR__
+      PEER_SENTINEL=__ETCD_PEER_ADDR__
+      ENDPOINT='192.168.1.240'
+
+      [ -f "${CFG}" ] || exit 0
+      # Idempotent: both addresses are fixed once the API and etcd have
+      # initialised, and this runs on every k0s start. Anchored to the value
+      # lines so nothing else in the file can keep this alive.
+      if ! grep -qE "^[[:space:]]*(address|peerAddress): (${SENTINEL}|${PEER_SENTINEL})\$" "${CFG}"; then
+        exit 0
+      fi
+
+      detect_addr() {
+        local src dev
+        # The address the kernel would use to reach the control-plane endpoint.
+        # That is by definition the one joiners can reach, which is what has to
+        # end up in the join token. Selected by routing, never by interface name.
+        src="$(ip -4 route get "${ENDPOINT}" 2>/dev/null |
+               sed -n 's/.*[[:space:]]src[[:space:]]\{1,\}\([0-9.]\{1,\}\).*/\1/p' | head -1)"
+        # If the endpoint is already local — kube-vip claimed the VIP on an earlier
+        # boot — the kernel answers with the VIP itself, which is not a per-node
+        # address and must not be advertised as one.
+        if [ -n "${src}" ] && [ "${src}" != "${ENDPOINT}" ]; then
+          echo "${src}"
+          return 0
+        fi
+        # Fall back to whichever interface carries the default route. An isolated
+        # provisioning network advertises no gateway, so this lands on the routable
+        # one.
+        dev="$(ip -4 route show default 2>/dev/null | awk '{print $5; exit}')"
+        if [ -n "${dev}" ]; then
+          src="$(ip -4 -o addr show dev "${dev}" scope global 2>/dev/null |
+                 awk '{print $4}' | cut -d/ -f1 | head -1)"
+          if [ -n "${src}" ]; then
+            echo "${src}"
+            return 0
+          fi
+        fi
+        return 1
+      }
+
+      # Bounded wait: the DHCP lease can lag the ExecStartPre by a few seconds, and
+      # k0s reads this address at first init/join so it must be right by then.
+      ADDR=""
+      for i in $(seq 1 30); do
+        ADDR="$(detect_addr || true)"
+        if [ -n "${ADDR}" ]; then
+          break
+        fi
+        echo "k0s-api-addr: waiting for a routable address (${i}/30)..."
+        sleep 2
+      done
+
+      if [ -n "${ADDR}" ]; then
+        sed -i "s|^\([[:space:]]*address: \)${SENTINEL}\$|\1${ADDR}|" "${CFG}"
+        sed -i "s|^\([[:space:]]*peerAddress: \)${PEER_SENTINEL}\$|\1${ADDR}|" "${CFG}"
+        echo "k0s-api-addr: api.address and etcd peerAddress set to ${ADDR}"
+      else
+        # Fail open. An unsubstituted sentinel makes k0s reject the config and
+        # crash-loop; dropping the line just returns k0s to auto-detection.
+        sed -i "/^[[:space:]]*address: ${SENTINEL}\$/d" "${CFG}"
+        sed -i "/^[[:space:]]*peerAddress: ${PEER_SENTINEL}\$/d" "${CFG}"
+        echo "k0s-api-addr: no routable address found; removed api.address and peerAddress, k0s will auto-detect"
+      fi
+  - path: /etc/systemd/system/k0scontroller.service.d/zz-capi-api-addr.conf
+    permissions: "0644"
+    owner: root
+    group: root
+    content: |
+      [Service]
+      ExecStartPre=/bin/sh -c '/usr/local/bin/kairos-k0s-api-addr.sh || true'
   # ADR 0005 (HA) join node: k0s controller-role join token. Sourced from
   # .JoinToken, which the Phase-3 controller produces on the init controller
   # (k0s token create --role=controller) and delivers over the node-push channel


### PR DESCRIPTION
> Stacked on #99 (same k0s CAPV template, goldens and test file). Merge after it — until then the Files tab shows that PR's diff as well.

## Summary

The CAPK k0s template has carried `spec.api.address` and `spec.storage.etcd.peerAddress` since its own masquerade lab; the CAPV template — the default for every non-KubeVirt provider — never got either and emitted only `api.sans`. Ports both, with a routing-based address selection instead of CAPK's known-bad-range exclusion.

## Why

A bare-metal HA node is dual-homed (an isolated provisioning NIC plus a routable one), exactly like a KubeVirt node behind masquerade. With no `api.address`, k0s picks an advertise address itself. Measured on the lab (2026-09-08):

```
init   enp1s0 192.168.190.61/24   enp6s0 172.16.56.46/24
joiner enp1s0 192.168.190.62/24   enp6s0 172.16.56.47/24
```

k0s chose the provisioning address, `k0s token create` baked it into the controller-join token, and every joiner failed with `failed to join existing cluster via https://192.168.190.61:9443: Get ".../v1beta1/ca": context deadline exceeded` — while the join API answered 401 (healthy) when probed on the node itself. The control plane sat at 1/3. `peerAddress` is how etcd members reach each other; etcd reads it at init/join and it cannot be corrected afterwards, so it has the same must-be-right-before-first-start constraint.

## What changes

Both settings are rendered with a placeholder that a `k0scontroller` `ExecStartPre` resolves before k0s starts (CAPK's shape). The address is chosen by **routing** — the source the kernel would use to reach the control-plane endpoint — which is by definition an address a joiner can reach, needs no subnet knowledge, and never hardcodes an interface name. If the endpoint is already local because kube-vip claimed the VIP on an earlier boot, the kernel answers with the VIP itself; that is rejected as not a per-node address, falling back to the default-route interface.

Every resolver operation is anchored to the two config lines (the "already done" check, the substitutions, the fail-open deletion) and the placeholder is never named in prose, so each file has exactly one occurrence per setting — an unanchored `sed` had rewritten the placeholder inside its own comment on the first lab pass, which also defeated the idempotence check. When no address can be found the resolver **deletes** the two lines, returning k0s to auto-detection rather than wedging the node (an unsubstituted placeholder makes k0s reject the config).

Squashed from three commits of the lab series (the port, the `sed` anchoring, `peerAddress`) so the intermediate defect never appears upstream.

## Tests and verification

`TestHA_K0sApiAddressResolved`: the placeholders are never rendered without both the resolver script and the `ExecStartPre` that runs it; both settings present in the config body with exactly one occurrence each; non-HA renders carry none of it; the fail-open deletion is present. Negative-verified against a missing script, a stray placeholder in a comment, and a removed `peerAddress`.

On the lab the resolver picked the routable `172.16.56.47` over `192.168.190.62` with both placeholders substituted, and the three etcd members peer on the routable network (`k0s etcd member-list` shows all three on `172.16.56.x:2380`).

## Review follow-up

The first version's fail-open branch deleted only the `peerAddress:` line, which leaves `etcd:` as an explicit null. k0s does not repair that (`StorageSpec.UnmarshalJSON` re-defaults etcd only for kine), `k0s config validate` passes, and the etcd component dereferences the nil at start. The second commit drops the whole `storage:` section instead (it exists only to carry `peerAddress`), guarded so the range delete cannot run past its closing line, and adds `TestHA_K0sApiAddressResolverRuns`, which executes the rendered resolver against the rendered config on both paths and parses the result — it fails on the previous resolver. The `api:` half was already safe (`ClusterConfig.UnmarshalJSON` restores a nil `spec.api`). The 60 s detection wait does not interact with a start timeout: the Kairos `k0scontroller.service` runs with `TimeoutStartSec=infinity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

